### PR TITLE
Harden refine recovery and privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 **Self-improvement loop for Hermes Agent** — the agent reads its own trajectory,
 finds repeated failures and reusable tactics, then proposes and applies the
-**smallest possible edit** to its skills or memory. Every edit is journaled with
-a backup, so it can be rolled back in one command.
+**smallest possible edit** to its skills or memory. Mutations are prepared in a
+durable journal before they run and carry conflict-aware recovery metadata.
 
 This is a port of the `/refine` concept from
 [Prime Intellect's Prime Agent](https://www.primeintellect.ai/blog/prime-agent)
@@ -33,40 +33,42 @@ entries are editable. Built-in, pinned, and hub-installed skills are off-limits.
 ## How it works
 
 ```
-trajectory (state.db) → scrub → fingerprint + aggregate → signal gate ─┬→ no_op (no model call)
-                                                                      └→ LLM proposal → guardrails
-                                                                         → apply → journal + backup
-                                                                                  → usefulness ledger
+trajectory (state.db) → scrub → fingerprint + aggregate → signal gate ─┬→ no_op
+                                                                      └→ LLM proposal
+                                                                         → guardrails + backup
+                                                                         → prepared journal record
+                                                                         → apply → finalized outcome
+                                                                                 → usefulness ledger
 ```
 
 | Stage | What happens |
 |---|---|
-| **1. Collect evidence** | Reads the last N messages of the session from `<HERMES_HOME>/state.db` (read-only). Credentials are redacted at this point, so every downstream consumer gets scrubbed text |
-| **2. Aggregate** | Normalizes each error to its invariant shape (ids, paths, timestamps stripped) and fingerprints it, then counts occurrences — within this session and across the last 7 days |
-| **3. Signal gate** | No failure repeated and no user correction → `no_op` **without calling the model at all** |
-| **4. LLM proposal** | Calls the host model with structured output: one minimal `create`/`patch`/`no_op` proposal, grounded in a listed pattern |
-| **5. Guardrails** | Validates: agent-created skills only for patches, fresh name for creates, no `delete`, no reserved `hermes-` prefix, size limits, daily budget, no duplicate of a recent edit |
-| **6. Apply** | Runs the edit through the standard `skill_manage` / `memory_tool` APIs (approval gate respected) |
-| **7. Journal + ledger** | Appends a JSONL record with trigger, proposal, outcome and backup path, and registers the edit for later auditing |
-| **8. Rollback** | `rollback <id>` restores the pre-edit state from the backup |
+| **1. Collect evidence** | Reads the last N messages of the session from `<HERMES_HOME>/state.db` (read-only). Credentials are redacted before downstream use |
+| **2. Aggregate** | Normalizes each error to its invariant shape and records a complete 12-character fingerprint, then counts occurrences within and across sessions |
+| **3. Signal gate** | No repeated failure and no explicit user correction → `no_op` without calling the model |
+| **4. LLM proposal** | Calls the host model with structured output: one minimal `create`/`patch`/`no_op` proposal. Every model-bound field is sanitized. Skill patches get the current complete `SKILL.md` only when it is unchanged by sanitization and at most 15,000 characters; otherwise the patch becomes `no_op` |
+| **5. Guardrails** | Validates agent-created patch targets, fresh create names, content/frontmatter, size limits, daily budget, and recent duplicates |
+| **6. Prepare** | Creates a durable patch backup or exact append-recovery metadata, then appends and `fsync`s a `prepared` journal record before mutation |
+| **7. Apply and reconcile** | Runs the standard host API (`patch` maps to host `edit`), proves immediate writes from actual target state, and records `applied`, `pending_approval`, or `error`. Pending approvals retain their host ID and reconcile lazily before later runs, audit, or rollback |
+| **8. Rollback** | Journals `rollback_prepared` before the side effect. Immediate rollback is finalized only after target-state proof; staged rollback remains `pending_rollback` until approval reconciliation |
 
 ### Why fingerprinting
 
 "The same failure happened again" is a question about shapes, not strings.
 `HTTP 429 for /users/8821` and `HTTP 429 for /users/9134` are one failure, not two.
-Normalizing away the volatile parts and hashing what remains turns a flat list of
-error text into countable patterns — which is what lets the plugin *assert* that
-something recurs instead of asking the model to guess from a transcript.
+Normalizing away volatile parts and hashing what remains turns a flat list of
+error text into countable patterns.
 
-A pattern that appears in several **different** sessions is a much stronger signal
-than one repeated twice inside a single conversation, where it is usually just a
-retry loop. Both counters are tracked and shown to the model.
+A pattern that appears in several **different** sessions is a stronger signal
+than one repeated twice inside one conversation. Interactive prompts remain
+bounded, while `/refine audit` evaluates recurrence over the complete available
+post-edit period.
 
 ### Provider compatibility
 
 The proposal is requested via `json_schema` structured output, with an automatic
 fallback to `json_mode` (then raw-text JSON salvage) for providers that reject
-`response_format.type=json_schema` — verified on opencode-go ("Console Go").
+`response_format.type=json_schema`.
 
 ---
 
@@ -74,11 +76,10 @@ fallback to `json_mode` (then raw-text JSON salvage) for providers that reject
 
 > **Note:** this is a plugin for [Hermes Agent](https://hermes-agent.nousresearch.com/docs) — it requires a working Hermes installation (≥ 0.17.0) and does not run standalone.
 
-The plugin lives in `<HERMES_HOME>/plugins/refine/` — that is `~/.hermes/plugins/refine/`
-on Linux and macOS, and `%LOCALAPPDATA%\hermes\plugins\refine\` on Windows. Under a
-Hermes profile it follows the profile. The plugin resolves this itself via
-`hermes_constants.get_hermes_home()`, so the journal and the trajectory are always
-read from the same place Hermes uses.
+The plugin lives in `<HERMES_HOME>/plugins/refine/` — `~/.hermes/plugins/refine/`
+on Linux and macOS, and `%LOCALAPPDATA%\hermes\plugins\refine\` on Windows. Under
+a Hermes profile it follows the profile. The plugin resolves this through
+`hermes_constants.get_hermes_home()`.
 
 1. Add to your Hermes `config.yaml`:
 
@@ -93,7 +94,7 @@ plugins:
         allow_provider_override: false
 ```
 
-2. Restart Hermes (gateway or CLI):
+2. Restart Hermes:
 
 ```bash
 hermes gateway restart
@@ -110,9 +111,7 @@ hermes plugins list
 
 ## Usage
 
-### Manual (slash command)
-
-In any Hermes chat:
+### Manual
 
 ```
 /refine
@@ -121,50 +120,57 @@ In any Hermes chat:
 /refine rollback 1f2a3b4c5d6e
 ```
 
+`audit` and `rollback <12-character-id>` are exact subcommands. Other text,
+including reasons beginning with those words, is passed to the proposal model as
+the manual reason.
+
 ### Auditing what refine wrote
 
-`/refine audit` answers the question the loop otherwise never asks — did any of
-this help?
+`/refine audit` reports whether refine-created entries were used and whether the
+failure fingerprint recurred after the edit. Timestamp-aware host counts are
+preferred. If the host exposes only an all-time aggregate, the report labels it
+`all:` and does not claim post-edit use from it. Pending approvals remain marked
+as pending rather than being reported as applied. On the next audit, run, or
+rollback request, the plugin checks the host pending store and the actual skill
+or memory target: an exact target match becomes applied, an unresolved host
+record stays pending, and a removed host record without a target match becomes
+rejected.
 
 ```
 Refine-created entries (3):
 
-  name                           age   uses  recurred  verdict
-  gmail-scope-fix                12d     ~5        no  working
-  prisma-migrate-note             9d     ~0         —  unused
-  bash-path-hint                  3d     ~0       yes  did not help
+  name                           age     uses  recurred  verdict
+  gmail-scope-fix                12d        5        no  working
+  prisma-migrate-note             9d       ~0         —  too early
+  bash-path-hint                  3d        2       yes  did not help
 
 Candidates for removal:
   bash-path-hint — /refine rollback 8c1d2e3f4a5b
 ```
 
-The `recurred` column re-runs the fingerprint aggregation restricted to the time
-*after* the skill was written and checks whether the failure it targeted came
-back. That is the honest answer to "did this work?", and it is only possible
-because each proposal records the fingerprint it addressed.
+The audit deletes nothing. It prints a rollback command only for recorded
+candidates. Skills that remain unused are fed into later proposals as negative
+examples.
 
-The audit deletes nothing. It prints the command; you decide.
+### Automatic
 
-Skills that were never used are also fed back into the next proposal as negative
-examples, so the model stops writing more of the same shape.
-
-### Automatic (hook)
-
-Enable in config — the plugin then runs after every session with enough
-messages (background thread, never blocks session teardown):
+Enable the session-end hook in config:
 
 ```yaml
 plugins:
   entries:
     refine:
-      auto_enabled: true      # run refine after each session
-      auto_min_messages: 15   # require at least 15 messages
+      auto_enabled: true
+      auto_min_messages: 15
 ```
+
+Automatic and manual runs share a cross-thread and cross-process mutation lock,
+then recheck the daily budget inside that lock.
 
 ### Agent-invocable tool
 
-The agent itself gets a `refine_run` tool (toolset `refine`), so it can trigger
-a refinement pass whenever it notices a repeated failure or a reusable tactic.
+The agent gets a `refine_run` tool (toolset `refine`) and may trigger the same
+serialized flow with an optional reason.
 
 ---
 
@@ -176,16 +182,16 @@ All keys live under `plugins.entries.refine`:
 |---|---|---|---|
 | `auto_enabled` | bool | `false` | Auto-run on `on_session_end` |
 | `auto_min_messages` | int | `15` | Min messages for auto-analysis |
-| `max_edits_per_run` | int | `1` | Max CRUD edits per single run |
-| `max_edits_per_day` | int | `3` | Max edits per day (all triggers) |
+| `max_edits_per_run` | int | `1` | Max applied or reserved edits per run |
+| `max_edits_per_day` | int | `3` | Max applied, pending, or prepared edits per UTC day |
 | `only_agent_created` | bool | `true` | Only patch agent-created skills |
-| `journal_dir` | path | `<HERMES_HOME>/plugins/refine` | Journal + backup location |
+| `journal_dir` | path | `<HERMES_HOME>/plugins/refine` | Journal, lock, ledger, and backups |
 | `min_signal_required` | bool | `true` | Skip the model call when nothing repeated |
 | `min_pattern_count` | int | `2` | Repeats before a failure counts as a signal |
 | `cross_session_enabled` | bool | `true` | Aggregate failures across recent sessions |
-| `cross_session_days` | int | `7` | Look-back window for cross-session patterns |
-| `cross_session_max_sessions` | int | `25` | Cap on sessions scanned per run |
-| `dedup_window_days` | int | `7` | Refuse an edit identical to a recent one |
+| `cross_session_days` | int | `7` | Interactive cross-session look-back window |
+| `cross_session_max_sessions` | int | `25` | Interactive session scan cap |
+| `dedup_window_days` | int | `7` | Refuse an edit identical to a recent applied, pending, or prepared edit |
 
 LLM trust policy (`plugins.entries.refine.llm`):
 
@@ -200,14 +206,25 @@ llm:
 
 ## Rollback
 
-Every applied edit writes a journal entry with a backup:
+A successful mutation returns a rollback command only when its journal record is
+actually reversible:
 
 ```
 /refine rollback <journal_id>
 ```
 
-Manual fallback: find the entry in `refine_journal.jsonl`, restore the matching
-`.bak` file from `backups/`.
+Create rollback deletes the skill only if its current content still exactly
+matches the refine proposal. Patch rollback likewise refuses to overwrite a
+later change before restoring its durable backup. Memory rollback removes only
+the exact appended entry and preserves unrelated later entries.
+
+If mutation succeeded but journal finalization failed, the returned recovery ID
+points to the durable `prepared` record. Pending forward approvals consume budget
+but are not advertised as reversible until the target exactly matches the
+proposal. Rollback intent is journaled before its side effect; a staged rollback
+returns a pending ID and is not called rolled back until the target change is
+confirmed. A rejected rollback returns the entry to `applied`, so it can be
+retried.
 
 ---
 
@@ -215,16 +232,20 @@ Manual fallback: find the entry in `refine_journal.jsonl`, restore the matching
 
 ```bash
 cd <HERMES_HOME>/plugins/refine
-python3 -m tests.run_tests
+python -m tests.run_tests
 ```
 
-The suite covers: trajectory collection (real `state.db`, read-only), credential
-scrubbing (including a regression test proving no secret survives into the tool
-result), error fingerprinting and aggregation, the signal gate, guardrails and the
-dedup guard, journal roundtrip, the usefulness ledger, an end-to-end
-create→apply→delete cycle, and rollback error handling. A mock LLM is used — no
-API tokens spent, and tests that need message rows build a throwaway SQLite file
-rather than touching the real `state.db`.
+The stdlib-only suite installs an in-memory fake Hermes host before importing the
+plugin. Every database, journal, backup, skill, memory file, ledger, and lock
+lives under a fresh `TemporaryDirectory`; running the tests cannot touch live
+`~/.hermes` or profile state. It covers proposal completion, host action mapping,
+backup/journal failures, create/patch/memory rollback conflicts, failed applies,
+secret sanitation and idempotent redaction, pending approval/rejection
+reconciliation, staged rollback and finalization recovery, concurrent budget
+checks and lock initialization races, append-only journal tail recovery,
+multipass partial-success IDs, complete patch limits and metadata preservation,
+streaming full-history audit aggregation, full fingerprints, command parsing,
+error/correction classification, and audit scope. No model API is called.
 
 ---
 
@@ -233,57 +254,61 @@ rather than touching the real `state.db`.
 ```
 refine/
 ├── plugin.yaml          # Hermes plugin manifest
-├── __init__.py          # register(ctx): /refine command, refine_run tool, on_session_end hook
-├── config.py            # config.yaml reader (plugins.entries.refine.*)
-├── core.py              # evidence collection, scrubbing, guardrails, apply logic
-├── patterns.py          # error normalization, fingerprinting, aggregation, signal gate
-├── ledger.py            # usefulness ledger + /refine audit report
-├── llm.py               # structured LLM proposal + json_mode fallback + validation
-├── journal.py           # JSONL journal, backups, rollback, dedup
+├── __init__.py          # command, tool, and session-end hook registration
+├── config.py            # plugins.entries.refine config reader
+├── core.py              # evidence, guardrails, serialized apply orchestration
+├── sanitization.py      # recursive credential redaction
+├── patterns.py          # normalization, fingerprints, aggregation, signal gate
+├── ledger.py            # timestamp-aware usefulness ledger and audit report
+├── llm.py               # structured proposal and complete patch regeneration
+├── journal.py           # atomic journal, lock, backups, recovery, rollback
 └── tests/
-    └── run_tests.py     # self-contained test suite
+    └── run_tests.py     # hermetic fake-host regression suite
 ```
 
 ---
 
 ## What gets sent to the model
 
-Refine reads your session content and sends part of it to whichever LLM provider
-Hermes is configured to use. Specifically: aggregated error patterns, quotes from
-messages where you corrected the agent, your existing skill and memory names, and
-up to 8000 characters of recent trajectory as context.
+Refine sends sanitized aggregated error patterns, explicit correction excerpts,
+existing skill and memory names/snippets, the optional manual reason/prior-pass
+note, and up to 8000 characters of sanitized recent trajectory to the configured
+provider. When a skill patch is selected, a second structured request receives
+the target's current complete `SKILL.md` only if it is already safe and no larger
+than the shared 15,000-character input/output limit. Unsafe or oversized current
+skill content aborts the patch as `no_op`; it is never redacted, truncated, or
+used to generate a destructive replacement.
 
-Credentials are redacted first (see below), but the rest is ordinary conversation
-content. If that matters for your setup, keep `auto_enabled: false` and run
-`/refine` manually, so nothing leaves the machine unless you asked for it.
-
-The signal gate limits this considerably: when nothing repeated and you corrected
-nothing, the run ends as a `no_op` and **no data is sent at all**.
+Credentials are redacted first, but the remaining content is ordinary
+conversation or skill content. Keep `auto_enabled: false` if model-bound session
+analysis must be manually initiated. With the signal gate enabled, no model call
+occurs when nothing repeated and no explicit correction was detected.
 
 ---
 
 ## Safety & limits
 
-- **Credential scrubbing** — redaction happens at the single point where rows
-  leave `state.db`, so every consumer downstream (the model, the journal, the tool
-  result echoed back into context) gets scrubbed text. Covers GitHub/GitLab/Slack/
-  OpenAI/Anthropic/HuggingFace/SendGrid/AWS/Google key formats, JWTs, private key
-  blocks, `Authorization:` headers, basic-auth URLs, `.env`-style lines, and
-  generic `token=`/`password=` values.
-- **Signal gate** — no repeated failure and no user correction means no model call.
-- **Agent-created skills only** for patches; creates must use a free name, so a
-  bundled, pinned or hub-installed skill can never be overwritten.
-- **No delete** — refine can only create or patch. `/refine audit` reports
-  removal candidates but never acts on them.
-- **Daily budget** — max 3 applied edits per day (UTC), max 1 per run.
-- **No duplicate edits** — an edit identical to one applied in the last 7 days is refused.
-- **Backup before edit, rollback by ID.**
-- **No system prompt access** — the base prompt stays immutable.
-- **Approval gate respected** — if skill writes are gated, edits stage as
-  `pending_approval` instead of being applied.
+- **Credential scrubbing** covers evidence, reasons, proposals, host errors, and
+  every recursively nested journal field, including quoted JSON keys and
+  punctuation-heavy values.
+- **Signal gate** requires a repeated failure or explicit correction.
+- **Agent-created skills only** for patches; creates require a free normalized
+  name and cannot use the reserved `hermes-` prefix.
+- **No autonomous delete** — delete is used only by an explicit rollback of an
+  unchanged skill created by refine.
+- **Serialized budget** counts applied, pending-approval, and unresolved prepared
+  records after acquiring the process-safe mutation lock.
+- **Durable append journal** writes one locked, fsynced JSON line per state
+  transition without rewriting history. A corrupt trailing line is skipped and
+  isolated before the next valid record; backup and ledger replacement writes
+  remain atomic.
+- **Conflict-aware rollback** preserves later skill and memory changes.
+- **Approval gate respected** — staged forward and rollback writes persist their
+  pending IDs and are reconciled from both host-pending and exact target state.
 - **Read-only trajectory** — `state.db` is opened with `mode=ro`.
-- Requires Hermes ≥ 0.17.0 (plugin API: `register_tool`, `register_command`,
-  `register_hook`, `ctx.llm`).
+- **No system prompt access** — the base prompt stays immutable.
+- Requires Hermes ≥ 0.17.0 (`register_tool`, `register_command`, `register_hook`,
+  and `ctx.llm`).
 
 ---
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,12 +1,8 @@
-"""refine plugin — self-improvement loop for Hermes Agent.
+"""Refine plugin registration and command handlers."""
 
-Registers:
-  - /refine  slash command (manual trigger)
-  - refine_run tool (agent-invocable)
-  - on_session_end hook (auto trigger, config-gated)
-"""
-
+import json
 import logging
+import re
 import threading
 from typing import Optional
 
@@ -15,95 +11,90 @@ from agent.plugin_llm import PluginLlm
 try:
     from . import config, core
 except ImportError:
-    import config, core  # noqa: F811 — standalone test
+    import config, core  # noqa: F811
 
 logger = logging.getLogger(__name__)
+_ROLLBACK_COMMAND = re.compile(r"^rollback\s+([0-9a-fA-F]{12})$")
 
 
 def _get_llm(ctx) -> PluginLlm:
-    """Get a PluginLlm, preferring ctx.llm, falling back to standalone."""
     try:
         return ctx.llm
     except Exception:
         return PluginLlm(plugin_id="refine")
 
 
-# ── /refine slash command handler ───────────────────────────────────────────
-
-
 def _handle_refine_command(raw_args: str) -> Optional[str]:
-    """Handler for /refine [reason|rollback <id>].
-
-    Called inside a session; raw_args is everything after " /refine".
-    Returns a string the user sees.
-    """
+    """Handle exact audit/rollback subcommands; all other text is a reason."""
     args = raw_args.strip()
-
-    # Audit path — read-only, never deletes anything
-    if args.startswith("audit"):
+    if args == "audit":
         try:
-            result = core.refine_audit()
+            return core.refine_audit().get("report", "No data.")
         except Exception as exc:
             logger.exception("refine audit failed")
             return f"❌ Audit failed: {exc}"
-        return result.get("report", "No data.")
 
-    # Rollback path
-    if args.startswith("rollback"):
-        entry_id = args.replace("rollback", "").strip()
-        if not entry_id:
-            return (
-                "Usage: /refine rollback <journal_id>\n"
-                "Find ids in <HERMES_HOME>/plugins/refine/refine_journal.jsonl"
-            )
+    if args == "rollback":
+        return (
+            "Usage: /refine rollback <12-character journal_id>\n"
+            "Find ids in <HERMES_HOME>/plugins/refine/refine_journal.jsonl"
+        )
+    rollback_match = _ROLLBACK_COMMAND.fullmatch(args)
+    if rollback_match:
+        entry_id = rollback_match.group(1).lower()
         result = core.refine_rollback(entry_id)
         if result.get("success"):
             return f"✅ Rollback {entry_id}: {result.get('message', 'done')}"
         return f"❌ Rollback failed: {result.get('error', 'unknown error')}"
 
-    # Normal refine run
     try:
-        llm = PluginLlm(plugin_id="refine")
-        result = core.refine_run(llm=llm, reason=args, auto=False)
+        result = core.refine_run(
+            llm=PluginLlm(plugin_id="refine"), reason=args, auto=False
+        )
     except Exception as exc:
         logger.exception("refine command failed")
         return f"❌ Refine failed: {exc}"
 
-    if result.get("success") and result.get("message"):
-        jid = result.get("journal_id", "?")
-        summary = result["message"]
-        proposal = result.get("proposal", {})
-        if proposal.get("action") not in (None, "no_op"):
-            summary += (
-                f"\n📝 {proposal.get('action', '?')} {proposal.get('kind', '?')} "
-                f"\"{proposal.get('name', '?')}\""
-            )
-        summary += f"\n🔖 {jid} (rollback: /refine rollback {jid})"
-        return summary
+    if not result.get("success") and result.get("outcome") != "partial_success":
+        return f"❌ {result.get('message', 'Unknown error')}"
 
-    return f"❌ {result.get('message', 'Unknown error')}"
-
-
-# ── refine_run tool handler ─────────────────────────────────────────────────
+    summary = result.get("message", "done")
+    if result.get("outcome") == "partial_success":
+        summary = "⚠️ " + summary
+    proposal = result.get("proposal", {})
+    if proposal.get("action") not in (None, "no_op"):
+        summary += (
+            f"\n📝 {proposal.get('action', '?')} {proposal.get('kind', '?')} "
+            f"\"{proposal.get('name', '?')}\""
+        )
+    recoveries = result.get("recoveries", [])
+    if recoveries:
+        summary += "\nRecovery / rollback IDs:"
+        for recovery in recoveries:
+            journal_id = recovery.get("journal_id", "?")
+            line = f"\n🔖 {journal_id} ({recovery.get('outcome', 'unknown')})"
+            if recovery.get("rollback_command"):
+                line += f" — {recovery['rollback_command']}"
+            summary += line
+    else:
+        journal_id = result.get("journal_id")
+        if journal_id:
+            summary += f"\n🔖 {journal_id}"
+            if result.get("reversible"):
+                summary += f" (rollback: /refine rollback {journal_id})"
+    return summary
 
 
 def _handle_refine_run(args: dict, **kw) -> str:
-    """Tool handler for ``refine_run``."""
-    import json
-
     reason = args.get("reason", "") if isinstance(args, dict) else ""
-
     try:
-        llm = PluginLlm(plugin_id="refine")
-        result = core.refine_run(llm=llm, reason=reason, auto=False)
+        result = core.refine_run(
+            llm=PluginLlm(plugin_id="refine"), reason=reason, auto=False
+        )
     except Exception as exc:
         logger.exception("refine_run tool failed")
         return json.dumps({"success": False, "error": str(exc)})
-
     return json.dumps(result, ensure_ascii=False)
-
-
-# ── on_session_end hook ────────────────────────────────────────────────────
 
 
 def _on_session_end(
@@ -113,53 +104,40 @@ def _on_session_end(
     interrupted: bool = False,
     **kwargs,
 ) -> None:
-    """Auto-trigger refine at session end, config-gated."""
-    if not config.auto_enabled():
+    if not config.auto_enabled() or interrupted:
         return
 
-    # Skip interrupted/empty sessions
-    if interrupted:
-        return
-
-    # Run in background thread to not block session teardown
-    def _run():
+    def _run() -> None:
         try:
-            from .core import collect_evidence
-
-            evidence = collect_evidence(session_id=session_id, limit=30)
-            msg_count = len(evidence.get("messages", []))
-            if msg_count < config.auto_min_messages():
-                logger.debug(
-                    "refine auto: not enough messages (%d < %d)", msg_count, config.auto_min_messages()
-                )
+            evidence = core.collect_evidence(session_id=session_id, limit=30)
+            count = len(evidence.get("messages", []))
+            if count < config.auto_min_messages():
+                logger.debug("refine auto: not enough messages (%d)", count)
                 return
-
-            llm = PluginLlm(plugin_id="refine")
-            core.refine_run(llm=llm, session_id=session_id, auto=True)
+            core.refine_run(
+                llm=PluginLlm(plugin_id="refine"),
+                session_id=session_id,
+                auto=True,
+            )
         except Exception:
             logger.exception("refine auto hook failed")
 
-    t = threading.Thread(target=_run, daemon=True, name="refine-auto")
-    t.start()
-
-
-# ── plugin entry ───────────────────────────────────────────────────────────
+    threading.Thread(target=_run, daemon=True, name="refine-auto").start()
 
 
 REFINE_RUN_SCHEMA = {
     "name": "refine_run",
     "description": (
-        "Trigger a self-improvement pass. Reads the agent's recent trajectory, "
-        "proposes one minimal edit to a skill or memory to fix a recurring problem "
-        "or capture a reusable tactic. Edits are journaled with rollback."
+        "Trigger a self-improvement pass over recent repeated failures or explicit corrections. "
+        "Mutations are serialized, journaled, and reversible when applied."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "reason": {
                 "type": "string",
-                "description": "Optional specific issue or area to focus on.",
-            },
+                "description": "Optional issue or area to focus on; passed to the proposal model.",
+            }
         },
         "required": [],
     },
@@ -167,28 +145,18 @@ REFINE_RUN_SCHEMA = {
 
 
 def register(ctx) -> None:
-    """Register /refine command, refine_run tool, and on_session_end hook."""
-
-    # Slash command
     ctx.register_command(
         "refine",
         _handle_refine_command,
-        description="Self-improve skills/memory from trajectory. Usage: /refine [reason|audit|rollback <id>]",
+        description="Self-improve skills/memory. Usage: /refine [reason|audit|rollback <id>]",
         args_hint="[reason | audit | rollback <id>]",
     )
-    logger.info("refine plugin: registered /refine command")
-
-    # Tool
     ctx.register_tool(
         "refine_run",
         "refine",
         REFINE_RUN_SCHEMA,
         _handle_refine_run,
-        description="Run one self-improvement pass over trajectory → skill/memory edit",
+        description="Run one self-improvement pass over trajectory",
         emoji="🧠",
     )
-    logger.info("refine plugin: registered refine_run tool")
-
-    # Hook
     ctx.register_hook("on_session_end", _on_session_end)
-    logger.info("refine plugin: registered on_session_end hook")

--- a/core.py
+++ b/core.py
@@ -1,103 +1,48 @@
-"""Core refine logic: collect trajectory evidence, run guardrails, apply edits.
-
-This module does NOT import PluginContext — it receives a ``PluginLlm``
-and works standalone (testable without a live session).
-"""
+"""Core refine orchestration: evidence, guardrails, durable apply, rollback."""
 
 import json
 import logging
 import re
 import sqlite3
 import time
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.plugin_llm import PluginLlm
 
 try:
     from . import config, journal, ledger, llm as _llm, patterns
+    from .sanitization import sanitize, scrub_text
 except ImportError:
-    import config, journal, ledger, llm as _llm, patterns  # noqa: F811 — standalone test
+    import config, journal, ledger, llm as _llm, patterns  # noqa: F811
+    from sanitization import sanitize, scrub_text  # noqa: F811
 
 logger = logging.getLogger(__name__)
 
-# ── secret scrubbing ─────────────────────────────────────────────────────────
-# Trajectory fragments (tool outputs, user messages) may contain credentials.
-# Scrub them before anything leaves the machine: LLM calls AND the journal.
-
-_RED = '[REDACTED]'
-_B = 'Bearer'
-
-_SECRET_PATTERNS = [
-    (re.compile(r"github_pat_[A-Za-z0-9_]+"), "[REDACTED]"),
-    (re.compile(r"ghp_[A-Za-z0-9]{20,}"), "[REDACTED]"),
-    (re.compile(r"gho_[A-Za-z0-9]{20,}"), "[REDACTED]"),
-    (re.compile(r"sk-[A-Za-z0-9_\-]{20,}"), "[REDACTED]"),
-    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED]"),
-    (re.compile(r"AIza[A-Za-z0-9_\-]{20,}"), "[REDACTED]"),
-    (re.compile(r"xox[baprs]-[A-Za-z0-9\-]{10,}"), "[REDACTED]"),
-    (re.compile(r"ntn_[A-Za-z0-9]{20,}"), "[REDACTED]"),
-    (re.compile(r"hf_[A-Za-z0-9]{20,}"), "[REDACTED]"),
-    (re.compile(r"glpat-[A-Za-z0-9_\-]{15,}"), "[REDACTED]"),
-    (re.compile(r"SG\.[A-Za-z0-9_\-]{15,}\.[A-Za-z0-9_\-]{15,}"), "[REDACTED]"),
-    (re.compile(r"dop_v1_[a-f0-9]{60,}"), "[REDACTED]"),
-    (re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"), "[REDACTED]"),
-    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S), "[REDACTED]"),
-    # Credentials embedded in a URL: https://user:pass@host
-    (re.compile(r"(https?://)[^/\s:@]+:[^/\s:@]+@"), r"\1[REDACTED]@"),
-    # .env-style line pasted into a message: FOO_API_KEY=value
-    (re.compile(r"(?m)^(\s*[A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD)[A-Z0-9_]*\s*=\s*)\S+$"), r"\1[REDACTED]"),
-    # "Authorization: <B> <token>" / "<B> <token>" (space-separated value)
-    (re.compile(r"(?i)\bauthorization\s*:\s*bearer\s+[A-Za-z0-9_\-\.\/\+]{4,}"), "Authorization: " + _B + " " + _RED),
-    (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9_\-\.\/\+]{8,}"), _B + " " + _RED),
-    # Generic key=value. Floor of 6 chars: shorter values are overwhelmingly
-    # literals like true/null/1234, and redacting those only destroys evidence.
-    (re.compile(r"(?i)(authorization|bearer|api[_-]?key|password|passwd|secret|token)\s*[:=]\s*[\"']?[A-Za-z0-9_\-\.\/\+]{6,}"), r"\1=[REDACTED]"),
-]
-
-
-def scrub_text(text: str) -> str:
-    """Replace known credential patterns with [REDACTED]."""
-    if not text:
-        return text
-    for pattern, repl in _SECRET_PATTERNS:
-        text = pattern.sub(repl, text)
-    return text
-
 
 def scrub_proposal(proposal: Dict[str, Any]) -> Dict[str, Any]:
-    """Scrub all string fields of a proposal dict before journaling."""
-    out = dict(proposal)
-    for key, val in list(out.items()):
-        if isinstance(val, str):
-            out[key] = scrub_text(val)
-        elif isinstance(val, list):
-            out[key] = [scrub_text(v) if isinstance(v, str) else v for v in val]
-    return out
+    """Compatibility wrapper for recursive shared sanitation."""
+    return sanitize(proposal)
 
-# ── trajectory collector ────────────────────────────────────────────────────
+
+# ── trajectory collection ──────────────────────────────────────────────────
 
 
 def _open_db() -> Optional[sqlite3.Connection]:
-    """Open state.db read-only. Returns None on failure."""
-    db_path = config.state_db_path()
-    if not db_path.is_file():
-        logger.warning("state.db not found at %s", db_path)
+    path = config.state_db_path()
+    if not path.is_file():
         return None
     try:
-        uri = f"file:{db_path}?mode=ro"
-        con = sqlite3.connect(uri, uri=True)
-        con.row_factory = sqlite3.Row
-        return con
+        connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        return connection
     except Exception as exc:
         logger.warning("Cannot open state.db: %s", exc)
         return None
 
 
-def _get_recent_session_id(con: sqlite3.Connection) -> Optional[str]:
-    """Get the most recently ended session id."""
+def _get_recent_session_id(connection: sqlite3.Connection) -> Optional[str]:
     try:
-        row = con.execute(
+        row = connection.execute(
             "SELECT id FROM sessions ORDER BY started_at DESC LIMIT 1"
         ).fetchone()
         return row["id"] if row else None
@@ -105,241 +50,238 @@ def _get_recent_session_id(con: sqlite3.Connection) -> Optional[str]:
         return None
 
 
-def collect_evidence(session_id: Optional[str] = None, limit: int = 60) -> Dict[str, Any]:
-    """Gather recent trajectory from state.db.
-
-    Returns dict with: messages, error_count, tool_errors, user_corrections, session_id.
-    """
-    con = _open_db()
-    if not con:
-        return {
-            "messages": [],
-            "error_count": 0,
-            "tool_errors": [],
-            "user_corrections": [],
-            "session_id": "",
-        }
-
+def _structured_error_status(content: str) -> Optional[bool]:
+    """Return a definitive structured status, or None when text is unstructured."""
     try:
-        if not session_id:
-            session_id = _get_recent_session_id(con)
+        value = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        value = None
+    if isinstance(value, dict):
+        exit_values = [
+            value[key]
+            for key in ("exit_code", "returncode", "return_code")
+            if key in value
+            and isinstance(value[key], (int, float))
+            and not isinstance(value[key], bool)
+        ]
+        if any(code != 0 for code in exit_values):
+            return True
+        error = value.get("error")
+        if error not in (None, "", False, [], {}):
+            return True
+        if value.get("success") is False or value.get("ok") is False:
+            return True
+        if exit_values and all(code == 0 for code in exit_values):
+            return False
+        if value.get("success") is True or value.get("ok") is True:
+            return False
 
-        if not session_id:
-            return {
-                "messages": [],
-                "error_count": 0,
-                "tool_errors": [],
-                "user_corrections": [],
-                "session_id": "",
-            }
-
-        rows = con.execute(
-            "SELECT role, content, tool_name, timestamp "
-            "FROM messages "
-            "WHERE session_id = ? AND active = 1 "
-            "ORDER BY timestamp DESC LIMIT ?",
-            (session_id, limit),
-        ).fetchall()
-
-        messages: List[Dict[str, Any]] = []
-        error_count = 0
-        tool_errors: List[Dict[str, Any]] = []
-        user_corrections: List[Dict[str, Any]] = []
-        error_items: List[Dict[str, Any]] = []
-
-        for row in reversed(rows):
-            role = row["role"] or ""
-            # Scrub at the single point where rows leave the DB — every
-            # downstream consumer (LLM evidence, journal, tool result echoed
-            # back into context) gets the redacted text automatically.
-            content = scrub_text(str(row["content"] or ""))[:3000]  # truncate long outputs
-            tool_name = row["tool_name"] or ""
-
-            entry: Dict[str, Any] = {
-                "role": role,
-                "content": content if len(content) <= 400 else content[:400] + "…",
-                "tool_name": tool_name,
-            }
-            messages.append(entry)
-
-            # Detect errors
-            if role == "tool" and _is_error_content(content):
-                error_count += 1
-                tool_errors.append({
-                    "tool": tool_name,
-                    "snippet": content[:300],
-                })
-                error_items.append({
-                    "tool": tool_name,
-                    "content": content,
-                    "session_id": session_id,
-                    "ts": row["timestamp"] or 0,
-                })
-
-            # Detect user corrections
-            if role == "user" and _is_correction(content):
-                user_corrections.append({
-                    "snippet": content[:300],
-                })
-
-        return {
-            "messages": messages[-limit:],
-            "error_count": error_count,
-            # tool_errors is the flat pre-aggregation view — kept for
-            # compatibility. error_patterns is what callers should read.
-            "tool_errors": tool_errors[-10:],
-            "error_patterns": patterns.extract_patterns(error_items),
-            "user_corrections": user_corrections[-5:],
-            "session_id": session_id,
-        }
-    finally:
-        con.close()
-
-
-def collect_cross_session_patterns(
-    days: Optional[int] = None,
-    max_rows: int = 4000,
-) -> List[Dict[str, Any]]:
-    """Aggregate error patterns across recent sessions.
-
-    A failure that recurs in several *different* sessions is a much stronger
-    signal than one repeated twice inside a single conversation, where it is
-    usually just a retry loop. Only tool rows are read, and the row cap is hard —
-    this runs in a background thread at session end and must not turn into a
-    full-history scan.
-    """
-    if not config.cross_session_enabled():
-        return []
-
-    window_days = days if days is not None else config.cross_session_days()
-    con = _open_db()
-    if not con:
-        return []
-
-    try:
-        since = time.time() - (window_days * 86400)
-        rows = con.execute(
-            "SELECT session_id, tool_name, content, timestamp "
-            "FROM messages "
-            "WHERE role = 'tool' AND active = 1 AND timestamp >= ? "
-            "ORDER BY timestamp DESC LIMIT ?",
-            (since, max_rows),
-        ).fetchall()
-    except Exception as exc:
-        logger.warning("Cross-session query failed: %s", exc)
-        return []
-    finally:
-        con.close()
-
-    items: List[Dict[str, Any]] = []
-    sessions_seen: set = set()
-    max_sessions = config.cross_session_max_sessions()
-
-    for row in rows:
-        sid = str(row["session_id"] or "")
-        if sid and sid not in sessions_seen:
-            if len(sessions_seen) >= max_sessions:
-                continue
-            sessions_seen.add(sid)
-        # Scrub here too: the choke-point rule applies to every path out of the DB.
-        content = scrub_text(str(row["content"] or ""))[:3000]
-        if not _is_error_content(content):
-            continue
-        items.append({
-            "tool": row["tool_name"] or "",
-            "content": content,
-            "session_id": sid,
-            "ts": row["timestamp"] or 0,
-        })
-
-    return patterns.extract_patterns(items)
-
-
-# A successful JSON tool result usually still contains the word "error" — as a
-# field name with a null value. Counting those as failures buries the real ones.
-_JSON_SUCCESS_MARKERS = (
-    '"success": true', '"success":true',
-    '"error": null', '"error":null',
-    '"error": ""', '"error":""',
-    '"ok": true', '"ok":true',
-)
+    codes = [
+        int(match)
+        for match in re.findall(
+            r"(?i)(?:\bexit[_ ]?code\b|\breturncode\b)\s*[:=]?\s*(-?\d+)",
+            content,
+        )
+    ]
+    if any(code != 0 for code in codes):
+        return True
+    return False if codes else None
 
 
 def _is_error_content(content: str) -> bool:
-    """Heuristic: does this look like a tool error?"""
-    if len(content) >= 2000:
-        return False  # error messages tend to be short
-
-    lower = content.lower()
-
-    # An explicit success marker outranks any incidental "error" keyword.
-    if any(marker in lower for marker in _JSON_SUCCESS_MARKERS):
+    """Classify structured status first, then bounded head/tail error text."""
+    if not content:
         return False
-
-    return any(
-        kw in content or kw in lower
-        for kw in ["Traceback", "exit_code", " error", "failed", "ERROR", "timeout"]
+    structured = _structured_error_status(content)
+    if structured is not None:
+        return structured
+    sample = (
+        content
+        if len(content) <= 4000
+        else content[:1000] + "\n…\n" + content[-3000:]
+    )
+    sample = re.sub(r'(?i)["\']?error["\']?\s*:\s*(?:null|""|\'\')', "", sample)
+    return bool(
+        re.search(
+            r"(?i)(?:^|[\s\[{(,:;])(?:traceback|error\b|failed\b|failure\b|timed?\s*out\b|timeout\b)",
+            sample,
+        )
     )
 
 
 def _is_correction(content: str) -> bool:
-    """Heuristic: is the user clearly correcting the agent?
-
-    Deliberately narrow — generic words like "no", "не", "use", "try" match
-    almost every message and produce noise. Only explicit correction phrasings
-    (plus a minimum length) count as a signal.
-    """
-    if len(content) < 15:
+    """Recognize explicit agent corrections, not routine instructions."""
+    if len(content.strip()) < 12:
         return False
-    lower = content.lower()
-    correction_phrases = [
-        "wrong", "неправильно", "не так", "not right", "fix it", "fix the",
-        "don't", "do not", "замість", "instead", "correct", "спробуй інакше",
-        "try again", "stop", "не треба", "не роби", "не використовуй",
-        "use the", "use this", "that's not", "that is not", "перероби",
-    ]
-    return any(ph in lower for ph in correction_phrases)
+    text = re.sub(r"\s+", " ", content.strip().lower())
+    strong = (
+        r"\b(?:that(?:'s| is) (?:wrong|not right)|you (?:are|were) wrong|wrong answer|incorrect)\b",
+        r"\b(?:неправильно|це не так|ти помилив|ви помилили)\b",
+        r"^(?:no|ні|нет)[,;:]\s+.{0,100}\b(?:wrong|not right|не так|неправильно|instead|замість)\b",
+        r"\b(?:you used|ти використав|ви використали)\b.{0,120}\b(?:use|instead|замість)\b",
+    )
+    return any(re.search(pattern, text) for pattern in strong)
 
 
-# ── existing skills / memories ──────────────────────────────────────────────
+def collect_evidence(session_id: Optional[str] = None, limit: int = 60) -> Dict[str, Any]:
+    connection = _open_db()
+    empty = {
+        "messages": [],
+        "error_count": 0,
+        "tool_errors": [],
+        "error_patterns": [],
+        "user_corrections": [],
+        "session_id": "",
+    }
+    if not connection:
+        return empty
+    try:
+        session_id = session_id or _get_recent_session_id(connection)
+        if not session_id:
+            return empty
+        rows = connection.execute(
+            "SELECT role, content, tool_name, timestamp FROM messages "
+            "WHERE session_id = ? AND active = 1 ORDER BY timestamp DESC LIMIT ?",
+            (session_id, limit),
+        ).fetchall()
+        messages: List[Dict[str, Any]] = []
+        tool_errors: List[Dict[str, Any]] = []
+        corrections: List[Dict[str, Any]] = []
+        error_items: List[Dict[str, Any]] = []
+        for row in reversed(rows):
+            role = str(row["role"] or "")
+            content = scrub_text(str(row["content"] or ""))
+            tool_name = str(row["tool_name"] or "")
+            shown = content[:400] + ("…" if len(content) > 400 else "")
+            messages.append({"role": role, "content": shown, "tool_name": tool_name})
+            if role == "tool" and _is_error_content(content):
+                bounded = (
+                    content
+                    if len(content) <= 4000
+                    else content[:1000] + "\n…\n" + content[-3000:]
+                )
+                tool_errors.append({"tool": tool_name, "snippet": bounded[:300]})
+                error_items.append({
+                    "tool": tool_name,
+                    "content": bounded,
+                    "session_id": session_id,
+                    "ts": row["timestamp"] or 0,
+                })
+            if role == "user" and _is_correction(content):
+                corrections.append({"snippet": content[:300]})
+        return {
+            "messages": messages[-limit:],
+            "error_count": len(tool_errors),
+            "tool_errors": tool_errors[-10:],
+            "error_patterns": patterns.extract_patterns(error_items),
+            "user_corrections": corrections[-5:],
+            "session_id": session_id,
+        }
+    finally:
+        connection.close()
+
+
+def collect_cross_session_patterns(
+    days: Optional[int] = None,
+    max_rows: Optional[int] = 4000,
+    *,
+    since_ts: Optional[float] = None,
+    max_sessions: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    if not config.cross_session_enabled():
+        return []
+    connection = _open_db()
+    if not connection:
+        return []
+    since = (
+        since_ts
+        if since_ts is not None
+        else time.time() - ((days or config.cross_session_days()) * 86400)
+    )
+    sql = (
+        "SELECT session_id, tool_name, content, timestamp FROM messages "
+        "WHERE role = 'tool' AND active = 1 AND timestamp >= ? ORDER BY timestamp DESC"
+    )
+    params: List[Any] = [since]
+    if max_rows is not None:
+        sql += " LIMIT ?"
+        params.append(max_rows)
+    try:
+        cursor = connection.execute(sql, tuple(params))
+        session_cap = (
+            config.cross_session_max_sessions()
+            if max_sessions is None and since_ts is None
+            else max_sessions
+        )
+        seen: set = set()
+
+        def iter_items():
+            for row in cursor:
+                sid = scrub_text(str(row["session_id"] or ""))
+                if sid and sid not in seen:
+                    if session_cap is not None and len(seen) >= session_cap:
+                        continue
+                    seen.add(sid)
+                content = scrub_text(str(row["content"] or ""))
+                if not _is_error_content(content):
+                    continue
+                bounded = (
+                    content
+                    if len(content) <= 4000
+                    else content[:1000] + "\n…\n" + content[-3000:]
+                )
+                yield {
+                    "tool": scrub_text(str(row["tool_name"] or "")),
+                    "content": bounded,
+                    "session_id": sid,
+                    "ts": row["timestamp"] or 0,
+                }
+
+        full_audit = since_ts is not None and max_rows is None and max_sessions is None
+        return patterns.extract_patterns(
+            iter_items(), limit=None if full_audit else 10
+        )
+    except Exception as exc:
+        logger.warning("Cross-session query failed: %s", scrub_text(str(exc)))
+        return []
+    finally:
+        connection.close()
+
+
+# ── host context ───────────────────────────────────────────────────────────
 
 
 def list_skill_names() -> List[str]:
-    """Return a list of all loaded skill names."""
     try:
         from tools.skills_tool import skills_list
+
         raw = skills_list()
-        # skills_list returns a JSON string — parse it (dict/list also handled).
-        if isinstance(raw, str):
-            result = json.loads(raw)
-        else:
-            result = raw
-        if isinstance(result, dict) and "skills" in result:
-            return [s.get("name", "") for s in result["skills"]]
-        if isinstance(result, list):
-            return [s.get("name", "") for s in result]
-    except Exception:
-        pass
-    return []
-
-
-def list_memory_snippets() -> List[str]:
-    """Return short memory snippets for context."""
-    try:
-        from tools.memory_tool import MemoryStore
-        store = MemoryStore()
-        store.load_from_disk()
-        entries = store.memory_entries + store.user_entries
-        return [e[:120] for e in entries[-20:]]
+        result = raw if not isinstance(raw, str) else json.loads(raw)
+        skills = result.get("skills", []) if isinstance(result, dict) else result
+        return [
+            scrub_text(str(item.get("name", "")))
+            for item in skills
+            if isinstance(item, dict)
+        ]
     except Exception:
         return []
 
 
-# ── guardrails ──────────────────────────────────────────────────────────────
+def list_memory_snippets() -> List[str]:
+    try:
+        from tools.memory_tool import MemoryStore
+
+        store = MemoryStore()
+        store.load_from_disk()
+        return [
+            scrub_text(str(entry))[:120]
+            for entry in (store.memory_entries + store.user_entries)[-20:]
+        ]
+    except Exception:
+        return []
 
 
 def _unused_skills_safe() -> List[str]:
-    """Never let ledger trouble break a refine run."""
     try:
         return ledger.unused_skills()
     except Exception as exc:
@@ -347,124 +289,138 @@ def _unused_skills_safe() -> List[str]:
         return []
 
 
+def _reconcile_pending() -> List[Dict[str, Any]]:
+    """Reconcile durable approval states and mirror transitions to the ledger."""
+    changed = journal.reconcile()
+    for entry in changed:
+        try:
+            ledger.record_journal_state(entry)
+        except Exception as exc:
+            logger.warning("Cannot mirror reconciled state in ledger: %s", scrub_text(str(exc)))
+    return changed
+
+
 def refine_audit() -> Dict[str, Any]:
-    """Read-only report: did the skills refine wrote actually help?"""
+    with journal.mutation_lock():
+        _reconcile_pending()
+    earliest = ledger.earliest_created_ts()
     try:
-        current = collect_cross_session_patterns()
+        current = (
+            collect_cross_session_patterns(
+                since_ts=earliest,
+                max_rows=None,
+                max_sessions=None,
+            )
+            if earliest
+            else []
+        )
     except Exception:
         current = []
     rows = ledger.audit(current)
     return {"success": True, "rows": rows, "report": ledger.format_audit(rows)}
 
 
-def _validate_proposal(proposal: Dict[str, Any]) -> Optional[str]:
-    """Check guardrails. Returns None if OK, or an error reason string."""
-    action = proposal.get("action", "no_op")
-    if action == "no_op":
-        return None  # not an error
+# ── proposal validation and apply ──────────────────────────────────────────
 
-    kind = proposal.get("kind", "")
-    name = proposal.get("name", "").strip()
 
-    if not name:
-        return "Proposal missing name"
-
-    # Size check
-    content = proposal.get("content", "")
-    if action == "create" and len(content) > 15000:
-        return f"Content too large ({len(content)} chars)"
-
-    if action == "patch" and len(content) > 15000:
-        return f"Content too large ({len(content)} chars)"
-
-    # Patch may only touch skills the agent itself created — never bundled
-    # or hub-installed. Create is protected separately by the already-exists
-    # check below (a fresh name can't be a bundled skill).
-    if kind == "skill" and action == "patch" and config.only_agent_created():
-        try:
-            from tools.skill_usage import is_agent_created
-            if not is_agent_created(name):
-                return (
-                    f"Skill '{name}' is bundled/hub-installed "
-                    "(denied by only_agent_created)"
-                )
-        except ImportError:
-            return "Cannot import skill_usage module"
-
-    # Create must target a NEW skill name — never overwrite an existing one
-    # (bundled, user, or agent-created). Existing skills are patched, not created.
-    if kind == "skill" and action == "create" and name in list_skill_names():
-        return f"Skill '{name}' already exists — use patch, not create"
-
-    # Refuse an edit identical to one already applied recently
-    if journal.was_applied_recently(proposal, config.dedup_window_days()):
-        return (
-            f"Identical edit already applied within "
-            f"{config.dedup_window_days()} day(s)"
-        )
-
-    # Don't delete anything
-    if action == "delete":
-        return "Delete action not allowed from refine"
-
-    # Don't touch skills that start with "hermes-" (reserved)
-    if kind == "skill" and name.startswith("hermes-"):
-        return f"Skill '{name}' has reserved prefix"
-
+def _skill_content_error(name: str, content: str) -> Optional[str]:
+    if not content.startswith("---"):
+        return "Skill content must start with YAML frontmatter"
+    match = re.match(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", content, re.S)
+    if not match:
+        return "Skill content has incomplete YAML frontmatter"
+    frontmatter = match.group(1)
+    name_match = re.search(r"(?m)^name\s*:\s*[\"']?([^\n\"']+)", frontmatter)
+    if not name_match or name_match.group(1).strip() != name:
+        return "Skill frontmatter name must exactly match the target name"
+    if not re.search(r"(?m)^description\s*:\s*\S", frontmatter):
+        return "Skill frontmatter requires a non-empty description"
+    if not content[match.end():].strip():
+        return "Skill content requires a Markdown body"
     return None
 
 
-# ── apply ───────────────────────────────────────────────────────────────────
+def _validate_proposal(proposal: Dict[str, Any]) -> Optional[str]:
+    action = str(proposal.get("action", "no_op"))
+    if action == "no_op":
+        return None
+    if action not in ("create", "patch"):
+        return f"Unsupported action: {action}"
+    kind = str(proposal.get("kind", ""))
+    if kind not in ("skill", "memory"):
+        return f"Unsupported kind: {kind}"
+    name = str(proposal.get("name", "")).strip()
+    content = str(proposal.get("content", ""))
+    if not name:
+        return "Proposal missing name"
+    if not content.strip():
+        return f"{action.title()} requires non-empty content"
+    if len(content) > _llm.MAX_CONTENT_CHARS:
+        return f"Content too large ({len(content)} chars; max {_llm.MAX_CONTENT_CHARS})"
+    if kind == "skill":
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,63}", name):
+            return "Skill name must use lowercase letters, digits, hyphens, or underscores"
+        format_error = _skill_content_error(name, content)
+        if format_error:
+            return format_error
+        if name.startswith("hermes-"):
+            return f"Skill '{name}' has reserved prefix"
+        if action == "create" and name in list_skill_names():
+            return f"Skill '{name}' already exists — use patch, not create"
+        if action == "patch" and config.only_agent_created():
+            try:
+                from tools.skill_usage import is_agent_created
+
+                if not is_agent_created(name):
+                    return f"Skill '{name}' is bundled/hub-installed (denied by only_agent_created)"
+            except ImportError:
+                return "Cannot import skill_usage module"
+    fingerprint = str(proposal.get("pattern_fingerprint", "") or "")
+    if fingerprint and not re.fullmatch(r"[0-9a-f]{12}", fingerprint):
+        return "pattern_fingerprint must be the complete 12-character fingerprint"
+    if journal.was_applied_recently(proposal, config.dedup_window_days()):
+        return f"Identical edit already applied within {config.dedup_window_days()} day(s)"
+    return None
 
 
 def _apply_skill(proposal: Dict[str, Any]) -> Dict[str, Any]:
-    """Apply a skill create/patch via skill_manage."""
-    action = proposal["action"]
-    name = proposal["name"]
-    content = proposal["content"]
-    category = proposal.get("category", "")
-
     from tools.skill_manager_tool import skill_manage
 
-    result_str = skill_manage(
+    action = "edit" if proposal["action"] == "patch" else proposal["action"]
+    raw = skill_manage(
         action=action,
-        name=name,
-        content=content if content else None,
-        category=category if category else None,
+        name=proposal["name"],
+        content=proposal["content"],
+        category=proposal.get("category") or None,
     )
+    if isinstance(raw, dict):
+        return raw
     try:
-        return json.loads(result_str)
-    except json.JSONDecodeError:
-        return {"success": False, "error": result_str}
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {"success": False, "error": str(raw)}
 
 
 def _apply_memory(proposal: Dict[str, Any]) -> Dict[str, Any]:
-    """Apply a memory create/patch via memory_tool."""
-    action = proposal["action"]
-    content = proposal["content"]
-    kind = proposal.get("kind", "memory")
-    target = "user" if kind == "user" else "memory"
-
     from tools.memory_tool import MemoryStore
 
+    target = "user" if proposal.get("kind") == "user" else "memory"
+    if proposal.get("action") not in ("create", "patch"):
+        return {"success": False, "error": f"Unknown memory action: {proposal.get('action')}"}
     store = MemoryStore()
     store.load_from_disk()
-
-    if action == "create":
-        result = store.add(target, content)
-    elif action == "patch":
-        # For memory, a 'patch' means replace the oldest/whole entry.
-        # We treat the content as a new add (since memory is append-only by nature).
-        result = store.add(target, content)
-    else:
-        return {"success": False, "error": f"Unknown action '{action}' for memory"}
-
-    if result.get("success"):
+    result = store.add(target, proposal["content"])
+    if result.get("success") and not result.get("staged"):
         store.save_to_disk(target)
     return result
 
 
-# ── main entry ──────────────────────────────────────────────────────────────
+def _journal_nonmutation(**kwargs: Any) -> Optional[str]:
+    try:
+        return journal.log(**kwargs)
+    except Exception as exc:
+        logger.error("Cannot write refine journal: %s", exc)
+        return None
 
 
 def _refine_once(
@@ -474,22 +430,19 @@ def _refine_once(
     session_id: Optional[str] = None,
     auto: bool = False,
 ) -> Dict[str, Any]:
-    """Run a single refine pass (one proposal → one edit)."""
     trigger = "auto" if auto else "manual"
-    t_start = time.time()
+    started = time.time()
+    safe_reason = scrub_text(reason)
 
-    # 1. Daily limit check
     if journal.daily_limit_reached():
         return {
             "success": False,
             "message": f"Daily edit limit reached ({config.max_edits_per_day()}). "
-                       f"Edits today: {journal.count_today_applied()}.",
+            f"Applied/pending/prepared today: {journal.count_today_applied()}.",
         }
 
-    # 2. Collect evidence
     evidence = collect_evidence(session_id=session_id)
-    sid = evidence.get("session_id", "")
-
+    session = evidence.get("session_id", "")
     if len(evidence.get("messages", [])) < 3:
         return {
             "success": True,
@@ -497,190 +450,266 @@ def _refine_once(
             "evidence": evidence,
         }
 
-    # 3. Aggregate failures across this session and the recent window
     error_patterns = patterns.merge_patterns(
-        evidence.get("error_patterns", []),
-        collect_cross_session_patterns(),
+        evidence.get("error_patterns", []), collect_cross_session_patterns()
     )
     evidence["error_patterns"] = error_patterns
     corrections = evidence.get("user_corrections", [])
-
-    # 4. Signal gate — a single one-off error teaches nothing generalizable,
-    # so do not spend a model call on it.
     if config.min_signal_required() and not patterns.has_signal(
         error_patterns, corrections, min_count=config.min_pattern_count()
     ):
         proposal = {
             "action": "no_op",
-            "reason": (
-                f"No repeated failure (min {config.min_pattern_count()}x) and no user "
-                f"correction in the last {config.cross_session_days()} day(s)."
-            ),
+            "reason": f"No repeated failure (min {config.min_pattern_count()}x) and no explicit correction.",
         }
-        entry_id = journal.log(
+        entry_id = _journal_nonmutation(
             trigger=trigger,
-            reason=reason or proposal["reason"],
-            session_id=sid,
+            reason=safe_reason or proposal["reason"],
+            session_id=session,
             proposal=proposal,
             outcome="no_op",
         )
+        if not entry_id:
+            return {
+                "success": False,
+                "message": "No edit was needed, but the journal write failed.",
+                "evidence": evidence,
+            }
         return {
             "success": True,
             "message": f"No actionable improvement found. {proposal['reason']}",
             "journal_id": entry_id,
             "llm_called": False,
             "evidence": evidence,
+            "reversible": False,
         }
 
-    # 5. Get existing skills/memories for context
-    skills = list_skill_names()
-    memories = list_memory_snippets()
+    lines: List[str] = []
+    for message in evidence.get("messages", []):
+        tag = f"[{message['role']}]"
+        if message.get("tool_name"):
+            tag += f"({message['tool_name']})"
+        lines.append(f"{tag} {message['content'][:400]}")
 
-    # 6. Build evidence text for LLM
-    ev_lines: List[str] = []
-    for m in evidence.get("messages", []):
-        role_tag = f"[{m['role']}]"
-        if m.get("tool_name"):
-            role_tag += f"({m['tool_name']})"
-        ev_lines.append(f"{role_tag} {m['content'][:400]}")
-    evidence_text = "\n".join(ev_lines)
-
-    # 7. LLM proposal
     proposal = _llm.propose(
         llm=llm,
-        evidence_text=evidence_text,
-        existing_skills=skills,
-        existing_memories=memories,
+        evidence_text="\n".join(lines),
+        existing_skills=list_skill_names(),
+        existing_memories=list_memory_snippets(),
         error_patterns=error_patterns,
-        user_corrections=[c.get("snippet", "") for c in corrections],
+        user_corrections=[item.get("snippet", "") for item in corrections],
         unused_skills=_unused_skills_safe(),
         purpose="refine",
+        run_context=safe_reason,
+        skill_content_loader=journal.read_skill_content,
     )
+    proposal = sanitize(proposal)
 
-    # Scrub before journaling/returning — credentials must never persist.
-    proposal = scrub_proposal(proposal)
-
-    # 6. If no_op, log and return
     if proposal.get("action") == "no_op":
-        entry_id = journal.log(
+        entry_id = _journal_nonmutation(
             trigger=trigger,
-            reason=reason or proposal.get("reason", ""),
-            session_id=sid,
+            reason=safe_reason or proposal.get("reason", ""),
+            session_id=session,
             proposal=proposal,
             outcome="no_op",
         )
+        if not entry_id:
+            return {
+                "success": False,
+                "message": "Proposal was no_op, but the journal write failed.",
+                "proposal": proposal,
+            }
         return {
             "success": True,
             "message": f"No actionable improvement found. {proposal.get('reason', '')}",
             "journal_id": entry_id,
+            "proposal": proposal,
             "evidence": evidence,
+            "reversible": False,
         }
 
-    # 7. Guardrails
-    guardrail_err = _validate_proposal(proposal)
-    if guardrail_err:
-        entry_id = journal.log(
+    guardrail_error = _validate_proposal(proposal)
+    if guardrail_error:
+        entry_id = _journal_nonmutation(
             trigger=trigger,
-            reason=reason,
-            session_id=sid,
+            reason=safe_reason,
+            session_id=session,
             proposal=proposal,
             outcome="rejected",
-            error=guardrail_err,
+            error=guardrail_error,
         )
-        return {
+        result = {
             "success": False,
-            "message": f"Proposal rejected by guardrails: {guardrail_err}",
-            "journal_id": entry_id,
+            "message": f"Proposal rejected by guardrails: {guardrail_error}",
             "proposal": proposal,
+            "reversible": False,
         }
+        if entry_id:
+            result["record_id"] = entry_id
+        return result
 
-    # 8. Backup
+    kind = proposal["kind"]
+    action = proposal["action"]
+    name = proposal["name"]
     backup_path = ""
-    kind = proposal.get("kind", "skill")
-    name = proposal.get("name", "")
-    action = proposal.get("action", "")
-
+    recovery: Dict[str, Any] = {}
     if kind == "skill" and action == "patch":
-        bp = journal.backup_skill(name)
-        backup_path = str(bp) if bp else ""
-    elif kind == "memory":
-        mem_content = journal.backup_memory("memory")
-        if mem_content is not None:
-            bp = journal.backups_dir() / f"{int(time.time()*1000)}_memory.bak"
-            bp.write_text(mem_content, encoding="utf-8")
-            backup_path = str(bp)
+        backup = journal.backup_skill(name)
+        if backup is None:
+            error = f"Cannot create durable backup for skill '{name}'; mutation aborted"
+            _journal_nonmutation(
+                trigger=trigger,
+                reason=safe_reason,
+                session_id=session,
+                proposal=proposal,
+                outcome="error",
+                error=error,
+            )
+            return {
+                "success": False,
+                "message": error,
+                "proposal": proposal,
+                "reversible": False,
+            }
+        backup_path = str(backup)
+        recovery = {"type": "skill_patch", "name": name}
+    elif kind == "skill":
+        recovery = {"type": "skill_create", "name": name}
+    else:
+        target = "user" if kind == "user" else "memory"
+        memory_recovery = journal.memory_recovery(target, proposal["content"])
+        if memory_recovery is None:
+            error = f"Cannot capture {target} memory recovery state; mutation aborted"
+            _journal_nonmutation(
+                trigger=trigger,
+                reason=safe_reason,
+                session_id=session,
+                proposal=proposal,
+                outcome="error",
+                error=error,
+            )
+            return {
+                "success": False,
+                "message": error,
+                "proposal": proposal,
+                "reversible": False,
+            }
+        recovery = memory_recovery
 
-    # 9. Apply
     try:
-        if kind == "skill":
-            result = _apply_skill(proposal)
-        elif kind == "memory":
-            result = _apply_memory(proposal)
-        else:
-            result = {"success": False, "error": f"Unknown kind: {kind}"}
-    except Exception as exc:
-        entry_id = journal.log(
+        entry_id = journal.prepare(
             trigger=trigger,
-            reason=reason,
-            session_id=sid,
+            reason=safe_reason,
+            session_id=session,
             proposal=proposal,
-            outcome="error",
-            error=str(exc),
+            backup_path=backup_path,
+            recovery=recovery,
         )
+    except Exception as exc:
         return {
             "success": False,
-            "message": f"Apply failed: {exc}",
-            "journal_id": entry_id,
+            "message": f"Journal preparation failed; mutation aborted: {scrub_text(str(exc))}",
             "proposal": proposal,
+            "reversible": False,
         }
 
-    # 10. Journal
-    outcome = "applied" if result.get("success") else "error"
-    staged = result.get("staged", False)
-    if staged:
-        outcome = "pending_approval"
+    try:
+        apply_result = _apply_skill(proposal) if kind == "skill" else _apply_memory(proposal)
+    except Exception as exc:
+        apply_result = {"success": False, "error": scrub_text(str(exc))}
+    apply_result = sanitize(apply_result)
 
-    entry_id = journal.log(
-        trigger=trigger,
-        reason=reason,
-        session_id=sid,
-        proposal=proposal,
-        outcome=outcome,
-        backup_path=backup_path,
-        error=result.get("error", ""),
+    staged = bool(apply_result.get("success") and apply_result.get("staged"))
+    pending_id = scrub_text(str(apply_result.get("pending_id", ""))) if staged else ""
+    if staged and not pending_id:
+        apply_result = {
+            "success": False,
+            "error": "Host staged the mutation without a pending_id",
+        }
+        staged = False
+    if apply_result.get("success") and not staged:
+        prepared_entry = journal.get_entry(entry_id) or {
+            "proposal": proposal,
+            "recovery": recovery,
+            "backup_path": backup_path,
+        }
+        if not journal.target_matches_applied(prepared_entry):
+            apply_result = {
+                "success": False,
+                "error": "Host reported success but the target state does not match the proposal",
+            }
+    outcome = (
+        "pending_approval"
+        if staged
+        else ("applied" if apply_result.get("success") else "error")
     )
+    try:
+        finalized = journal.finalize(
+            entry_id,
+            outcome,
+            error=scrub_text(str(apply_result.get("error", ""))),
+            pending_id=pending_id if staged else None,
+        )
+    except Exception as exc:
+        if apply_result.get("success"):
+            return {
+                "success": False,
+                "message": f"Mutation completed but journal finalization failed; recovery id: {entry_id}. Error: {scrub_text(str(exc))}",
+                "journal_id": entry_id,
+                "proposal": proposal,
+                "result": sanitize(apply_result),
+                "backup_path": backup_path,
+                "reversible": not staged,
+            }
+        return {
+            "success": False,
+            "message": f"Apply failed and journal finalization also failed: {scrub_text(str(exc))}",
+            "proposal": proposal,
+            "result": sanitize(apply_result),
+            "reversible": False,
+        }
 
-    # Register in the usefulness ledger so /refine audit can judge it later.
     if outcome in ("applied", "pending_approval"):
         try:
-            ledger.record_edit(proposal, entry_id)
+            ledger.record_edit(
+                proposal,
+                entry_id,
+                outcome=outcome,
+                pending_id=pending_id,
+            )
         except Exception as exc:
             logger.warning("Cannot record edit in ledger: %s", exc)
 
-    elapsed = time.time() - t_start
-    msg_parts = [
-        f"done ({elapsed:.1f}s)",
-        f"action={proposal['action']} kind={kind} name={name}",
-        f"outcome={outcome}",
-    ]
-    if result.get("staged"):
-        msg_parts.append(f"pending_id={result.get('pending_id', '?')}")
-    if result.get("error"):
-        msg_parts.append(f"error={result['error'][:100]}")
+    message = (
+        f"done ({time.time() - started:.1f}s) | action={action} kind={kind} "
+        f"name={name} | outcome={outcome}"
+    )
+    if staged and pending_id:
+        message += f" | pending_id={pending_id}"
+    if apply_result.get("error"):
+        message += f" | error={scrub_text(str(apply_result['error']))[:100]}"
 
-    return {
-        "success": True,
-        "message": " | ".join(msg_parts),
-        "journal_id": entry_id,
+    success = bool(apply_result.get("success"))
+    response: Dict[str, Any] = {
+        "success": success,
+        "message": message,
         "proposal": proposal,
-        "result": result,
+        "result": sanitize(apply_result),
         "backup_path": backup_path,
+        "reversible": bool(
+            success and outcome == "applied" and journal.is_reversible(finalized)
+        ),
         "evidence": {
-            "session_id": sid,
+            "session_id": session,
             "messages": len(evidence.get("messages", [])),
             "errors": evidence.get("error_count", 0),
         },
     }
+    if success:
+        response["journal_id"] = entry_id
+    else:
+        response["record_id"] = entry_id
+    return response
 
 
 def refine_run(
@@ -690,66 +719,117 @@ def refine_run(
     session_id: Optional[str] = None,
     auto: bool = False,
 ) -> Dict[str, Any]:
-    """Run up to ``max_edits_per_run`` refine passes.
+    """Serialize a run, reconcile approvals, and preserve every recovery id."""
+    started = time.time()
+    with journal.mutation_lock():
+        _reconcile_pending()
+        runs: List[Dict[str, Any]] = []
+        max_runs = max(1, config.max_edits_per_run())
+        run_reason = scrub_text(reason)
+        for _ in range(max_runs):
+            if journal.daily_limit_reached():
+                break
+            result = _refine_once(
+                llm, reason=run_reason, session_id=session_id, auto=auto
+            )
+            runs.append(result)
+            action = result.get("proposal", {}).get("action")
+            accepted = bool(result.get("result", {}).get("success"))
+            if not result.get("success") or action in (None, "no_op") or not accepted:
+                break
+            done_name = scrub_text(str(result.get("proposal", {}).get("name", "")))
+            done_kind = scrub_text(str(result.get("proposal", {}).get("kind", "")))
+            note = (
+                f"Already completed or reserved {action} {done_kind} '{done_name}' in this run; "
+                "propose a different edit or no_op."
+            )
+            run_reason = f"{reason}\n{note}".strip() if reason else note
+            run_reason = scrub_text(run_reason)
 
-    Each pass proposes one edit; passes stop early on no_op/rejection/failure
-    or when the daily edit budget is exhausted. A single pass is returned
-    unchanged (backwards compatible); multiple passes are aggregated.
-    """
-    t_start = time.time()
-    runs: List[Dict[str, Any]] = []
-    max_runs = max(1, config.max_edits_per_run())
-    run_reason = reason
+        if not runs:
+            return {
+                "success": False,
+                "message": f"Daily edit limit reached ({config.max_edits_per_day()}).",
+                "reversible": False,
+            }
+        if len(runs) == 1:
+            return runs[0]
 
-    for _ in range(max_runs):
-        if journal.daily_limit_reached():
-            break
-        result = _refine_once(llm, reason=run_reason, session_id=session_id, auto=auto)
-        runs.append(result)
-        action = result.get("proposal", {}).get("action")
-        applied = bool(result.get("result", {}).get("success"))
-        if not result.get("success") or action in (None, "no_op") or not applied:
-            break
-        # Tell the next pass what was already done in this run so it doesn't
-        # re-propose the same edit (saves a wasted LLM call).
-        done_name = result.get("proposal", {}).get("name", "")
-        done_kind = result.get("proposal", {}).get("kind", "")
-        note = f"Already {action}d {done_kind} '{done_name}' in this run — propose something else or no_op."
-        run_reason = f"{reason}\n{note}".strip() if reason else note
+        recoveries: List[Dict[str, Any]] = []
+        for item in runs:
+            journal_id = item.get("journal_id")
+            if not journal_id or not item.get("result", {}).get("success"):
+                continue
+            durable = journal.get_entry(str(journal_id)) or {}
+            recovery_item: Dict[str, Any] = {
+                "journal_id": str(journal_id),
+                "outcome": durable.get("outcome", "unknown"),
+                "reversible": bool(item.get("reversible")),
+            }
+            if item.get("reversible"):
+                recovery_item["rollback_command"] = f"/refine rollback {journal_id}"
+            recoveries.append(recovery_item)
 
-    if not runs:
-        return {
-            "success": False,
-            "message": f"Daily edit limit reached ({config.max_edits_per_day()}).",
+        failed_after_success = bool(
+            recoveries and any(not item.get("success") for item in runs[1:])
+        )
+        last = runs[-1]
+        if failed_after_success:
+            message = (
+                f"PARTIAL SUCCESS: {len(recoveries)} earlier edit(s) were applied or reserved, "
+                "but a later pass failed. Use the recovery IDs listed below."
+            )
+            outcome = "partial_success"
+            success = False
+        else:
+            message = (
+                f"{len(runs)} pass(es), {len(recoveries)} edit(s) applied or reserved "
+                f"({time.time() - started:.1f}s)"
+            )
+            outcome = "completed"
+            success = all(item.get("success") for item in runs)
+        response: Dict[str, Any] = {
+            "success": success,
+            "outcome": outcome,
+            "message": message,
+            "proposal": last.get("proposal", runs[0].get("proposal", {})),
+            "results": runs,
+            "recoveries": recoveries,
+            "journal_ids": [item["journal_id"] for item in recoveries],
+            "evidence": runs[0].get("evidence", {}),
+            "reversible": any(item.get("reversible") for item in recoveries),
         }
-
-    if len(runs) == 1:
-        return runs[0]
-
-    applied_count = sum(1 for r in runs if r.get("result", {}).get("success"))
-    last = runs[-1]
-    return {
-        "success": any(r.get("success") for r in runs),
-        "message": f"{len(runs)} pass(es), {applied_count} edit(s) applied ({time.time() - t_start:.1f}s)",
-        "journal_id": last.get("journal_id", runs[0].get("journal_id", "")),
-        "proposal": last.get("proposal", runs[0].get("proposal", {})),
-        "results": runs,
-        "evidence": runs[0].get("evidence", {}),
-    }
+        return response
 
 
 def refine_rollback(entry_id: str) -> Dict[str, Any]:
-    """Rollback a previous refine edit by journal id."""
-    entry = journal.get_entry(entry_id)
-    if not entry:
-        return {"success": False, "error": f"Entry {entry_id} not found"}
-
-    proposal = entry.get("proposal", {})
-    kind = proposal.get("kind", "skill")
-
-    if kind == "skill":
-        return journal.rollback_skill(entry_id)
-    elif kind == "memory":
-        return journal.rollback_memory(entry_id)
-    else:
-        return {"success": False, "error": f"Unknown kind for rollback: {kind}"}
+    with journal.mutation_lock():
+        _reconcile_pending()
+        entry = journal.get_entry(entry_id)
+        if not entry:
+            return {"success": False, "error": f"Entry {entry_id} not found"}
+        if entry.get("outcome") == "rolled_back":
+            return {"success": True, "message": f"Entry {entry_id} is already rolled back"}
+        if entry.get("outcome") == "pending_rollback":
+            return {
+                "success": True,
+                "staged": True,
+                "pending_id": entry.get("pending_id", ""),
+                "message": "Rollback is still pending approval; target is unchanged",
+            }
+        if not journal.is_reversible(entry):
+            return {"success": False, "error": f"Entry {entry_id} is not reversible"}
+        kind = entry.get("proposal", {}).get("kind", "skill")
+        if kind == "skill":
+            result = journal.rollback_skill(entry_id)
+        elif kind in ("memory", "user"):
+            result = journal.rollback_memory(entry_id)
+        else:
+            return {"success": False, "error": f"Unknown kind for rollback: {kind}"}
+        latest = journal.get_entry(entry_id)
+        if latest:
+            try:
+                ledger.record_journal_state(latest)
+            except Exception as exc:
+                logger.warning("Cannot mirror rollback state in ledger: %s", scrub_text(str(exc)))
+        return sanitize(result)

--- a/journal.py
+++ b/journal.py
@@ -1,37 +1,40 @@
-"""Append-only JSONL journal + rollback for the refine plugin.
-
-Every refine action (applied, no_op, rejected, error) is logged
-to ``refine_journal.jsonl``. Before applying a skill/memory edit we
-back up the current state so it can be rolled back.
-"""
+"""Durable append-only journal, mutation lock, approvals, and rollback."""
 
 import hashlib
 import json
 import logging
-import shutil
+import os
+import tempfile
+import threading
 import time
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 try:
     from .config import journal_dir, max_edits_per_day
+    from .sanitization import sanitize, scrub_text
 except ImportError:
-    from config import journal_dir, max_edits_per_day  # noqa: F811 — standalone test
+    from config import journal_dir, max_edits_per_day  # noqa: F811
+    from sanitization import sanitize, scrub_text  # noqa: F811
 
 logger = logging.getLogger(__name__)
 
 _BACKUPS_DIR_NAME = "backups"
 _JOURNAL_FILE_NAME = "refine_journal.jsonl"
+_LOCK_FILE_NAME = ".mutation.lock"
+_LOCK_STALE_SECONDS = 300
+_THREAD_LOCK = threading.RLock()
+_LOCK_STATE = threading.local()
 
 
 def ensure_dirs() -> Path:
-    """Ensure journal and backup directories exist. Returns journal_dir Path."""
-    d = journal_dir()
-    d.mkdir(parents=True, exist_ok=True)
-    (d / _BACKUPS_DIR_NAME).mkdir(exist_ok=True)
-    return d
+    directory = journal_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / _BACKUPS_DIR_NAME).mkdir(exist_ok=True)
+    return directory
 
 
 def journal_path() -> Path:
@@ -42,59 +45,196 @@ def backups_dir() -> Path:
     return ensure_dirs() / _BACKUPS_DIR_NAME
 
 
-# ── journal I/O ─────────────────────────────────────────────────────────────
+def _pid_is_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _try_clear_stale_lock(path: Path) -> None:
+    """Clear only locks old enough to be stale, including malformed locks.
+
+    A creator may have made the file but not yet written its JSON. The mtime is
+    therefore authoritative for malformed/uninitialized locks and also guards
+    against deleting a recently replaced valid lock with an old timestamp.
+    """
+    try:
+        modified = path.stat().st_mtime
+    except FileNotFoundError:
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        pid = int(data.get("pid", 0))
+        created = float(data.get("created", 0))
+    except Exception:
+        pid, created = 0, 0
+    try:
+        modified = max(modified, path.stat().st_mtime)
+    except FileNotFoundError:
+        return
+    freshness = max(modified, created) if created > 0 else modified
+    if time.time() - freshness < _LOCK_STALE_SECONDS or _pid_is_alive(pid):
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+@contextmanager
+def mutation_lock(timeout: float = 30.0) -> Iterator[None]:
+    """Serialize refine mutations across threads and processes."""
+    with _THREAD_LOCK:
+        depth = getattr(_LOCK_STATE, "depth", 0)
+        if depth:
+            _LOCK_STATE.depth = depth + 1
+            try:
+                yield
+            finally:
+                _LOCK_STATE.depth -= 1
+            return
+
+        lock_path = ensure_dirs() / _LOCK_FILE_NAME
+        token = uuid.uuid4().hex
+        payload = json.dumps({"pid": os.getpid(), "created": time.time(), "token": token})
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                try:
+                    os.write(fd, payload.encode("utf-8"))
+                    os.fsync(fd)
+                finally:
+                    os.close(fd)
+                break
+            except FileExistsError:
+                _try_clear_stale_lock(lock_path)
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(f"Timed out waiting for refine mutation lock: {lock_path}")
+                time.sleep(0.05)
+
+        _LOCK_STATE.depth = 1
+        try:
+            yield
+        finally:
+            _LOCK_STATE.depth = 0
+            try:
+                current = json.loads(lock_path.read_text(encoding="utf-8"))
+                if current.get("token") == token:
+                    lock_path.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as exc:
+                logger.warning("Could not release refine mutation lock: %s", scrub_text(str(exc)))
+
+
+# ── durable file I/O ───────────────────────────────────────────────────────
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Atomically replace backup/stat files; journals use append-only writes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+    except Exception:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
 
 
 def _load_entries() -> List[Dict[str, Any]]:
-    """Read all journal entries (append-safe, corrupted lines skipped)."""
-    jp = journal_path()
-    entries: List[Dict[str, Any]] = []
-    if not jp.is_file():
-        return entries
+    """Stream journal state, skipping corrupt lines and collapsing updates by id."""
+    path = journal_path()
+    if not path.is_file():
+        return []
+    latest: Dict[str, Dict[str, Any]] = {}
+    order: List[str] = []
     try:
-        for line in jp.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entries.append(json.loads(line))
-            except json.JSONDecodeError:
-                logger.debug("Skipping corrupt journal line")
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("Skipping corrupt journal line")
+                    continue
+                entry_id = str(entry.get("id", ""))
+                if not entry_id:
+                    continue
+                if entry_id not in latest:
+                    order.append(entry_id)
+                latest[entry_id] = entry
     except Exception as exc:
-        logger.warning("Failed to read journal: %s", exc)
-    return entries
+        logger.warning("Failed to read journal: %s", scrub_text(str(exc)))
+        return []
+    return [latest[entry_id] for entry_id in order]
+
+
+def entries() -> List[Dict[str, Any]]:
+    """Return the latest durable state of each logical journal record."""
+    return _load_entries()
 
 
 def _append_entry(entry: Dict[str, Any]) -> None:
-    jp = journal_path()
-    try:
-        with open(jp, "a", encoding="utf-8") as fh:
-            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    except Exception as exc:
-        logger.error("Failed to write journal entry: %s", exc)
+    """Append one fsynced JSON line without rewriting journal history."""
+    safe_entry = sanitize(entry)
+    record = json.dumps(safe_entry, ensure_ascii=False, separators=(",", ":")) + "\n"
+    encoded = record.encode("utf-8")
+    with mutation_lock():
+        path = journal_path()
+        with path.open("a+b") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            separator = b""
+            if size:
+                handle.seek(-1, os.SEEK_END)
+                if handle.read(1) != b"\n":
+                    # Isolate a corrupt/partial prior tail so this valid record
+                    # remains independently loadable.
+                    separator = b"\n"
+            handle.seek(0, os.SEEK_END)
+            handle.write(separator + encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
 
 
-def count_today_applied() -> int:
-    """Count applied edits for today (UTC)."""
-    today = datetime.now(timezone.utc).date()
-    count = 0
-    for entry in _load_entries():
-        if entry.get("outcome") != "applied":
-            continue
-        ts = entry.get("ts", 0)
-        if not ts:
-            continue
-        try:
-            dt = datetime.fromtimestamp(ts, tz=timezone.utc).date()
-        except (OSError, OverflowError, ValueError):
-            continue
-        if dt == today:
-            count += 1
-    return count
-
-
-def daily_limit_reached() -> bool:
-    return count_today_applied() >= max_edits_per_day()
+def _new_entry(
+    *,
+    trigger: str,
+    reason: str,
+    session_id: str,
+    proposal: Dict[str, Any],
+    outcome: str,
+    backup_path: str = "",
+    error: str = "",
+    recovery: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "id": uuid.uuid4().hex[:12],
+        "ts": time.time(),
+        "trigger": trigger,
+        "reason": reason,
+        "session_id": str(session_id)[:64],
+        "proposal": proposal,
+        "outcome": outcome,
+        "backup_path": backup_path,
+        "recovery": recovery or {},
+        "error": error,
+    }
 
 
 def log(
@@ -106,26 +246,111 @@ def log(
     outcome: str,
     backup_path: str = "",
     error: str = "",
+    recovery: Optional[Dict[str, Any]] = None,
 ) -> str:
-    """Append a journal entry. Returns the entry id (UUID)."""
-    entry_id = uuid.uuid4().hex[:12]
-    entry: Dict[str, Any] = {
-        "id": entry_id,
-        "ts": time.time(),
-        "trigger": trigger,
-        "reason": reason,
-        "session_id": str(session_id)[:64],
-        "proposal": proposal,
-        "outcome": outcome,
-        "backup_path": backup_path,
-        "error": error,
-    }
+    entry = _new_entry(
+        trigger=trigger,
+        reason=reason,
+        session_id=session_id,
+        proposal=proposal,
+        outcome=outcome,
+        backup_path=backup_path,
+        error=error,
+        recovery=recovery,
+    )
     _append_entry(entry)
-    return entry_id
+    return entry["id"]
+
+
+def prepare(
+    *,
+    trigger: str,
+    reason: str,
+    session_id: str,
+    proposal: Dict[str, Any],
+    backup_path: str = "",
+    recovery: Optional[Dict[str, Any]] = None,
+) -> str:
+    return log(
+        trigger=trigger,
+        reason=reason,
+        session_id=session_id,
+        proposal=proposal,
+        outcome="prepared",
+        backup_path=backup_path,
+        recovery=recovery,
+    )
+
+
+def finalize(
+    entry_id: str,
+    outcome: str,
+    *,
+    error: str = "",
+    pending_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Append a new durable state for a logical record."""
+    entry = get_entry(entry_id)
+    if not entry:
+        raise KeyError(f"Prepared journal entry {entry_id} not found")
+    updated = dict(entry)
+    updated["outcome"] = outcome
+    updated["error"] = scrub_text(error)
+    if pending_id is not None:
+        updated["pending_id"] = scrub_text(str(pending_id))
+        recovery = dict(updated.get("recovery", {}))
+        recovery["pending_id"] = updated["pending_id"]
+        updated["recovery"] = recovery
+    updated["finalized_ts"] = time.time()
+    _append_entry(updated)
+    return sanitize(updated)
+
+
+def get_entry(entry_id: str) -> Optional[Dict[str, Any]]:
+    for entry in _load_entries():
+        if entry.get("id") == entry_id:
+            return entry
+    return None
+
+
+def is_reversible(entry: Optional[Dict[str, Any]]) -> bool:
+    if not entry or entry.get("outcome") not in ("applied", "prepared", "rollback_prepared"):
+        return False
+    proposal = entry.get("proposal", {})
+    kind = proposal.get("kind")
+    action = proposal.get("action")
+    if kind == "skill" and action == "create":
+        return bool(proposal.get("name") and proposal.get("content"))
+    if kind == "skill" and action == "patch":
+        return bool(entry.get("backup_path"))
+    if kind in ("memory", "user"):
+        return bool(entry.get("recovery"))
+    return False
+
+
+def count_today_applied() -> int:
+    """Count today's edits that are applied, reserved, or rollback-in-flight."""
+    today = datetime.now(timezone.utc).date()
+    consumed = {
+        "applied", "pending_approval", "prepared", "rollback_prepared", "pending_rollback"
+    }
+    count = 0
+    for entry in _load_entries():
+        if entry.get("outcome") not in consumed:
+            continue
+        try:
+            if datetime.fromtimestamp(entry.get("ts", 0), tz=timezone.utc).date() == today:
+                count += 1
+        except (OSError, OverflowError, ValueError, TypeError):
+            continue
+    return count
+
+
+def daily_limit_reached() -> bool:
+    return count_today_applied() >= max_edits_per_day()
 
 
 def proposal_hash(proposal: Dict[str, Any]) -> str:
-    """Stable id for "this exact edit", used to refuse repeats."""
     key = "|".join([
         str(proposal.get("kind", "")),
         str(proposal.get("name", "")),
@@ -135,163 +360,379 @@ def proposal_hash(proposal: Dict[str, Any]) -> str:
 
 
 def was_applied_recently(proposal: Dict[str, Any], within_days: int) -> bool:
-    """Has an identical proposal already been applied inside the window?
-
-    Stops a model that keeps re-proposing the same edit night after night.
-    """
     target = proposal_hash(proposal)
     cutoff = time.time() - (within_days * 86400)
+    consumed = {
+        "applied", "pending_approval", "prepared", "rollback_prepared", "pending_rollback"
+    }
     for entry in _load_entries():
-        if entry.get("outcome") not in ("applied", "pending_approval"):
+        if entry.get("outcome") not in consumed:
             continue
-        if (entry.get("ts") or 0) < cutoff:
-            continue
-        if proposal_hash(entry.get("proposal", {})) == target:
+        if (entry.get("ts") or 0) >= cutoff and proposal_hash(entry.get("proposal", {})) == target:
             return True
     return False
 
 
-def get_entry(entry_id: str) -> Optional[Dict[str, Any]]:
-    """Find a journal entry by id."""
-    for entry in _load_entries():
-        if entry.get("id") == entry_id:
-            return entry
-    return None
+# ── recovery metadata and target-state proof ───────────────────────────────
 
 
-# ── backups ─────────────────────────────────────────────────────────────────
+def _read_skill_state(name: str) -> tuple:
+    """Return (known, content); absence is known only from an explicit not-found."""
+    from tools.skills_tool import skill_view
+
+    try:
+        raw = skill_view(name)
+        result = raw if isinstance(raw, dict) else json.loads(raw)
+    except Exception as exc:
+        logger.warning("Cannot view skill '%s': %s", name, scrub_text(str(exc)))
+        return False, None
+    if not isinstance(result, dict):
+        return False, None
+    if not result.get("success"):
+        error = str(result.get("error", "")).lower()
+        return (True, None) if "not found" in error else (False, None)
+    direct = result.get("content")
+    if isinstance(direct, str):
+        return True, direct
+    skill_path = result.get("skill_dir", "") or result.get("path", "")
+    if not skill_path:
+        return False, None
+    path = Path(skill_path)
+    if path.is_dir():
+        path = path / "SKILL.md"
+    try:
+        return True, path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return True, None
+    except Exception:
+        return False, None
+
+
+def _skill_view_result(name: str) -> Optional[Dict[str, Any]]:
+    """Compatibility view used by callers that require an existing skill."""
+    known, content = _read_skill_state(name)
+    return {"success": True, "content": content} if known and content is not None else None
+
+
+def read_skill_content(name: str) -> Optional[str]:
+    known, content = _read_skill_state(name)
+    return content if known else None
 
 
 def backup_skill(name: str) -> Optional[Path]:
-    """Copy current SKILL.md for *name* into the backups dir.
-
-    Returns the backup path, or None if the skill doesn't exist.
-    """
-    from tools.skills_tool import skill_view as _skill_view
-
-    # skill_view returns a JSON string — parse it (dict input also handled).
+    content = read_skill_content(name)
+    if content is None:
+        return None
+    backup = backups_dir() / f"{int(time.time() * 1000)}_skill_{name}.bak"
     try:
-        raw = _skill_view(name)
-        if isinstance(raw, dict):
-            result = raw
-        else:
-            result = json.loads(raw)
-    except Exception:
-        logger.warning("Cannot view skill '%s' for backup", name)
+        _atomic_write_text(backup, content)
+    except Exception as exc:
+        logger.warning("Cannot back up skill '%s': %s", name, scrub_text(str(exc)))
         return None
-
-    if not isinstance(result, dict) or not result.get("success"):
-        return None
-
-    skill_dir = result.get("skill_dir", "") or result.get("path", "")
-    if not skill_dir:
-        return None
-    skill_dir = Path(skill_dir)
-
-    skill_md = skill_dir / "SKILL.md"
-    if not skill_md.is_file():
-        return None
-
-    ts = int(time.time() * 1000)
-    backup = backups_dir() / f"{ts}_skill_{name}.bak"
-    shutil.copy2(skill_md, backup)
-    logger.info("Backed up skill '%s' → %s", name, backup)
     return backup
 
 
-def backup_memory(target: str) -> Optional[str]:
-    """Extract current memory/user entry text as a backup string.
-
-    Returns the full current content, or "" when the store is empty (still a
-    valid backup — "memory was empty"), or None on read failure.
-    """
+def _memory_entries(target: str) -> Optional[List[str]]:
     from tools.memory_tool import MemoryStore
 
     try:
         store = MemoryStore()
         store.load_from_disk()
-        entries = store._entries_for(target)  # noqa: SLF001 — internal but safe
-        if not entries:
-            return ""
-        return "\n\n---\n\n".join(entries)
+        return list(store._entries_for(target))  # noqa: SLF001 - host has no public reader
     except Exception as exc:
-        logger.warning("Cannot back up memory: %s", exc)
+        logger.warning("Cannot read %s memory: %s", target, scrub_text(str(exc)))
         return None
 
 
-def rollback_skill(entry_id: str) -> Dict[str, Any]:
-    """Restore a skill from its backup. Returns a result dict."""
-    entry = get_entry(entry_id)
-    if not entry:
-        return {"success": False, "error": f"Journal entry {entry_id} not found"}
+def backup_memory(target: str) -> Optional[str]:
+    entries_value = _memory_entries(target)
+    if entries_value is None:
+        return None
+    return "\n\n---\n\n".join(entries_value)
 
-    backup_path = entry.get("backup_path", "")
-    if not backup_path or not Path(backup_path).is_file():
-        return {"success": False, "error": f"Backup file not found: {backup_path}"}
 
+def memory_recovery(target: str, content: str) -> Optional[Dict[str, Any]]:
+    entries_value = _memory_entries(target)
+    if entries_value is None:
+        return None
+    digest = hashlib.sha256(
+        json.dumps(entries_value, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return {
+        "type": "memory_append",
+        "target": target,
+        "index": len(entries_value),
+        "prefix_digest": digest,
+        "content": content,
+    }
+
+
+def _memory_prefix_matches(recovery: Dict[str, Any], values: List[str]) -> bool:
+    index = recovery.get("index")
+    if not isinstance(index, int) or index < 0 or index > len(values):
+        return False
+    digest = hashlib.sha256(
+        json.dumps(list(values[:index]), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return digest == recovery.get("prefix_digest")
+
+
+def target_matches_applied(entry: Dict[str, Any]) -> Optional[bool]:
+    """Prove the proposal target; return None when target state is unavailable."""
     proposal = entry.get("proposal", {})
-    name = proposal.get("name", "")
-    if not name:
-        return {"success": False, "error": "Journal entry has no skill name"}
+    kind = proposal.get("kind")
+    if kind == "skill":
+        known, content = _read_skill_state(str(proposal.get("name", "")))
+        return (content == str(proposal.get("content", ""))) if known else None
+    if kind in ("memory", "user"):
+        recovery = entry.get("recovery", {})
+        values = _memory_entries(str(recovery.get("target", "memory")))
+        if values is None:
+            return None
+        index = recovery.get("index")
+        return bool(
+            _memory_prefix_matches(recovery, values)
+            and isinstance(index, int)
+            and index < len(values)
+            and values[index] == recovery.get("content")
+        )
+    return False
 
-    backup_content = Path(backup_path).read_text(encoding="utf-8")
+
+def rollback_target_matches(entry: Dict[str, Any]) -> Optional[bool]:
+    """Prove rollback state; return None when target state is unavailable."""
+    proposal = entry.get("proposal", {})
+    kind = proposal.get("kind")
+    if kind == "skill":
+        name = str(proposal.get("name", ""))
+        if proposal.get("action") == "create":
+            known, content = _read_skill_state(name)
+            return (content is None) if known else None
+        backup_path = Path(str(entry.get("backup_path", "")))
+        if not backup_path.is_file():
+            return False
+        try:
+            expected = backup_path.read_text(encoding="utf-8")
+        except Exception:
+            return False
+        known, current = _read_skill_state(name)
+        return (current == expected) if known else None
+    if kind in ("memory", "user"):
+        recovery = entry.get("recovery", {})
+        values = _memory_entries(str(recovery.get("target", "memory")))
+        if values is None:
+            return None
+        index = recovery.get("index")
+        return bool(
+            _memory_prefix_matches(recovery, values)
+            and isinstance(index, int)
+            and (index >= len(values) or values[index] != recovery.get("content"))
+        )
+    return False
+
+
+def _pending_exists(subsystem: str, pending_id: str) -> Optional[bool]:
+    """Return True/False for known approval state, None when host lookup failed."""
+    if not pending_id:
+        return False
+    try:
+        from tools.write_approval import get_pending
+
+        raw = get_pending(subsystem, pending_id)
+        result = json.loads(raw) if isinstance(raw, str) else raw
+        return bool(result)
+    except Exception as exc:
+        logger.warning("Cannot query pending approval %s: %s", pending_id, scrub_text(str(exc)))
+        return None
+
+
+def reconcile() -> List[Dict[str, Any]]:
+    """Lazily reconcile forward and rollback approvals from host and target state."""
+    changed: List[Dict[str, Any]] = []
+    for snapshot in _load_entries():
+        entry_id = str(snapshot.get("id", ""))
+        outcome = snapshot.get("outcome")
+        proposal = snapshot.get("proposal", {})
+        subsystem = "skills" if proposal.get("kind") == "skill" else "memory"
+        try:
+            if outcome == "prepared":
+                applied_state = target_matches_applied(snapshot)
+                if applied_state is True:
+                    changed.append(finalize(entry_id, "applied"))
+                continue
+            if outcome == "pending_approval":
+                pending = _pending_exists(subsystem, str(snapshot.get("pending_id", "")))
+                if pending is not False:
+                    # While the host record still exists (or its state cannot be
+                    # queried), an already-matching target is not proof that this
+                    # particular request was approved.
+                    continue
+                applied_state = target_matches_applied(snapshot)
+                if applied_state is True:
+                    changed.append(finalize(entry_id, "applied"))
+                elif applied_state is False:
+                    changed.append(finalize(entry_id, "rejected", error="Approval rejected"))
+                continue
+            if outcome == "rollback_prepared":
+                if rollback_target_matches(snapshot) is True:
+                    changed.append(finalize(entry_id, "rolled_back"))
+                continue
+            if outcome == "pending_rollback":
+                pending = _pending_exists(subsystem, str(snapshot.get("pending_id", "")))
+                if pending is not False:
+                    continue
+                rollback_state = rollback_target_matches(snapshot)
+                if rollback_state is True:
+                    changed.append(finalize(entry_id, "rolled_back"))
+                elif rollback_state is False:
+                    changed.append(
+                        finalize(entry_id, "applied", error="Rollback approval rejected")
+                    )
+        except Exception as exc:
+            logger.warning("Cannot reconcile journal entry %s: %s", entry_id, scrub_text(str(exc)))
+    return changed
+
+
+# ── rollback side effects ──────────────────────────────────────────────────
+
+
+def _restore_applied(entry_id: str, error: str) -> None:
+    try:
+        finalize(entry_id, "applied", error=error)
+    except Exception as exc:
+        logger.warning("Cannot restore applied state for %s: %s", entry_id, scrub_text(str(exc)))
+
+
+def rollback_skill(entry_id: str) -> Dict[str, Any]:
+    entry = get_entry(entry_id)
+    if not is_reversible(entry):
+        return {"success": False, "error": f"Journal entry {entry_id} is not a reversible skill edit"}
+    proposal = entry.get("proposal", {})
+    if proposal.get("kind") != "skill":
+        return {"success": False, "error": "Journal entry is not a skill edit"}
+    name = str(proposal.get("name", ""))
+    action = proposal.get("action")
+
+    current = read_skill_content(name)
+    expected = str(proposal.get("content", ""))
+    if current != expected:
+        return {"success": False, "error": f"Rollback conflict: skill '{name}' changed after refine applied it"}
+    backup_content = ""
+    if action != "create":
+        backup_path = Path(str(entry.get("backup_path", "")))
+        if not backup_path.is_file():
+            return {"success": False, "error": f"Backup file not found: {backup_path}"}
+        backup_content = backup_path.read_text(encoding="utf-8")
+
+    try:
+        if entry.get("outcome") != "rollback_prepared":
+            entry = finalize(entry_id, "rollback_prepared")
+    except Exception as exc:
+        return {"success": False, "error": f"Cannot journal rollback intent: {scrub_text(str(exc))}"}
+
     try:
         from tools.skill_manager_tool import skill_manage
-        result_str = skill_manage(action="edit", name=name, content=backup_content)
-        result = json.loads(result_str)
-    except Exception as exc:
-        return {"success": False, "error": f"Rollback failed: {exc}"}
 
-    if result.get("success"):
-        log(
-            trigger=f"rollback:{entry_id}",
-            reason=f"Rollback of skill '{name}'",
-            session_id=entry.get("session_id", ""),
-            proposal=proposal,
-            outcome="rolled_back",
-            backup_path=backup_path,
+        raw = (
+            skill_manage(action="delete", name=name)
+            if action == "create"
+            else skill_manage(action="edit", name=name, content=backup_content)
         )
-    return result
+        result = raw if isinstance(raw, dict) else json.loads(raw)
+    except Exception as exc:
+        error = f"Rollback failed: {scrub_text(str(exc))}"
+        _restore_applied(entry_id, error)
+        return {"success": False, "error": error}
+
+    if not result.get("success"):
+        error = scrub_text(str(result.get("error", "Rollback host operation failed")))
+        _restore_applied(entry_id, error)
+        return sanitize(result)
+
+    if result.get("staged"):
+        pending_id = str(result.get("pending_id", ""))
+        if not pending_id:
+            error = "Rollback was staged without a pending_id"
+            _restore_applied(entry_id, error)
+            return {"success": False, "error": error}
+        try:
+            finalize(entry_id, "pending_rollback", pending_id=pending_id)
+        except Exception as exc:
+            return {
+                "success": False,
+                "staged": True,
+                "pending_id": pending_id,
+                "error": (
+                    "Rollback was reserved but pending state finalization failed; "
+                    f"recovery id: {entry_id}. {scrub_text(str(exc))}"
+                ),
+            }
+        result["message"] = "Rollback is pending approval; target has not been marked rolled back"
+        return sanitize(result)
+
+    current_entry = get_entry(entry_id) or entry
+    if not rollback_target_matches(current_entry):
+        error = "Rollback host reported success but the target state did not change"
+        _restore_applied(entry_id, error)
+        return {"success": False, "error": error}
+    try:
+        finalize(entry_id, "rolled_back")
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": (
+                "Rollback changed the target but journal finalization failed; "
+                f"recovery id: {entry_id}. {scrub_text(str(exc))}"
+            ),
+        }
+    result["message"] = result.get("message", f"Skill '{name}' rolled back")
+    return sanitize(result)
 
 
 def rollback_memory(entry_id: str) -> Dict[str, Any]:
-    """Restore memory from a backup string. Returns a result dict."""
     entry = get_entry(entry_id)
-    if not entry:
-        return {"success": False, "error": f"Journal entry {entry_id} not found"}
-
-    backup_path = entry.get("backup_path", "")
-    if not backup_path or not Path(backup_path).is_file():
-        return {"success": False, "error": f"Memory backup file not found: {backup_path}"}
-
-    proposal = entry.get("proposal", {})
-    # The proposal schema only knows "skill"|"memory"; "user" memory entries
-    # are not produced by refine, but keep the mapping defensive anyway.
-    kind = proposal.get("kind", "memory")
-    target = "user" if kind == "user" else "memory"
-    old_content = Path(backup_path).read_text(encoding="utf-8")
+    if not is_reversible(entry):
+        return {"success": False, "error": f"Journal entry {entry_id} is not a reversible memory edit"}
+    recovery = entry.get("recovery", {})
+    if recovery.get("type") != "memory_append":
+        return {"success": False, "error": "Memory recovery metadata is missing"}
+    target = str(recovery.get("target", "memory"))
+    expected = recovery.get("content", "")
+    index = recovery.get("index")
 
     try:
         from tools.memory_tool import MemoryStore
+
         store = MemoryStore()
         store.load_from_disk()
-
-        # Remove all current and restore from backup
-        entries = [e.strip() for e in old_content.split("\n\n---\n\n") if e.strip()]
-        # Just overwrite the target file — crude but works with MemoryStore
-        from tools.memory_tool import get_memory_dir as _get_mem_dir
-        mem_dir = _get_mem_dir()
-        filename = "USER.md" if target == "user" else "MEMORY.md"
-        Path(mem_dir, filename).write_text(old_content, encoding="utf-8")
-
-        log(
-            trigger=f"rollback:{entry_id}",
-            reason=f"Rollback of {target} memory",
-            session_id=entry.get("session_id", ""),
-            proposal=proposal,
-            outcome="rolled_back",
-            backup_path=backup_path,
-        )
-        return {"success": True, "message": f"Memory '{target}' restored"}
+        values = store._entries_for(target)  # noqa: SLF001
+        if not isinstance(index, int) or index < 0 or index >= len(values):
+            return {"success": False, "error": "Memory rollback conflict: appended entry position changed"}
+        if not _memory_prefix_matches(recovery, list(values)) or values[index] != expected:
+            return {"success": False, "error": "Memory rollback conflict: target entry or earlier memory changed"}
+        if entry.get("outcome") != "rollback_prepared":
+            entry = finalize(entry_id, "rollback_prepared")
+        del values[index]
+        store.save_to_disk(target)
     except Exception as exc:
-        return {"success": False, "error": f"Memory rollback failed: {exc}"}
+        latest = get_entry(entry_id) or entry
+        if not rollback_target_matches(latest):
+            _restore_applied(entry_id, scrub_text(str(exc)))
+        return {"success": False, "error": f"Memory rollback failed: {scrub_text(str(exc))}"}
+
+    latest = get_entry(entry_id) or entry
+    if not rollback_target_matches(latest):
+        error = "Memory rollback target state did not change"
+        _restore_applied(entry_id, error)
+        return {"success": False, "error": error}
+    try:
+        finalize(entry_id, "rolled_back")
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": (
+                "Memory rollback changed the target but journal finalization failed; "
+                f"recovery id: {entry_id}. {scrub_text(str(exc))}"
+            ),
+        }
+    return {"success": True, "message": f"Removed the exact appended {target} memory entry"}

--- a/ledger.py
+++ b/ledger.py
@@ -1,48 +1,37 @@
-"""Usefulness ledger for refine-created skills.
-
-Without this, refine is a write-only loop: it creates skills and never learns
-whether any of them helped. That matters because skills enter the context of
-later sessions — a useless skill is not neutral, it actively costs attention.
-
-The ledger records what refine created and answers two questions:
-  1. has this skill been used since it was written?
-  2. did the failure it was written for stop happening?
-
-Question 2 is only answerable because the proposal stores the fingerprint of the
-pattern it addressed (see ``patterns.py``).
-
-Deliberately dependency-free apart from ``config``: this module must not import
-``core``, which imports it back through the command handler.
-"""
+"""Timestamp-aware usefulness ledger for refine-created entries."""
 
 import json
 import logging
+import os
+import sqlite3
+import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
+    from . import journal
     from .config import journal_dir, state_db_path
 except ImportError:
-    from config import journal_dir, state_db_path  # noqa: F811 — standalone test
+    import journal  # type: ignore
+    from config import journal_dir, state_db_path  # noqa: F811
 
 logger = logging.getLogger(__name__)
-
 _STATS_FILE_NAME = "skill_stats.json"
 
 
 def stats_path() -> Path:
-    d = journal_dir()
-    d.mkdir(parents=True, exist_ok=True)
-    return d / _STATS_FILE_NAME
+    path = journal_dir()
+    path.mkdir(parents=True, exist_ok=True)
+    return path / _STATS_FILE_NAME
 
 
 def load_stats() -> Dict[str, Any]:
-    p = stats_path()
-    if not p.is_file():
+    path = stats_path()
+    if not path.is_file():
         return {}
     try:
-        data = json.loads(p.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
         return data if isinstance(data, dict) else {}
     except Exception as exc:
         logger.warning("Cannot read skill stats: %s", exc)
@@ -50,171 +39,230 @@ def load_stats() -> Dict[str, Any]:
 
 
 def _save_stats(stats: Dict[str, Any]) -> None:
+    path = stats_path()
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
     try:
-        stats_path().write_text(
-            json.dumps(stats, ensure_ascii=False, indent=2), encoding="utf-8"
-        )
-    except Exception as exc:
-        logger.error("Cannot write skill stats: %s", exc)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(stats, handle, ensure_ascii=False, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+    except Exception:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
 
 
-def record_edit(proposal: Dict[str, Any], journal_id: str) -> None:
-    """Register an applied edit so it can be audited later."""
+def record_edit(
+    proposal: Dict[str, Any],
+    journal_id: str,
+    *,
+    outcome: str = "applied",
+    pending_id: str = "",
+) -> None:
     name = str(proposal.get("name", "")).strip()
     if not name:
         return
-    stats = load_stats()
-    stats[name] = {
-        "created_ts": time.time(),
-        "journal_id": journal_id,
-        "kind": proposal.get("kind", "skill"),
-        "action": proposal.get("action", ""),
-        "pattern_fingerprint": proposal.get("pattern_fingerprint", ""),
-    }
-    _save_stats(stats)
+    with journal.mutation_lock():
+        stats = load_stats()
+        previous = stats.get(name, {})
+        created_ts = (
+            previous.get("created_ts", time.time())
+            if previous.get("journal_id") == journal_id
+            else time.time()
+        )
+        stats[name] = {
+            "created_ts": created_ts,
+            "journal_id": journal_id,
+            "kind": proposal.get("kind", "skill"),
+            "action": proposal.get("action", ""),
+            "pattern_fingerprint": proposal.get("pattern_fingerprint", ""),
+            "outcome": outcome,
+            "pending_id": pending_id,
+        }
+        _save_stats(stats)
 
 
-# ── usage counting ──────────────────────────────────────────────────────────
+def record_journal_state(entry: Dict[str, Any]) -> None:
+    """Mirror a reconciled journal state without resetting its creation time."""
+    proposal = entry.get("proposal", {})
+    record_edit(
+        proposal,
+        str(entry.get("id", "")),
+        outcome=str(entry.get("outcome", "")),
+        pending_id=str(entry.get("pending_id", "")),
+    )
 
 
-def count_uses(name: str, since_ts: float) -> Optional[int]:
-    """How many times a skill was used since *since_ts*.
+def earliest_created_ts() -> Optional[float]:
+    values = [
+        float(meta.get("created_ts", 0))
+        for meta in load_stats().values()
+        if isinstance(meta, dict)
+        and meta.get("created_ts")
+        and meta.get("outcome", "applied") == "applied"
+    ]
+    return min(values) if values else None
 
-    Prefers a real counter from the host. The state.db fallback is a
-    **heuristic**: it counts messages mentioning the skill name, which
-    over-counts discussion about the skill and under-counts silent loads.
-    Never present its output as exact — ``audit`` renders it with a "~".
 
-    Returns None when neither source is available.
-    """
-    # 1. Host API, if Hermes tracks this itself.
+# ── usage counting ─────────────────────────────────────────────────────────
+
+
+def _count_uses_with_scope(name: str, since_ts: float) -> Tuple[Optional[int], str]:
+    """Return (count, scope): since_exact, all_time, since_approx, unavailable."""
     try:
-        from tools import skill_usage as _su
-        for fn_name in ("get_usage_count", "usage_count", "get_use_count"):
-            fn = getattr(_su, fn_name, None)
-            if callable(fn):
+        from tools import skill_usage as usage
+
+        for function_name in ("get_usage_count", "usage_count", "get_use_count"):
+            function = getattr(usage, function_name, None)
+            if not callable(function):
+                continue
+            try:
+                return int(function(name, since_ts=since_ts)), "since_exact"
+            except TypeError:
                 try:
-                    return int(fn(name))
+                    return int(function(name)), "all_time"
                 except Exception:
                     continue
+            except Exception:
+                continue
     except ImportError:
         pass
 
-    # 2. Fallback: approximate from the trajectory store.
     try:
-        import sqlite3
-
-        db_path = state_db_path()
-        if not db_path.is_file():
-            return None
-        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        path = state_db_path()
+        if not path.is_file():
+            return None, "unavailable"
+        connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
         try:
-            row = con.execute(
-                "SELECT COUNT(*) FROM messages "
-                "WHERE active = 1 AND timestamp > ? AND content LIKE ?",
+            row = connection.execute(
+                "SELECT COUNT(*) FROM messages WHERE active = 1 "
+                "AND timestamp > ? AND content LIKE ?",
                 (since_ts, f"%{name}%"),
             ).fetchone()
-            return int(row[0]) if row else 0
+            return (int(row[0]) if row else 0), "since_approx"
         finally:
-            con.close()
+            connection.close()
     except Exception as exc:
         logger.debug("Usage fallback failed for %s: %s", name, exc)
-        return None
+        return None, "unavailable"
+
+
+def count_uses(name: str, since_ts: float) -> Optional[int]:
+    """Compatibility API returning the best available count."""
+    return _count_uses_with_scope(name, since_ts)[0]
 
 
 def unused_skills(min_age_days: int = 14) -> List[str]:
-    """Refine-created skills old enough to judge that were never used.
-
-    Fed back into the proposal prompt as negative examples — the cheapest
-    available defence against the model writing plausible-sounding trivia.
-    """
-    out: List[str] = []
     cutoff = time.time() - (min_age_days * 86400)
+    result: List[str] = []
     for name, meta in load_stats().items():
-        if meta.get("kind") != "skill":
+        if (
+            meta.get("kind") != "skill"
+            or meta.get("created_ts", 0) > cutoff
+            or meta.get("outcome", "applied") != "applied"
+        ):
             continue
-        created = meta.get("created_ts", 0)
-        if created > cutoff:
-            continue  # too young to judge
-        uses = count_uses(name, created)
+        uses, _scope = _count_uses_with_scope(name, meta.get("created_ts", 0))
         if uses == 0:
-            out.append(name)
-    return out[:10]
+            result.append(name)
+    return result[:10]
 
 
-# ── audit ───────────────────────────────────────────────────────────────────
+# ── audit ──────────────────────────────────────────────────────────────────
 
 
 def audit(current_patterns: Optional[List[Dict[str, Any]]] = None) -> List[Dict[str, Any]]:
-    """Build the audit table.
-
-    Args:
-        current_patterns: recent error patterns (from
-            ``core.collect_cross_session_patterns``). Used to answer "did the
-            failure this skill was written for come back?"
-    """
-    by_fp: Dict[str, Dict[str, Any]] = {
-        str(p.get("fingerprint", "")): p for p in (current_patterns or [])
+    by_fingerprint = {
+        str(item.get("fingerprint", "")): item for item in (current_patterns or [])
     }
     now = time.time()
     rows: List[Dict[str, Any]] = []
-
     for name, meta in sorted(load_stats().items()):
         created = meta.get("created_ts", 0) or now
         age_days = max(0, int((now - created) // 86400))
-        uses = count_uses(name, created)
-        fp = str(meta.get("pattern_fingerprint", "") or "")
-
+        outcome = meta.get("outcome", "applied")
+        fingerprint = str(meta.get("pattern_fingerprint", "") or "")
         recurred: Optional[bool] = None
-        if fp:
-            hit = by_fp.get(fp)
-            recurred = bool(hit and (hit.get("last_ts") or 0) > created)
 
-        if recurred is True:
-            verdict = "did not help"
-        elif uses == 0 and age_days >= 14:
-            verdict = "unused"
-        elif uses and uses > 0 and recurred is False:
-            verdict = "working"
+        if outcome == "pending_approval":
+            uses, usage_scope = None, "unavailable"
+            verdict = "pending approval"
+        elif outcome in ("rollback_prepared", "pending_rollback"):
+            uses, usage_scope = None, "unavailable"
+            verdict = "rollback pending"
+        elif outcome == "rolled_back":
+            uses, usage_scope = None, "unavailable"
+            verdict = "rolled back"
+        elif outcome == "rejected":
+            uses, usage_scope = None, "unavailable"
+            verdict = "rejected"
         else:
-            verdict = "too early" if age_days < 14 else "unclear"
+            uses, usage_scope = _count_uses_with_scope(name, created)
+            if fingerprint:
+                hit = by_fingerprint.get(fingerprint)
+                recurred = bool(hit and (hit.get("last_ts") or 0) > created)
+
+            if recurred is True:
+                verdict = "did not help"
+            elif uses == 0 and age_days >= 14:
+                verdict = "unused"
+            elif (
+                uses
+                and uses > 0
+                and recurred is False
+                and usage_scope in ("since_exact", "since_approx")
+            ):
+                verdict = "working"
+            else:
+                verdict = "too early" if age_days < 14 else "unclear"
 
         rows.append({
             "name": name,
             "kind": meta.get("kind", "skill"),
             "age_days": age_days,
             "uses": uses,
+            "usage_scope": usage_scope,
             "pattern_recurred": recurred,
             "verdict": verdict,
             "journal_id": meta.get("journal_id", ""),
+            "outcome": outcome,
         })
-
     return rows
 
 
 def format_audit(rows: List[Dict[str, Any]]) -> str:
-    """Render the audit table for the chat. Read-only — never deletes."""
     if not rows:
         return "No refine-created skills recorded yet."
-
     lines = [f"Refine-created entries ({len(rows)}):", ""]
-    lines.append(f"  {'name':<28} {'age':>5}  {'uses':>5}  {'recurred':>8}  verdict")
-    for r in rows:
-        uses = "?" if r["uses"] is None else f"~{r['uses']}"
-        rec = {True: "yes", False: "no", None: "—"}[r["pattern_recurred"]]
+    lines.append(f"  {'name':<28} {'age':>5}  {'uses':>7}  {'recurred':>8}  verdict")
+    for row in rows:
+        scope = row.get("usage_scope")
+        if row["uses"] is None:
+            uses = "?"
+        elif scope == "all_time":
+            uses = f"all:{row['uses']}"
+        elif scope == "since_approx":
+            uses = f"~{row['uses']}"
+        else:
+            uses = str(row["uses"])
+        recurred = {True: "yes", False: "no", None: "—"}[row["pattern_recurred"]]
         lines.append(
-            f"  {r['name'][:28]:<28} {str(r['age_days']) + 'd':>5}  {uses:>5}  {rec:>8}  {r['verdict']}"
+            f"  {row['name'][:28]:<28} {str(row['age_days']) + 'd':>5}  "
+            f"{uses:>7}  {recurred:>8}  {row['verdict']}"
         )
 
-    dead = [r for r in rows if r["verdict"] in ("unused", "did not help")]
-    if dead:
-        lines.append("")
-        lines.append("Candidates for removal:")
-        for r in dead:
-            lines.append(f"  {r['name']} — /refine rollback {r['journal_id']}")
-        lines.append("")
-        lines.append("Nothing was deleted. Run the command yourself if you agree.")
-
-    lines.append("")
-    lines.append("Note: use counts are approximate unless Hermes exposes a real counter.")
+    candidates = [row for row in rows if row["verdict"] in ("unused", "did not help")]
+    if candidates:
+        lines.extend(["", "Candidates for removal:"])
+        for row in candidates:
+            lines.append(f"  {row['name']} — /refine rollback {row['journal_id']}")
+        lines.extend(["", "Nothing was deleted. Run the command yourself if you agree."])
+    lines.extend([
+        "",
+        "Use labels: plain = timestamped host count, ~ = trajectory estimate, all: = host all-time aggregate.",
+        "All-time aggregates are not used to claim post-edit usage.",
+    ])
     return "\n".join(lines)

--- a/llm.py
+++ b/llm.py
@@ -1,151 +1,168 @@
-"""LLM proposal engine for the refine plugin.
-
-Wraps ``PluginLlm`` to call the user's active model with structured output
-and produce a validated refine proposal (or no_op).
-"""
+"""LLM proposal engine for the refine plugin."""
 
 import json
 import logging
 import re
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from agent.plugin_llm import (
     PluginLlm,
     PluginLlmInput,
-    PluginLlmStructuredResult,
     PluginLlmTextInput,
     PluginLlmTrustError,
 )
 
-logger = logging.getLogger(__name__)
+try:
+    from .sanitization import sanitize, scrub_text
+except ImportError:
+    from sanitization import sanitize, scrub_text  # type: ignore
 
-# ── schema ──────────────────────────────────────────────────────────────────
+logger = logging.getLogger(__name__)
+MAX_CONTENT_CHARS = 15000
 
 REFINE_PROPOSAL_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "properties": {
-        "action": {
-            "type": "string",
-            "enum": ["create", "patch", "no_op"],
-            "description": "The smallest useful action: create a new skill/memory, patch an existing one (tiny targeted fix), or no_op when nothing worthwhile found."
-        },
-        "kind": {
-            "type": "string",
-            "enum": ["skill", "memory"],
-            "description": "What to edit — a Hermes skill or a memory entry."
-        },
-        "name": {
-            "type": "string",
-            "description": "Target name. For create: new skill/memory name (lowercase, hyphens, max 64 chars for skills). For patch: existing name."
-        },
+        "action": {"type": "string", "enum": ["create", "patch", "no_op"]},
+        "kind": {"type": "string", "enum": ["skill", "memory"]},
+        "name": {"type": "string"},
         "content": {
             "type": "string",
-            "description": "For create: full SKILL.md content (YAML frontmatter + body). For patch: the new replacement text that fixes the issue. Empty for no_op."
+            "description": "Complete replacement SKILL.md for skill create/patch; appended entry for memory.",
         },
-        "category": {
-            "type": "string",
-            "description": "Optional category folder for skill creation (e.g. 'devops', 'research')."
-        },
-        "reason": {
-            "type": "string",
-            "description": "Why this edit, citing the specific failure/pattern from the trajectory."
-        },
-        "evidence": {
-            "type": "array",
-            "items": {"type": "string"},
-            "description": "Short verbatim quotes from the trajectory that justify this edit (2-4 items)."
-        },
+        "category": {"type": "string"},
+        "reason": {"type": "string"},
+        "evidence": {"type": "array", "items": {"type": "string"}},
         "pattern_fingerprint": {
             "type": "string",
-            "description": "The fp value of the listed repeated failure this edit addresses, if any. Enables later checking whether the edit actually stopped that failure."
+            "description": "Exact 12-character fp value from the repeated-failures list.",
         },
     },
     "required": ["action", "reason"],
 }
 
-REFINE_SYSTEM_PROMPT: str = (
-    "You are a self-improvement mechanic for an AI agent named Hermes. "
-    "Your job: read the agent's recent conversation trajectory and find "
-    "ONE specific, recurring problem or ONE useful reusable tactic. "
-    "Propose the SMALLEST possible edit — a create or patch of ONE skill "
-    "or ONE memory entry — that would prevent the problem or capture the tactic.\n\n"
+REFINE_SYSTEM_PROMPT = (
+    "You are a self-improvement mechanic for an AI agent named Hermes. Read the "
+    "trajectory and propose ONE evidence-grounded, minimal edit.\n\n"
     "RULES:\n"
-    "1. Only ONE edit per proposal. If you see multiple issues, pick the most impactful.\n"
-    "2. Only act when there is real evidence in the trajectory — do not guess.\n"
-    "3. Do not duplicate existing skills (existing skill names are listed above).\n"
-    "4. NEVER edit built-in or bundled skills. Only user/agent-created ones.\n"
-    "5. If patch: provide the NEW full content (the fix), not a diff.\n"
-    "6. Skills MUST have YAML frontmatter (name, description) + markdown body.\n"
-    "7. If nothing worthwhile — return action='no_op' with a brief reason.\n"
-    "8. Be MINIMAL. The smallest edit that fixes the problem. No scope creep.\n"
-    "9. ALWAYS use exactly these fields: action (create|patch|no_op), kind (skill|memory), "
-    "name, content, category (optional), reason, evidence. "
-    "NEVER invent new field names (e.g. 'type') and never combine action+kind "
-    "into one value like 'create_memory'.\n"
-    "Example: {\"action\": \"create\", \"kind\": \"skill\", \"name\": \"my-tip\", "
-    "\"content\": \"---\\nname: my-tip\\ndescription: ...\\n---\\n\\n# Body\", "
-    "\"reason\": \"why\", \"evidence\": [\"quote\"]}\n"
+    "1. Return only one create, patch, or no_op proposal.\n"
+    "2. Never guess or duplicate an existing skill.\n"
+    "3. Never edit built-in or bundled skills.\n"
+    "4. For every skill create or patch, content is the COMPLETE SKILL.md, not a diff. "
+    "Preserve all useful current content when patching.\n"
+    "5. Skills require YAML frontmatter with name and description, then a Markdown body.\n"
+    "6. Return no_op when no worthwhile edit exists.\n"
+    "7. Use exactly: action, kind, name, content, category, reason, evidence, and optional "
+    "pattern_fingerprint. Never combine action and kind.\n"
 )
-
-# ── engine ──────────────────────────────────────────────────────────────────
 
 
 def _salvage_parsed(result: Any) -> Any:
-    """Return ``result.parsed``, or salvage a JSON object from raw text when
-    the provider's json_mode parsing failed (parsed is None/str)."""
     parsed = getattr(result, "parsed", None)
     if isinstance(parsed, dict):
         return parsed
     text = getattr(result, "text", "") or ""
-    if isinstance(parsed, str):
-        text = parsed if not text else text
+    if isinstance(parsed, str) and not text:
+        text = parsed
     if text:
-        m = re.search(r"\{.*\}", text, re.S)
-        if m:
+        match = re.search(r"\{.*\}", text, re.S)
+        if match:
             try:
-                return json.loads(m.group(0))
+                return json.loads(match.group(0))
             except json.JSONDecodeError:
                 pass
     return parsed
 
 
-def _propose_structured(llm: PluginLlm, instructions: str, input_blocks: List[PluginLlmInput]) -> Any:
-    """Call complete_structured, preferring json_schema and falling back to
-    json_mode for providers that reject ``response_format.type=json_schema``
-    (e.g. opencode-go "This response_format type is unavailable now").
-
-    Returns ``result.parsed`` (dict) or raises on final failure.
-    """
+def _propose_structured(
+    llm: PluginLlm, instructions: str, input_blocks: List[PluginLlmInput]
+) -> Any:
+    """Invoke the model only with recursively sanitized text inputs."""
+    safe_blocks: List[PluginLlmInput] = []
+    for block in input_blocks:
+        text = getattr(block, "text", None)
+        if text is None:
+            raise TypeError("Refine accepts only text model inputs")
+        safe_blocks.append(PluginLlmTextInput(text=scrub_text(str(text))))
     common = dict(
-        instructions=instructions,
-        input=input_blocks,
+        instructions=scrub_text(str(instructions)),
+        input=safe_blocks,
         schema_name="refine_proposal",
         purpose="refine",
         temperature=0.0,
-        max_tokens=2048,
+        max_tokens=4096,
     )
+    system_prompt = scrub_text(REFINE_SYSTEM_PROMPT)
     try:
         result = llm.complete_structured(
-            system_prompt=REFINE_SYSTEM_PROMPT, json_schema=REFINE_PROPOSAL_SCHEMA, **common
+            system_prompt=system_prompt,
+            json_schema=sanitize(REFINE_PROPOSAL_SCHEMA),
+            **common,
         )
         return _salvage_parsed(result)
     except PluginLlmTrustError:
         raise
     except Exception as first_exc:
         logger.warning(
-            "complete_structured(json_schema) failed (%s) — falling back to json_mode", first_exc
+            "json_schema proposal failed (%s); falling back to json_mode",
+            scrub_text(str(first_exc)),
         )
-        try:
-            result = llm.complete_structured(
-                system_prompt=REFINE_SYSTEM_PROMPT
-                + "\n\nReply with a single JSON object ONLY. No markdown fences, no commentary.",
-                json_mode=True,
-                **common,
-            )
-            return _salvage_parsed(result)
-        except Exception as exc2:
-            logger.error("json_mode fallback also failed: %s", exc2)
-            raise
+        result = llm.complete_structured(
+            system_prompt=system_prompt
+            + "\nReply with one JSON object only, without Markdown fences.",
+            json_mode=True,
+            **common,
+        )
+        return _salvage_parsed(result)
+
+
+def _ensure_dict(parsed: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(parsed, dict):
+        return sanitize(parsed)
+    if isinstance(parsed, str):
+        match = re.search(r"\{.*\}", parsed, re.S)
+        if match:
+            try:
+                value = json.loads(match.group(0))
+                return sanitize(value) if isinstance(value, dict) else None
+            except json.JSONDecodeError:
+                pass
+    return None
+
+
+def _normalize_fields(parsed: Dict[str, Any]) -> Tuple[str, str, str, str, str]:
+    action = str(parsed.get("action", "no_op")).strip().lower()
+    for verb in ("create", "patch"):
+        for candidate_kind in ("skill", "memory"):
+            if action == f"{verb}_{candidate_kind}":
+                parsed.setdefault("kind", candidate_kind)
+                action = verb
+    kind = str(parsed.get("kind") or parsed.get("type") or "").strip().lower()
+    name = str(parsed.get("name", "")).strip()
+    content = str(parsed.get("content", ""))
+    category = str(parsed.get("category", "")).strip()
+    if kind not in ("skill", "memory") and action == "create":
+        kind = (
+            "skill"
+            if re.search(r"^---\s*$", content[:300], re.M) and "name:" in content[:300]
+            else "memory"
+        )
+    if kind == "skill":
+        name = _normalize_skill_name(name)
+    return action, kind, name, content, category
+
+
+def _default_skill_loader(name: str) -> Optional[str]:
+    try:
+        from .journal import read_skill_content
+    except ImportError:
+        from journal import read_skill_content  # type: ignore
+    return read_skill_content(name)
+
+
+def _valid_fingerprint(value: Any) -> str:
+    candidate = str(value or "").strip().lower()
+    return candidate if re.fullmatch(r"[0-9a-f]{12}", candidate) else ""
 
 
 def propose(
@@ -158,125 +175,83 @@ def propose(
     user_corrections: Optional[List[str]] = None,
     unused_skills: Optional[List[str]] = None,
     purpose: str = "refine",
+    run_context: str = "",
+    skill_content_loader: Optional[Callable[[str], Optional[str]]] = None,
 ) -> Dict[str, Any]:
-    """Call the LLM to propose a refine edit.
-
-    Args:
-        llm: A ``PluginLlm`` instance (can be ``ctx.llm`` or a fresh one).
-        evidence_text: Recent trajectory content (truncated by caller).
-        existing_skills: List of current skill names (to avoid duplicates).
-        existing_memories: List of current memory entry short summaries.
-        error_patterns: Aggregated repeated failures from ``patterns.extract_patterns``.
-        user_corrections: Short quotes where the user corrected the agent.
-        unused_skills: Refine-created skills that were never used — negative examples.
-        purpose: Audit purpose string.
-
-    Returns:
-        A dict with shape ``{"action": str, "kind": str, "name": str,
-        "content": str, "category": str, "reason": str, "evidence": list}``,
-        or ``{"action": "no_op", "reason": "..."}`` on failure.
-    """
-    # Build instructions with context. The aggregated signal goes FIRST: a model
-    # reasons far better over pre-counted patterns than over a transcript it has
-    # to count through itself.
+    """Propose one edit; skill patches are regenerated from safe full content."""
     try:
         from . import patterns as _patterns
     except ImportError:
-        import patterns as _patterns  # noqa: F811 — standalone test
+        import patterns as _patterns  # type: ignore
 
-    skills_list = "\n".join(f"  - {s}" for s in sorted(existing_skills)[:50]) or "  (none)"
-    mems_list = "\n".join(f"  - {m[:100]}" for m in existing_memories[:30]) or "  (none)"
-    patterns_block = _patterns.format_patterns(error_patterns or [])
-    corrections_block = (
-        "\n".join(f"  - {c[:200]}" for c in (user_corrections or [])[:5]) or "  (none)"
-    )
+    # Sanitize independently at this final model boundary even when callers have
+    # already sanitized their evidence. This keeps every prompt piece safe.
+    evidence_text = scrub_text(str(evidence_text))
+    existing_skills = [scrub_text(str(item)) for item in existing_skills]
+    existing_memories = [scrub_text(str(item)) for item in existing_memories]
+    error_patterns = sanitize(error_patterns or [])
+    user_corrections = [scrub_text(str(item)) for item in (user_corrections or [])]
+    unused_skills = [scrub_text(str(item)) for item in (unused_skills or [])]
+    run_context = scrub_text(str(run_context))
+    del purpose  # The host purpose is fixed to the plugin's trusted purpose.
 
+    skills_list = "\n".join(
+        f"  - {name}" for name in sorted(existing_skills)[:50]
+    ) or "  (none)"
+    mems_list = "\n".join(
+        f"  - {item[:100]}" for item in existing_memories[:30]
+    ) or "  (none)"
+    corrections = "\n".join(
+        f"  - {item[:200]}" for item in user_corrections[:5]
+    ) or "  (none)"
     unused_block = ""
     if unused_skills:
         unused_block = (
-            "\n=== YOUR PREVIOUS SKILLS THAT WERE NEVER USED ===\n"
-            + "\n".join(f"  - {s}" for s in unused_skills[:10])
-            + "\nDo not create skills of this shape again. A skill must change what "
-            "the agent DOES in a specific situation, not merely record a fact.\n"
+            "\n=== PREVIOUS UNUSED SKILLS ===\n"
+            + "\n".join(f"  - {name}" for name in unused_skills[:10])
+            + "\nDo not create more skills of this ineffective shape.\n"
         )
-
+    context_block = run_context.strip() or "(none)"
     instructions = (
-        "Below is aggregated evidence from the agent's recent sessions. "
-        "Ground your proposal in ONE of the listed repeated failures or user "
-        "corrections and propose the smallest edit that would prevent it.\n\n"
-        "=== REPEATED FAILURES (aggregated, strongest first) ===\n"
-        f"{patterns_block}\n\n"
+        "Ground the proposal in one repeated failure or explicit correction.\n\n"
+        "=== RUN REQUEST / PRIOR PASS CONTEXT ===\n"
+        f"{context_block}\n\n"
+        "=== REPEATED FAILURES ===\n"
+        f"{_patterns.format_patterns(error_patterns)}\n\n"
         "=== USER CORRECTIONS ===\n"
-        f"{corrections_block}\n\n"
-        "=== EXISTING SKILLS (do NOT duplicate) ===\n"
+        f"{corrections}\n\n"
+        "=== EXISTING SKILLS ===\n"
         f"{skills_list}\n\n"
         "=== EXISTING MEMORIES ===\n"
         f"{mems_list}\n"
         f"{unused_block}\n"
-        "=== RECENT TRAJECTORY (context only — the signal is above) ===\n"
+        "=== RECENT TRAJECTORY ===\n"
         f"{evidence_text[-8000:]}\n\n"
-        "Return a single JSON object with your proposal. When your proposal "
-        "addresses a listed failure, set pattern_fingerprint to its fp value."
+        "Return one JSON object. Copy the full 12-character fp exactly when applicable."
     )
-
-    # Short imperative instruction goes to ``instructions=``; the full context
-    # is passed as the input block. Passing the same text in both places would
-    # double the tokens on every call.
-    short_instructions = "Propose one minimal skill or memory edit."
-    input_blocks: List[PluginLlmInput] = [
-        PluginLlmTextInput(text=instructions),
-    ]
+    short = "Propose one minimal skill or memory edit."
 
     try:
-        parsed = _propose_structured(llm, short_instructions, input_blocks)
-
-        if not isinstance(parsed, dict):
-            # Provider returned non-object (e.g. raw text) — try to salvage JSON.
-            if isinstance(parsed, str):
-                import re as _re
-                m = _re.search(r"\{.*\}", parsed, _re.S)
-                if m:
-                    try:
-                        parsed = json.loads(m.group(0))
-                    except json.JSONDecodeError:
-                        pass
-        if not isinstance(parsed, dict):
-            logger.warning("LLM returned non-dict parsed: %s", type(parsed))
+        parsed = _ensure_dict(
+            _propose_structured(llm, short, [PluginLlmTextInput(text=instructions)])
+        )
+        if parsed is None:
             return {"action": "no_op", "reason": "LLM returned non-object output"}
 
-        # Retry once if the model proposed create without content (a common
-        # json_mode miss) — nudge it to include the content field.
-        if (
-            str(parsed.get("action", "")).strip() == "create"
-            and not str(parsed.get("content") or "").strip()
-        ):
-            retry_instructions = (
-                instructions
-                + "\n\nIMPORTANT: action='create' REQUIRES a non-empty 'content' "
-                + "field containing the full SKILL.md or memory text. Include it."
+        action, kind, name, content, category = _normalize_fields(parsed)
+        if action == "create" and not content:
+            retry_text = instructions + "\n\nA create requires non-empty complete content. Return it now."
+            retry = _ensure_dict(
+                _propose_structured(llm, short, [PluginLlmTextInput(text=retry_text)])
             )
-            retry = _propose_structured(
-                llm, short_instructions, [PluginLlmTextInput(text=retry_instructions)]
-            )
-            if isinstance(retry, dict) and str(retry.get("content") or "").strip():
+            if retry is not None:
                 parsed = retry
-
-        # Validate + normalize
-        action = str(parsed.get("action", "no_op")).strip().lower()
-
-        # Normalize "<verb>_<kind>" style (create_memory, patch_skill, ...)
-        # that some models emit in json_mode instead of separate fields.
-        for _verb in ("create", "patch"):
-            for _kind in ("skill", "memory"):
-                if action == f"{_verb}_{_kind}":
-                    parsed.setdefault("kind", _kind)
-                    action = _verb
+                action, kind, name, content, category = _normalize_fields(parsed)
 
         if action not in ("create", "patch", "no_op"):
             return {"action": "no_op", "reason": f"Invalid action: {action}"}
-
         if action == "no_op":
-            return {
+            return sanitize({
                 "action": "no_op",
                 "kind": "",
                 "name": "",
@@ -284,65 +259,97 @@ def propose(
                 "category": "",
                 "reason": str(parsed.get("reason", "No actionable improvement found")),
                 "evidence": _ensure_list(parsed.get("evidence")),
-            }
-
-        kind = str(parsed.get("kind") or parsed.get("type") or "").strip()
-        name = str(parsed.get("name", "")).strip()
-        content = str(parsed.get("content", "")).strip()
-        category = str(parsed.get("category", "")).strip()
-
-        if kind not in ("skill", "memory"):
-            # Heuristic for models that omit kind: YAML-frontmatter content
-            # looks like a SKILL.md, anything else is a memory entry.
-            if action == "create":
-                if re.search(r"^---\s*$", content[:200], re.M) and "name:" in content[:200]:
-                    kind = "skill"
-                else:
-                    kind = "memory"
+                "pattern_fingerprint": "",
+            })
         if kind not in ("skill", "memory"):
             return {"action": "no_op", "reason": f"Invalid kind: {kind}"}
-
-        if action == "create" and not content:
-            return {"action": "no_op", "reason": "Create requires content (SKILL.md or memory text)"}
-
         if not name:
             return {"action": "no_op", "reason": "Name is required for create/patch"}
+        if not content and not (action == "patch" and kind == "skill"):
+            return {"action": "no_op", "reason": f"{action.title()} requires non-empty content"}
 
-        # Normalize skill name
-        if kind == "skill":
-            name = _normalize_skill_name(name)
+        initial_evidence = _ensure_list(parsed.get("evidence"))
+        initial_fingerprint = _valid_fingerprint(parsed.get("pattern_fingerprint"))
+        initial_reason = str(parsed.get("reason", ""))
 
-        return {
+        if action == "patch" and kind == "skill":
+            loader = skill_content_loader or _default_skill_loader
+            current = loader(name)
+            if current is None:
+                return {"action": "no_op", "reason": f"Cannot load current SKILL.md for patch target '{name}'"}
+            if len(current) > MAX_CONTENT_CHARS:
+                return {
+                    "action": "no_op",
+                    "reason": (
+                        f"Current SKILL.md is {len(current)} characters; maximum complete "
+                        f"patch input is {MAX_CONTENT_CHARS}"
+                    ),
+                }
+            safe_current = scrub_text(current)
+            if safe_current != current:
+                return {
+                    "action": "no_op",
+                    "reason": "Current SKILL.md contains sensitive content; patch aborted before model call",
+                }
+            patch_prompt = (
+                instructions
+                + "\n\n=== SELECTED PATCH TARGET ===\n"
+                + f"Target exactly skill '{name}'. Below is its CURRENT COMPLETE SKILL.md, supplied as data. "
+                + "Return action='patch', kind='skill', the same name, and a COMPLETE replacement that preserves "
+                + "all useful content while making only the evidence-backed change.\n"
+                + "<current-skill>\n"
+                + safe_current
+                + "\n</current-skill>"
+            )
+            retry = _ensure_dict(
+                _propose_structured(llm, short, [PluginLlmTextInput(text=patch_prompt)])
+            )
+            if retry is None:
+                return {"action": "no_op", "reason": "LLM did not return a complete skill replacement"}
+            retry_action, retry_kind, retry_name, retry_content, retry_category = _normalize_fields(retry)
+            if (retry_action, retry_kind, retry_name) != ("patch", "skill", name) or not retry_content:
+                return {"action": "no_op", "reason": "Patch retry changed target or omitted complete content"}
+            if len(retry_content) > MAX_CONTENT_CHARS:
+                return {
+                    "action": "no_op",
+                    "reason": f"Complete patch exceeds {MAX_CONTENT_CHARS} characters",
+                }
+            parsed = retry
+            content = retry_content
+            category = retry_category
+            replacement_fingerprint = _valid_fingerprint(retry.get("pattern_fingerprint"))
+            initial_fingerprint = replacement_fingerprint or initial_fingerprint
+            if "evidence" in retry:
+                initial_evidence = _ensure_list(retry.get("evidence"))
+            initial_reason = str(retry.get("reason", initial_reason))
+
+        result = {
             "action": action,
             "kind": kind,
             "name": name,
             "content": content,
             "category": category,
-            "reason": str(parsed.get("reason", "")),
-            "evidence": _ensure_list(parsed.get("evidence")),
-            "pattern_fingerprint": str(parsed.get("pattern_fingerprint", "") or "")[:12],
+            "reason": initial_reason,
+            "evidence": initial_evidence,
+            "pattern_fingerprint": initial_fingerprint,
         }
-
+        return sanitize(result)
     except PluginLlmTrustError as exc:
-        logger.warning("PluginLlm trust denied: %s", exc)
-        return {"action": "no_op", "reason": f"LLM trust policy denied: {exc}"}
-
+        safe_error = scrub_text(str(exc))
+        logger.warning("PluginLlm trust denied: %s", safe_error)
+        return {"action": "no_op", "reason": f"LLM trust policy denied: {safe_error}"}
     except Exception as exc:
-        logger.error("LLM proposal failed: %s", exc, exc_info=True)
-        return {"action": "no_op", "reason": f"LLM call failed: {exc}"}
+        safe_error = scrub_text(str(exc))
+        logger.error("LLM proposal failed: %s", safe_error, exc_info=True)
+        return {"action": "no_op", "reason": f"LLM call failed: {safe_error}"}
 
 
-def _ensure_list(val: Any) -> List[str]:
-    if isinstance(val, list):
-        return [str(v) for v in val[:10]]
-    return []
+def _ensure_list(value: Any) -> List[str]:
+    return [scrub_text(str(item)) for item in value[:10]] if isinstance(value, list) else []
 
 
 def _normalize_skill_name(name: str) -> str:
-    """Normalize to lowercase-hyphens, max 64 chars."""
-    import re
-    name = name.lower().strip()
+    name = scrub_text(name).lower().strip()
     name = re.sub(r"[^a-z0-9_-]+", "-", name)
     name = re.sub(r"-{2,}", "-", name)
-    name = name.strip("-")
-    return name[:64]
+    return name.strip("-")[:64]

--- a/patterns.py
+++ b/patterns.py
@@ -13,7 +13,12 @@ without a Hermes host.
 
 import hashlib
 import re
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional
+
+try:
+    from .sanitization import scrub_text
+except ImportError:
+    from sanitization import scrub_text  # type: ignore
 
 # Order matters: timestamps and paths must be replaced before bare integers,
 # otherwise the digit rule eats the parts that make them recognizable.
@@ -56,7 +61,7 @@ def _strip_quotes(text: str) -> str:
     Tokenizing matters: a naive ``"[^"]*"`` regex matches from the closing quote
     of one JSON key to the opening quote of the next, mangling the boundary.
     """
-    return _DOUBLE_QUOTED.sub(lambda m: m.group(0)[1:-1], text)
+    return _DOUBLE_QUOTED.sub(lambda match: match.group(0)[1:-1], text)
 
 
 def normalize_error(content: str) -> str:
@@ -73,14 +78,14 @@ def normalize_error(content: str) -> str:
     # For a traceback, the only stable part is the final exception line; the
     # frames above it are noise that changes with every refactor.
     if any(marker in text for marker in _TRACEBACK_MARKERS):
-        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
         if lines:
             text = lines[-1]
 
     text = _strip_quotes(text)
 
-    for pattern, repl in _NORMALIZERS:
-        text = pattern.sub(repl, text)
+    for pattern, replacement in _NORMALIZERS:
+        text = pattern.sub(replacement, text)
 
     text = re.sub(r"\s+", " ", text).strip().lower()
     return text[:200]
@@ -92,16 +97,13 @@ def fingerprint(tool_name: str, content: str) -> str:
     return hashlib.sha1(key.encode("utf-8", "replace")).hexdigest()[:12]
 
 
-def extract_patterns(items: Iterable[Dict[str, Any]], limit: int = 10) -> List[Dict[str, Any]]:
+def extract_patterns(
+    items: Iterable[Dict[str, Any]], limit: Optional[int] = 10
+) -> List[Dict[str, Any]]:
     """Group error occurrences into counted patterns.
 
-    Args:
-        items: dicts with ``tool``, ``content``, and optionally ``session_id``
-            and ``ts``. Content is expected to be already scrubbed.
-        limit: max patterns returned.
-
-    Returns:
-        Patterns sorted by (distinct sessions, total count) descending.
+    ``limit=None`` returns every pattern and is used by the post-edit audit;
+    interactive refine runs retain the small default prompt budget.
     """
     grouped: Dict[str, Dict[str, Any]] = {}
 
@@ -141,8 +143,8 @@ def extract_patterns(items: Iterable[Dict[str, Any]], limit: int = 10) -> List[D
         entry["sessions_seen"] = max(1, len(sessions))
         out.append(entry)
 
-    out.sort(key=lambda e: (e["sessions_seen"], e["count"]), reverse=True)
-    return out[:limit]
+    out.sort(key=lambda entry: (entry["sessions_seen"], entry["count"]), reverse=True)
+    return out if limit is None else out[:limit]
 
 
 def merge_patterns(*groups: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -170,7 +172,7 @@ def merge_patterns(*groups: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             )
 
     out = list(merged.values())
-    out.sort(key=lambda e: (e.get("sessions_seen", 1), e.get("count", 0)), reverse=True)
+    out.sort(key=lambda entry: (entry.get("sessions_seen", 1), entry.get("count", 0)), reverse=True)
     return out
 
 
@@ -179,12 +181,7 @@ def has_signal(
     corrections: List[Any],
     min_count: int = 2,
 ) -> bool:
-    """Is there anything worth spending a model call on?
-
-    True when a failure actually repeated (within a session or across sessions),
-    or when the user explicitly corrected the agent. Everything else is a single
-    one-off error, which teaches nothing generalizable.
-    """
+    """Return whether a repeated failure or explicit correction is present."""
     if corrections:
         return True
     for entry in patterns or []:
@@ -204,8 +201,8 @@ def format_patterns(patterns: List[Dict[str, Any]], limit: int = 8) -> str:
                 count=entry.get("count", 1),
                 sessions=entry.get("sessions_seen", 1),
                 tool=entry.get("tool") or "?",
-                sample=(entry.get("sample") or "").replace("\n", " ")[:160],
-                fp=entry.get("fingerprint", "")[:8],
+                sample=scrub_text(str(entry.get("sample") or "")).replace("\n", " ")[:160],
+                fp=scrub_text(str(entry.get("fingerprint", ""))),
             )
         )
     return "\n".join(lines)

--- a/sanitization.py
+++ b/sanitization.py
@@ -1,0 +1,95 @@
+"""Recursive credential redaction shared by evidence and persistence paths."""
+
+import re
+from typing import Any
+
+_REDACTED = "[REDACTED]"
+
+_FIXED_PATTERNS = [
+    re.compile(r"github_pat_[A-Za-z0-9_]+"),
+    re.compile(r"gh[po]_[A-Za-z0-9]{20,}"),
+    re.compile(r"sk-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"AIza[A-Za-z0-9_-]{20,}"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"ntn_[A-Za-z0-9]{20,}"),
+    re.compile(r"hf_[A-Za-z0-9]{20,}"),
+    re.compile(r"glpat-[A-Za-z0-9_-]{15,}"),
+    re.compile(r"SG\.[A-Za-z0-9_-]{15,}\.[A-Za-z0-9_-]{15,}"),
+    re.compile(r"dop_v1_[a-f0-9]{60,}"),
+    re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"),
+    re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+        re.S,
+    ),
+]
+
+# Match exact generic labels and common compounds such as client_secret,
+# access-token, refreshToken, and github_api_key.
+_SECRET_KEY = (
+    r"(?:authorization|bearer|"
+    r"[A-Za-z0-9_-]*(?:api[_-]?key|password|passwd|secret|token)[A-Za-z0-9_-]*)"
+)
+_QUOTED_SECRET = re.compile(
+    rf"(?i)(?P<prefix>[\"']?{_SECRET_KEY}[\"']?\s*[:=]\s*)"
+    r"(?P<quote>[\"'])(?P<value>(?:\\.|(?!\2).)+)(?P=quote)"
+)
+_UNQUOTED_SECRET = re.compile(
+    rf"(?i)(?P<prefix>\b{_SECRET_KEY}\b\s*[:=]\s*)"
+    r"(?P<value>[^\s,;\}\]]{6,})"
+)
+_BEARER = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9_.+/=-]{8,}")
+_URL_CREDENTIALS = re.compile(r"(https?://)[^/\s:@]+:[^/\s:@]+@")
+_ENV_SECRET = re.compile(
+    r"(?m)^(\s*[A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD)[A-Z0-9_]*\s*=\s*)\S+$"
+)
+_NON_SECRETS = {"true", "false", "null", "none", "enabled", "disabled"}
+
+
+def _replace_quoted(match: re.Match) -> str:
+    return (
+        f"{match.group('prefix')}{match.group('quote')}"
+        f"{_REDACTED}{match.group('quote')}"
+    )
+
+
+def _replace_unquoted(match: re.Match) -> str:
+    value = match.group("value")
+    if value.lower() in _NON_SECRETS or value.isdigit():
+        return match.group(0)
+    return f"{match.group('prefix')}{_REDACTED}"
+
+
+def _scrub_chunk(text: str) -> str:
+    for pattern in _FIXED_PATTERNS:
+        text = pattern.sub(_REDACTED, text)
+    text = _URL_CREDENTIALS.sub(r"\1[REDACTED]@", text)
+    text = _ENV_SECRET.sub(r"\1[REDACTED]", text)
+    text = _BEARER.sub("Bearer [REDACTED]", text)
+    text = _QUOTED_SECRET.sub(_replace_quoted, text)
+    return _UNQUOTED_SECRET.sub(_replace_unquoted, text)
+
+
+def scrub_text(text: str) -> str:
+    """Redact credentials while preserving existing redaction markers exactly."""
+    if not text:
+        return text
+    # Sanitized proposals are deliberately scrubbed at several trust boundaries.
+    # Splitting around the marker prevents a later generic ``token=...`` match
+    # from consuming part of it and makes sanitation strictly idempotent.
+    return _REDACTED.join(_scrub_chunk(chunk) for chunk in text.split(_REDACTED))
+
+
+def sanitize(value: Any) -> Any:
+    """Recursively scrub every string in a journal- or model-bound value."""
+    if isinstance(value, str):
+        return scrub_text(value)
+    if isinstance(value, dict):
+        return {scrub_text(str(key)): sanitize(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [sanitize(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize(item) for item in value)
+    if isinstance(value, set):
+        return {sanitize(item) for item in value}
+    return value

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,826 +1,991 @@
-"""Tests for the refine plugin.
+"""Hermetic stdlib regression suite for Refine Cycle.
 
-Run:  python3 -m tests.run_tests   (from ~/.hermes/plugins/refine/)
-or:   python3 ~/.hermes/plugins/refine/tests/run_tests.py
-
-These tests use the real state.db (read-only), real skill_manage (creates a
-test skill, then deletes it), real MemoryStore, and a mock LLM.
-
-They must NOT break the running agent.
+Run from the repository root with ``python -m tests.run_tests``. The suite
+installs a fake Hermes host before importing the plugin and stores every file
+under a fresh TemporaryDirectory; it never reads or writes live Hermes state.
 """
 
+import importlib.util
+import inspect
 import json
+import shutil
+import sqlite3
 import sys
 import tempfile
+import threading
+import time
+import types
+import unittest
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from unittest.mock import patch
 
-# Add plugin root and pipx site-packages to path
-_HERE = Path(__file__).resolve().parent
-_PLUGIN_DIR = _HERE.parent
-if str(_PLUGIN_DIR) not in sys.path:
-    sys.path.insert(0, str(_PLUGIN_DIR))
-
-# pipx site-packages (where agent/, tools/, hermes_cli/ live)
-_PIPX_SP = Path.home() / ".local" / "share" / "pipx" / "venvs" / "hermes-agent" / "lib" / "python3.12" / "site-packages"
-if _PIPX_SP.is_dir() and str(_PIPX_SP) not in sys.path:
-    sys.path.insert(0, str(_PIPX_SP))
-
-# ── mock LLM ────────────────────────────────────────────────────────────────
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT)) if str(ROOT) not in sys.path else None
 
 
-class MockLlm:
-    """Fake PluginLlm that returns a fixed proposal."""
+# Minimal agent.plugin_llm contract installed before plugin imports.
+agent_module = types.ModuleType("agent")
+plugin_module = types.ModuleType("agent.plugin_llm")
 
-    def __init__(self, proposal: Optional[Dict[str, Any]] = None):
-        self._proposal = proposal
-        self.calls: List[Dict[str, Any]] = []
 
-    def complete_structured(self, **kwargs) -> Any:
-        self.calls.append(kwargs)
-        return MockResult(self._proposal)
+class PluginLlmTrustError(Exception):
+    pass
+
+
+class PluginLlmInput:
+    pass
+
+
+class PluginLlmTextInput(PluginLlmInput):
+    def __init__(self, text):
+        self.text = text
 
 
 class MockResult:
-    def __init__(self, parsed: Any):
+    def __init__(self, parsed):
         self.parsed = parsed
+        self.text = ""
 
 
-class FailingLlm(MockLlm):
-    """Fake that always raises."""
+class PluginLlm:
+    def __init__(self, plugin_id=""):
+        self.plugin_id = plugin_id
 
-    def complete_structured(self, **kwargs) -> Any:
+    def complete_structured(self, **kwargs):
+        return MockResult({"action": "no_op", "reason": "stub"})
+
+
+class MockLlm:
+    def __init__(self, *responses):
+        self.responses = list(responses) or [{"action": "no_op", "reason": "none"}]
+        self.calls = []
+
+    def complete_structured(self, **kwargs):
         self.calls.append(kwargs)
-        raise RuntimeError("Simulated LLM failure")
+        response = self.responses.pop(0) if len(self.responses) > 1 else self.responses[0]
+        if isinstance(response, Exception):
+            raise response
+        return MockResult(response)
 
 
-# ── test helpers ────────────────────────────────────────────────────────────
+plugin_module.PluginLlm = PluginLlm
+plugin_module.PluginLlmInput = PluginLlmInput
+plugin_module.PluginLlmTextInput = PluginLlmTextInput
+plugin_module.PluginLlmStructuredResult = object
+plugin_module.PluginLlmTrustError = PluginLlmTrustError
+agent_module.plugin_llm = plugin_module
+sys.modules.update({"agent": agent_module, "agent.plugin_llm": plugin_module})
 
 
-def ok(label: str) -> None:
-    print(f"  ✅ {label}")
+class FakeHost:
+    root = Path(".")
+    skills = {}
+    agent_created = set()
+    actions = []
+    stage_writes = False
+    fail_next = ""
+    memory_entries = []
+    user_entries = []
+    usage_counts = {}
+    config = {}
+    pending = {}
+    pending_counter = 0
 
+    @classmethod
+    def reset(cls, root):
+        cls.root = root
+        cls.skills = {}
+        cls.agent_created = set()
+        cls.actions = []
+        cls.stage_writes = False
+        cls.fail_next = ""
+        cls.memory_entries = []
+        cls.user_entries = []
+        cls.usage_counts = {}
+        cls.pending = {}
+        cls.pending_counter = 0
+        cls.config = {"plugins": {"entries": {"refine": {
+            "journal_dir": str(root / "journal"),
+            "max_edits_per_day": 20,
+            "max_edits_per_run": 1,
+            "min_signal_required": False,
+            "only_agent_created": True,
+            "cross_session_enabled": True,
+        }}}}
+        cls.make_db()
 
-def fail(label: str, msg: str) -> None:
-    print(f"  ❌ {label}: {msg}")
-    global _FAILURES
-    _FAILURES += 1
+    @classmethod
+    def entry_config(cls):
+        return cls.config["plugins"]["entries"]["refine"]
 
+    @classmethod
+    def make_db(cls, messages=None):
+        path = cls.root / "state.db"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.unlink(missing_ok=True)
+        now = time.time()
+        rows = messages or [
+            ("session", "user", "No, that is not right; use the other endpoint instead", "", now - 4, 1),
+            ("session", "tool", "ERROR: request failed for /item/100", "http", now - 3, 1),
+            ("session", "assistant", "Retrying", "", now - 2, 1),
+            ("session", "tool", "ERROR: request failed for /item/200", "http", now - 1, 1),
+        ]
+        connection = sqlite3.connect(path)
+        connection.execute("CREATE TABLE sessions (id TEXT, started_at REAL)")
+        connection.execute(
+            "CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, "
+            "tool_name TEXT, timestamp REAL, active INTEGER)"
+        )
+        connection.execute("INSERT INTO sessions VALUES ('session', ?)", (now - 10,))
+        connection.executemany("INSERT INTO messages VALUES (?,?,?,?,?,?)", rows)
+        connection.commit()
+        connection.close()
 
-_FAILURES = 0
+    @classmethod
+    def next_pending_id(cls, name):
+        cls.pending_counter += 1
+        return f"pending-{name}-{cls.pending_counter}"
 
-
-def assert_eq(actual, expected, label: str) -> None:
-    if actual == expected:
-        ok(label)
-    else:
-        fail(label, f"expected {expected!r}, got {actual!r}")
-
-
-def assert_true(cond: bool, label: str) -> None:
-    ok(label) if cond else fail(label, "expected True")
-
-
-def has_trajectory(min_messages: int = 3) -> bool:
-    """Is there real session data to test against?
-
-    A fresh Hermes install has no state.db. Tests that need a real trajectory
-    should skip rather than fail — an empty machine is not a defect, and a
-    suite that reports red for environment reasons trains people to ignore red.
-    """
-    try:
-        from core import collect_evidence
-        return len(collect_evidence().get("messages", [])) >= min_messages
-    except Exception:
-        return False
-
-
-def assert_in(substring: str, text: str, label: str) -> None:
-    (ok(label) if substring in text
-     else fail(label, f"'{substring[:40]}' not found"))
-
-
-# ── test functions ──────────────────────────────────────────────────────────
-
-
-def test_collect_evidence():
-    """collect_evidence() reads from real state.db."""
-    print("\nTest: collect_evidence")
-    from core import collect_evidence
-
-    result = collect_evidence()
-    assert isinstance(result, dict), "should return a dict"
-    assert "messages" in result, "should have messages key"
-    assert "error_count" in result, "should have error_count"
-    assert "session_id" in result, "should have session_id"
-    ok(f"Got {len(result['messages'])} messages, {result['error_count']} errors")
-    print(f"    session_id={result.get('session_id','(none)')[:20]}...")
-
-
-def test_llm_proposal_valid():
-    """Proposal with valid create-skill response."""
-    print("\nTest: llm.propose (valid create skill)")
-    from llm import propose
-
-    mock = MockLlm({
-        "action": "create",
-        "kind": "skill",
-        "name": "Test Skill Name",
-        "content": "---\nname: test-skill-name\ndescription: test\n---\n\n# Test\n",
-        "reason": "User keeps asking about caching",
-        "evidence": ["user: how to cache", "assistant: I don't know"],
-    })
-    result = propose(mock, "test evidence", ["existing-skill"], [], purpose="test")
-    assert_eq(result["action"], "create", "action should be create")
-    assert_eq(result["name"], "test-skill-name", "name should be normalized")
-    assert result["content"], "content should not be empty"
-    assert result["reason"], "reason should be set"
-
-
-def test_llm_proposal_noop():
-    """LLM returns no_op."""
-    print("\nTest: llm.propose (no_op)")
-    from llm import propose
-
-    mock = MockLlm({
-        "action": "no_op",
-        "reason": "Nothing to improve",
-    })
-    result = propose(mock, "test", [], [], purpose="test")
-    assert_eq(result["action"], "no_op", "should be no_op")
-
-
-def test_llm_proposal_invalid():
-    """LLM returns garbage — should fallback to no_op."""
-    print("\nTest: llm.propose (garbage)")
-    from llm import propose
-
-    mock = MockLlm({"action": "delete_all"})
-    result = propose(mock, "test", [], [], purpose="test")
-    assert_eq(result["action"], "no_op", "invalid action → no_op")
-
-
-def test_llm_trust_error():
-    """LLM trust error → no_op."""
-    print("\nTest: llm.propose (trust error)")
-    from llm import propose
-
-    result = propose(FailingLlm(), "test", [], [], purpose="test")
-    assert_eq(result["action"], "no_op", "failure → no_op")
-
-
-def test_journal_roundtrip():
-    """Journal write + read + count."""
-    print("\nTest: journal roundtrip")
-    from config import max_edits_per_day
-    import journal as j
-
-    proposal = {"action": "create", "kind": "skill", "name": "x"}
-    entry_id = j.log(
-        trigger="test",
-        reason="testing",
-        session_id="test-session",
-        proposal=proposal,
-        outcome="applied",
-    )
-    assert entry_id, "should return entry id"
-
-    entry = j.get_entry(entry_id)
-    assert entry, "should find entry"
-    assert_eq(entry.get("outcome"), "applied", "outcome should be applied")
-
-    count = j.count_today_applied()
-    assert_true(count >= 1, f"at least 1 applied today (got {count})")
-
-
-def test_guardrail_agent_created():
-    """Guardrail: non-agent-created skill detection varies by runtime environment.
-    In standalone test this may pass through if bundled detection isn't loaded.
-    Test the reserved prefix guardrail instead (reliable cross-environment)."""
-    print("\nTest: guardrail (reserved prefix + bundled check)")
-    from core import _validate_proposal
-    from config import only_agent_created as _cfg
-
-    # Reserved prefix always blocked
-    err = _validate_proposal({"action": "create", "kind": "skill", "name": "hermes-test"})
-    assert err, "hermes- prefix should be rejected"
-    ok(f"Rejected reserved prefix: {err[:60]}")
-
-    # Bundled check — may or may not work outside Hermes runtime
-    if _cfg():
-        err2 = _validate_proposal({"action": "patch", "kind": "skill", "name": "canvas-design", "content": "x"})
-        if err2:
-            ok(f"Rejected bundled skill: {err2[:60]}")
+    @classmethod
+    def approve_pending(cls, subsystem, pending_id):
+        record = cls.pending.pop((subsystem, pending_id))
+        if subsystem == "skills":
+            action = record["action"]
+            name = record["name"]
+            if action in ("create", "edit"):
+                cls.add_skill(name, record.get("content") or "")
+            elif action == "delete":
+                cls.skills.pop(name, None)
+                cls.agent_created.discard(name)
+                shutil.rmtree(cls.root / "skills" / name, ignore_errors=True)
         else:
-            ok("Bundled check skipped — not available in standalone test (expected)")
+            target = record["target"]
+            entries = cls.user_entries if target == "user" else cls.memory_entries
+            entries.append(record["content"])
+            filename = "USER.md" if target == "user" else "MEMORY.md"
+            (cls.root / filename).write_text(
+                "\n\n---\n\n".join(entries), encoding="utf-8"
+            )
+
+    @classmethod
+    def reject_pending(cls, subsystem, pending_id):
+        cls.pending.pop((subsystem, pending_id))
+
+    @classmethod
+    def add_skill(cls, name, content):
+        cls.skills[name] = content
+        cls.agent_created.add(name)
+        directory = cls.root / "skills" / name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "SKILL.md").write_text(content, encoding="utf-8")
 
 
-def test_guardrail_reserved_prefix():
-    """Guardrail rejects hermes- prefixed skills."""
-    print("\nTest: guardrail (reserved prefix)")
-    from core import _validate_proposal
-    err = _validate_proposal({"action": "create", "kind": "skill", "name": "hermes-test"})
-    assert err, "hermes- prefix → should be rejected"
-    ok(f"Rejected: {err[:60]}")
+def install_fake_host():
+    tools = types.ModuleType("tools")
+    tools.__path__ = []
+    skills = types.ModuleType("tools.skills_tool")
+    manager = types.ModuleType("tools.skill_manager_tool")
+    usage = types.ModuleType("tools.skill_usage")
+    memory = types.ModuleType("tools.memory_tool")
+    approval = types.ModuleType("tools.write_approval")
 
-
-def test_refine_e2e_noop():
-    """End-to-end: refine_run returns no_op with insufficient evidence."""
-    print("\nTest: refine_run → no_op (no real evidence)")
-    from core import refine_run
-
-    if not has_trajectory():
-        ok("skipped - no state.db / no session data on this machine")
-        return
-
-    mock = MockLlm({
-        "action": "no_op",
-        "reason": "Not enough evidence",
+    skills.skills_list = lambda: json.dumps({
+        "skills": [{"name": name} for name in sorted(FakeHost.skills)]
     })
-    result = refine_run(mock, reason="test")
-    assert result, "should return result dict"
-    # Should have journal entry
-    assert "journal_id" in result, "should have journal_id"
-    ok(f"Result: {result.get('message', 'no message')[:80]}")
 
-
-def test_refine_e2e_create_skill():
-    """End-to-end: create a test skill via refine, then delete it."""
-    print("\nTest: refine_run → create skill (full cycle)")
-    from core import refine_run
-    import journal as j
-
-    if not has_trajectory():
-        ok("skipped - no state.db / no session data on this machine")
-        return
-
-    skill_name = "refine-e2e-test-skill"
-    skill_content = (
-        "---\nname: refine-e2e-test-skill\ndescription: E2E test skill for refine\n---\n\n"
-        "# Refine E2E Test\n\nThis is a test skill created by refine_run.\n"
-    )
-
-    mock = MockLlm({
-        "action": "create",
-        "kind": "skill",
-        "name": skill_name,
-        "content": skill_content,
-        "category": "",
-        "reason": "User asked how to X, let's remember",
-        "evidence": ["user: how do I X?"],
-    })
-    result = refine_run(mock, reason="e2e test")
-
-    if result.get("result", {}).get("success"):
-        ok(f"Created skill: {skill_name}")
-        journal_id = result.get("journal_id", "")
-        assert journal_id, "should have journal_id"
-
-        # Verify skill exists
-        try:
-            from tools.skills_tool import skill_view
-            sv = skill_view(skill_name)
-            ok("skill_view returns content")
-        except Exception:
-            pass
-
-        # Rollback test (won't fully restore since backup is the old non-existent state)
-        # Instead, just delete the test skill
-        from tools.skill_manager_tool import skill_manage
-        del_result = json.loads(skill_manage(action="delete", name=skill_name))
-        if del_result.get("success"):
-            ok("Deleted test skill")
-        else:
-            fail("delete test skill", del_result.get("error", "?"))
-    else:
-        msg = result.get("message", result.get("result", {}).get("error", "unknown"))
-        if "staged" in str(result).lower() or "pending" in str(result).lower():
-            ok(f"Skipped — write gated (pending approval): {msg[:80]}")
-        else:
-            fail("create skill", msg)
-
-
-def test_refine_rollback_nonexistent():
-    """Rollback non-existent entry → error."""
-    print("\nTest: rollback nonexistent")
-    from core import refine_rollback
-    result = refine_rollback("nonexistent-id-12345")
-    assert not result.get("success"), "should return failure"
-    ok(f"Correctly rejected: {result.get('error', '?')[:60]}")
-
-
-def test_list_skill_names():
-    """list_skill_names() returns at least some skills."""
-    print("\nTest: list_skill_names")
-    from core import list_skill_names
-    names = list_skill_names()
-    assert isinstance(names, list), "should return list"
-    ok(f"Found {len(names)} skills")
-
-
-def test_scrub_text():
-    """Credential patterns are redacted; benign text is untouched."""
-    print("\nTest: scrub_text")
-    from core import scrub_text
-
-    t = (
-        "token is github_pat_11FAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKE "
-        "and sk-proj-abcdefghijklmnopqrstuvwxyz123456 and api_key=supersecret123 "
-        "and password: hunter2 and Authorization: Bearer aaaabbbbccccddddeeee "
-        "and max_tokens=2048 stays"
-    )
-    s = scrub_text(t)
-    assert "github_pat_11FAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKE" not in s, "PAT must be redacted"
-    assert "sk-proj-abcdefghijklmnopqrstuvwxyz123456" not in s, "sk- key must be redacted"
-    assert "supersecret123" not in s, "api_key= value must be redacted"
-    assert "hunter2" not in s, "password: value must be redacted"
-    assert "aaaabbbbccccddddeeee" not in s, "Bearer value must be redacted"
-    assert "max_tokens=2048" in s, "max_tokens must stay untouched"
-    assert "[REDACTED]" in s, "should contain REDACTED marker"
-    ok(f"redacted {s.count('[REDACTED]')} spots, benign text intact")
-
-
-def test_scrub_proposal():
-    """scrub_proposal redacts all string fields and list items."""
-    print("\nTest: scrub_proposal")
-    from core import scrub_proposal
-    p = {
-        "action": "create",
-        "name": "my-skill",
-        "reason": "saw token github_pat_11FAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKE",
-        "evidence": ["user said: password=hunter2"],
-        "content": "---\nname: my-skill\ndescription: x\n---\n\n# body",
-    }
-    s = scrub_proposal(p)
-    assert "github_pat_11FAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKE" not in s["reason"], "reason must be scrubbed"
-    assert "hunter2" not in s["evidence"][0], "evidence list must be scrubbed"
-    assert s["name"] == "my-skill", "name must stay"
-    assert "[REDACTED]" in s["reason"] and "[REDACTED]" in s["evidence"][0]
-    ok("all string fields scrubbed, structure preserved")
-
-
-def test_guardrail_create():
-    """create new name OK; create over existing rejected; patch bundled rejected."""
-    print("\nTest: guardrail create")
-    from core import _validate_proposal
-
-    err_new = _validate_proposal({
-        "action": "create", "kind": "skill", "name": "refine-guard-test-new",
-        "content": "---\nname: refine-guard-test-new\ndescription: x\n---\n\n# x",
-    })
-    assert err_new is None, f"create new name should pass, got: {err_new}"
-    ok("create new name allowed")
-
-    existing = None
-    from core import list_skill_names
-    names = list_skill_names()
-    if names:
-        existing = names[0]
-        err_over = _validate_proposal({
-            "action": "create", "kind": "skill", "name": existing,
-            "content": "---\nname: x\ndescription: x\n---\n\n# x",
+    def skill_view(name):
+        if name not in FakeHost.skills:
+            return json.dumps({"success": False, "error": "not found"})
+        return json.dumps({
+            "success": True,
+            "skill_dir": str(FakeHost.root / "skills" / name),
+            "content": FakeHost.skills[name],
         })
-        assert err_over and "already exists" in err_over, f"create over existing should be rejected, got: {err_over}"
-        ok(f"create over existing rejected ({existing})")
-    else:
-        ok("no existing skills to test create-over-existing (skipped)")
 
+    def skill_manage(action, name, content=None, category=None):
+        FakeHost.actions.append({
+            "action": action, "name": name, "content": content, "category": category
+        })
+        if FakeHost.fail_next:
+            error, FakeHost.fail_next = FakeHost.fail_next, ""
+            return json.dumps({"success": False, "error": error})
+        if FakeHost.stage_writes and action in ("create", "edit", "delete"):
+            pending_id = FakeHost.next_pending_id(name)
+            FakeHost.pending[("skills", pending_id)] = {
+                "action": action,
+                "name": name,
+                "content": content,
+                "category": category,
+            }
+            return json.dumps({
+                "success": True, "staged": True, "pending_id": pending_id
+            })
+        if action == "create":
+            if name in FakeHost.skills:
+                return json.dumps({"success": False, "error": "exists"})
+            FakeHost.add_skill(name, content or "")
+        elif action == "edit":
+            if name not in FakeHost.skills:
+                return json.dumps({"success": False, "error": "not found"})
+            FakeHost.add_skill(name, content or "")
+        elif action == "delete":
+            if name not in FakeHost.skills:
+                return json.dumps({"success": False, "error": "not found"})
+            del FakeHost.skills[name]
+            FakeHost.agent_created.discard(name)
+            shutil.rmtree(FakeHost.root / "skills" / name, ignore_errors=True)
+        else:
+            return json.dumps({"success": False, "error": f"unsupported {action}"})
+        return json.dumps({"success": True, "message": f"{action} ok"})
 
-def test_refine_multipass():
-    """refine_run honors max_edits_per_run>1: second pass sees the skill exists."""
-    print("\nTest: refine_run multi-pass")
-    import config as cfg
-    from core import refine_run
+    class MemoryStore:
+        def __init__(self):
+            self.memory_entries = FakeHost.memory_entries
+            self.user_entries = FakeHost.user_entries
 
-    if not has_trajectory():
-        ok("skipped - no state.db / no session data on this machine")
-        return
+        def load_from_disk(self):
+            return None
 
-    orig = cfg.max_edits_per_run
-    cfg.max_edits_per_run = lambda: 2
+        def _entries_for(self, target):
+            return FakeHost.user_entries if target == "user" else FakeHost.memory_entries
 
-    skill_name = "refine-multipass-test"
-    mock = MockLlm({
-        "action": "create",
-        "kind": "skill",
-        "name": skill_name,
-        "content": f"---\nname: {skill_name}\ndescription: multipass test\n---\n\n# Multipass\n",
-        "category": "",
-        "reason": "test multipass",
-        "evidence": ["test"],
+        def add(self, target, content):
+            if FakeHost.stage_writes:
+                pending_id = FakeHost.next_pending_id(target)
+                FakeHost.pending[("memory", pending_id)] = {
+                    "target": target,
+                    "content": content,
+                }
+                return {"success": True, "staged": True, "pending_id": pending_id}
+            self._entries_for(target).append(content)
+            return {"success": True}
+
+        def save_to_disk(self, target):
+            filename = "USER.md" if target == "user" else "MEMORY.md"
+            (FakeHost.root / filename).write_text(
+                "\n\n---\n\n".join(self._entries_for(target)), encoding="utf-8"
+            )
+
+    skills.skill_view = skill_view
+    manager.skill_manage = skill_manage
+    usage.is_agent_created = lambda name: name in FakeHost.agent_created
+    usage.get_usage_count = lambda name: FakeHost.usage_counts.get(name, 0)
+    memory.MemoryStore = MemoryStore
+    memory.get_memory_dir = lambda: str(FakeHost.root)
+    approval.get_pending = lambda subsystem, pending_id: FakeHost.pending.get(
+        (subsystem, pending_id)
+    )
+    tools.skills_tool, tools.skill_manager_tool = skills, manager
+    tools.skill_usage, tools.memory_tool = usage, memory
+    tools.write_approval = approval
+    sys.modules.update({
+        "tools": tools,
+        "tools.skills_tool": skills,
+        "tools.skill_manager_tool": manager,
+        "tools.skill_usage": usage,
+        "tools.memory_tool": memory,
+        "tools.write_approval": approval,
     })
 
-    try:
-        result = refine_run(mock, reason="multipass")
-        results = result.get("results", [result])
-        # First pass applied, second pass either rejected (already exists) or
-        # the loop stopped — either way nothing should be left behind.
-        from tools.skill_manager_tool import skill_manage
-        del_result = json.loads(skill_manage(action="delete", name=skill_name))
-        assert del_result.get("success"), "test skill should be deletable"
-        ok(f"multi-pass produced {len(results)} pass(es); cleanup ok")
-    finally:
-        cfg.max_edits_per_run = orig
+    constants = types.ModuleType("hermes_constants")
+    constants.get_hermes_home = lambda: str(FakeHost.root)
+    cli = types.ModuleType("hermes_cli")
+    cli.__path__ = []
+    cli_config = types.ModuleType("hermes_cli.config")
+    cli_config.load_config = lambda: FakeHost.config
+    cli.config = cli_config
+    sys.modules.update({
+        "hermes_constants": constants,
+        "hermes_cli": cli,
+        "hermes_cli.config": cli_config,
+    })
 
 
-def test_scrub_new_patterns():
-    """Vendor token formats and env-style lines are redacted."""
-    print("\nTest: scrub_text (extended patterns)")
-    from core import scrub_text
-
-    cases = [
-        ("HuggingFace", "hf_" + "a" * 24),
-        ("GitLab PAT", "glpat-" + "b" * 20),
-        ("SendGrid", "SG." + "c" * 20 + "." + "d" * 20),
-        ("DigitalOcean", "dop_v1_" + "e" * 64),
-        ("URL basic-auth", "https://admin:s3cr3tpass@internal.example.com/api"),
-        ("env line", "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIK7MDENGbPxRfiCY"),
-    ]
-    for label, raw in cases:
-        out = scrub_text(raw)
-        if "[REDACTED]" in out and raw.split("@")[0].split("=")[-1] not in out:
-            ok(f"{label} redacted")
-        else:
-            fail(f"{label} redacted", f"got {out[:60]!r}")
+install_fake_host()
+import config
+import core
+import journal
+import ledger
+import llm
+import patterns
 
 
-def test_scrub_no_false_positives():
-    """Benign config-looking text must survive untouched."""
-    print("\nTest: scrub_text (no false positives)")
-    from core import scrub_text
-
-    benign = [
-        "max_tokens=2048",
-        "token_count: 15",
-        "secretary=jane",
-        "secret=true",
-        "password: null",
-        '"api_key": null',
-        "use_secrets = False",
-        "auth: none",
-        "TOKEN = 1234",
-        "tokens: 8192",
-        "secret_scanning: enabled",
-        "https://github.com/Bergschloss/Refine-Cycle",
-        "see http://localhost:8080/api",
-    ]
-    for raw in benign:
-        out = scrub_text(raw)
-        if out == raw:
-            ok(f"kept: {raw}")
-        else:
-            fail(f"kept: {raw}", f"mangled to {out!r}")
+def load_plugin_init():
+    spec = importlib.util.spec_from_file_location("refine_plugin_init", ROOT / "__init__.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
 
 
-# ── temp state.db fixture ───────────────────────────────────────────────────
-
-_PLANTED_SECRET = "ghp_" + "Z" * 36
+plugin_init = load_plugin_init()
 
 
-def _make_fake_db(tmpdir: str, n_messages: int = 6) -> str:
-    """Build a throwaway state.db with the columns collect_evidence reads.
-
-    Never touches the real ~/.hermes/state.db.
-    """
-    import sqlite3 as _sq
-
-    path = str(Path(tmpdir) / "fake_state.db")
-    con = _sq.connect(path)
-    con.execute("CREATE TABLE sessions (id TEXT, started_at REAL)")
-    con.execute(
-        "CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, "
-        "tool_name TEXT, timestamp REAL, active INTEGER)"
-    )
-    con.execute("INSERT INTO sessions VALUES ('sess-test', 1000)")
-    rows = [
-        ("sess-test", "user", "deploy the thing", "", 1001, 1),
-        ("sess-test", "tool", f"error: auth failed, token={_PLANTED_SECRET}", "http", 1002, 1),
-        ("sess-test", "assistant", "retrying", "", 1003, 1),
-        ("sess-test", "tool", "error: auth failed again", "http", 1004, 1),
-        ("sess-test", "user", "no, that is not right, use the other endpoint", "", 1005, 1),
-        ("sess-test", "assistant", "ok", "", 1006, 1),
-    ][:n_messages]
-    con.executemany("INSERT INTO messages VALUES (?,?,?,?,?,?)", rows)
-    con.commit()
-    con.close()
-    return path
+def skill_content(name, body="# Guidance\n\nKeep this guidance."):
+    return f"---\nname: {name}\ndescription: Test skill\n---\n\n{body}\n"
 
 
-def _patched_db(path: str):
-    """Return an _open_db replacement bound to the fake database."""
-    import sqlite3 as _sq
-
-    def _open():
-        con = _sq.connect(f"file:{path}?mode=ro", uri=True)
-        con.row_factory = _sq.Row
-        return con
-
-    return _open
+def skill_proposal(name, body="# Guidance\n\nNew guidance."):
+    return {
+        "action": "create", "kind": "skill", "name": name,
+        "content": skill_content(name, body), "reason": "Repeated failure",
+        "evidence": ["request failed"], "pattern_fingerprint": "deadbeef1234",
+    }
 
 
-def test_evidence_scrubbed_from_db():
-    """A secret in a message row never survives collect_evidence()."""
-    print("\nTest: evidence scrubbed at DB read point")
-    import core
+class RefineTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        FakeHost.reset(self.root)
 
-    with tempfile.TemporaryDirectory() as td:
-        db = _make_fake_db(td)
-        orig = core._open_db
-        core._open_db = _patched_db(db)
-        try:
-            ev = core.collect_evidence()
-            blob = json.dumps(ev, ensure_ascii=False)
-        finally:
-            core._open_db = orig
+    def tearDown(self):
+        self.temp.cleanup()
 
-    assert_true(_PLANTED_SECRET not in blob, "planted secret absent from evidence")
-    assert_in("[REDACTED]", blob, "evidence contains redaction marker")
+    def run_proposal(self, proposal, **kwargs):
+        with patch.object(core._llm, "propose", return_value=proposal):
+            return core.refine_run(MockLlm(), **kwargs)
 
-
-def test_refine_run_output_scrubbed():
-    """Regression: the no_op return path must not leak raw evidence.
-
-    refine_run() returns the evidence dict on the no_op branch, and that dict
-    is serialized as the refine_run tool result — straight back into the
-    model's context and into state.db.
-    """
-    print("\nTest: refine_run output scrubbed (no_op path)")
-    import core
-    import journal as j
-
-    if j.daily_limit_reached():
-        ok("skipped — daily edit limit reached")
-        return
-
-    mock = MockLlm({"action": "no_op", "reason": "nothing to learn"})
-
-    with tempfile.TemporaryDirectory() as td:
-        db = _make_fake_db(td)
-        orig = core._open_db
-        core._open_db = _patched_db(db)
-        try:
-            result = core.refine_run(mock, reason="scrub regression")
-            blob = json.dumps(result, ensure_ascii=False)
-        finally:
-            core._open_db = orig
-
-    assert_true(_PLANTED_SECRET not in blob, "planted secret absent from tool result")
-    assert_true(bool(mock.calls), "mock LLM was actually called")
-
-    sent = json.dumps(mock.calls, ensure_ascii=False, default=str)
-    assert_true(_PLANTED_SECRET not in sent, "planted secret never sent to the LLM")
-
-
-def test_pattern_fingerprint():
-    """Errors that differ only by volatile detail collapse to one pattern."""
-    print("\nTest: error fingerprinting")
-    import patterns as P
-
-    a = P.fingerprint("http", "HTTP 429 rate limited for /users/8821 at 2026-08-06T10:11:12Z")
-    b = P.fingerprint("http", "HTTP 429 rate limited for /users/9134 at 2026-08-06T11:44:01Z")
-    assert_eq(a, b, "same shape, different ids → one fingerprint")
-
-    c = P.fingerprint("http", "HTTP 403 forbidden for /users/8821")
-    assert_true(a != c, "different status → different fingerprint")
-
-    d = P.fingerprint("bash", "HTTP 429 rate limited for /users/8821")
-    assert_true(a != d, "same text, different tool → different fingerprint")
-
-    tb = ('Traceback (most recent call last):\n  File "/tmp/x.py", line 12, in f\n'
-          '    raise ValueError("bad id 991")\nValueError: bad id 991')
-    assert_eq(P.normalize_error(tb), "valueerror: bad id n", "traceback reduced to final line")
-
-    # Structured tool results are mostly JSON. Two properties must hold at once:
-    # volatile detail inside a message collapses, but different messages do not.
-    js = '{"success": false, "error": "%s"}'
-    same_a = P.fingerprint("t", js % "rate limited for /u/8821")
-    same_b = P.fingerprint("t", js % "rate limited for /u/9134")
-    other = P.fingerprint("t", js % "permission denied")
-    assert_eq(same_a, same_b, "JSON: volatile ids inside a message collapse")
-    assert_true(same_a != other, "JSON: different error messages stay distinct")
-
-    # Blanking JSON keys would reduce every tool result to one useless shape.
-    assert_in("error", P.normalize_error(js % "boom"), "JSON keys survive normalization")
-
-    # A timeout at 10s and at 15s is one failure, not two.
-    assert_eq(
-        P.fingerprint("proc", "status: timeout, waited 10s, still running"),
-        P.fingerprint("proc", "status: timeout, waited 15s, still running"),
-        "durations normalize",
-    )
-
-
-def test_pattern_aggregation():
-    """extract_patterns counts occurrences and distinct sessions."""
-    print("\nTest: pattern aggregation")
-    import patterns as P
-
-    items = [
-        {"tool": "http", "content": f"HTTP 429 for /u/{i}", "session_id": f"s{i % 3}", "ts": 1000 + i}
-        for i in range(6)
-    ]
-    items.append({"tool": "gmail", "content": "insufficient scope", "session_id": "s9", "ts": 2000})
-
-    pats = P.extract_patterns(items)
-    assert_eq(len(pats), 2, "two distinct patterns")
-    assert_eq(pats[0]["count"], 6, "repeated pattern counted 6x")
-    assert_eq(pats[0]["sessions_seen"], 3, "seen across 3 sessions")
-
-    merged = P.merge_patterns(pats, [{"fingerprint": pats[0]["fingerprint"], "count": 99, "sessions_seen": 5}])
-    assert_eq(merged[0]["count"], 99, "merge keeps the higher count")
-
-
-def test_signal_gate():
-    """has_signal only fires on a real repeat or an explicit correction."""
-    print("\nTest: signal gate")
-    import patterns as P
-
-    assert_true(not P.has_signal([{"count": 1, "sessions_seen": 1}], []), "single one-off → no signal")
-    assert_true(P.has_signal([{"count": 2, "sessions_seen": 1}], []), "repeated twice → signal")
-    assert_true(P.has_signal([{"count": 1, "sessions_seen": 2}], []), "seen in 2 sessions → signal")
-    assert_true(P.has_signal([], ["no, that is wrong"]), "user correction → signal")
-
-
-def test_signal_gate_skips_llm():
-    """With no repeat and no correction, refine_run must not call the model."""
-    print("\nTest: signal gate skips the LLM call")
-    import core
-    import journal as j
-
-    if j.daily_limit_reached():
-        ok("skipped — daily edit limit reached")
-        return
-
-    mock = MockLlm({"action": "no_op", "reason": "unused"})
-
-    with tempfile.TemporaryDirectory() as td:
-        # 4 neutral messages: no errors, no corrections → no signal at all.
-        import sqlite3 as _sq
-        db = str(Path(td) / "quiet.db")
-        con = _sq.connect(db)
-        con.execute("CREATE TABLE sessions (id TEXT, started_at REAL)")
-        con.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, "
-                    "tool_name TEXT, timestamp REAL, active INTEGER)")
-        con.execute("INSERT INTO sessions VALUES ('quiet', 1000)")
-        con.executemany("INSERT INTO messages VALUES (?,?,?,?,?,?)", [
-            ("quiet", "user", "what is the weather", "", 1001, 1),
-            ("quiet", "assistant", "it is sunny today", "", 1002, 1),
-            ("quiet", "user", "thanks a lot friend", "", 1003, 1),
-            ("quiet", "assistant", "you are welcome", "", 1004, 1),
+    def test_evidence_is_sandboxed_scrubbed_and_classified(self):
+        secret = "ghp_" + "Z" * 36
+        now = time.time()
+        FakeHost.make_db([
+            ("session", "user", "No, that is not right; use another endpoint instead", "", now - 3, 1),
+            ("session", "tool", f'ERROR: denied, "api_key": "abc!{secret}"', "http", now - 2, 1),
+            ("session", "assistant", "retry", "", now - 1, 1),
         ])
-        con.commit(); con.close()
+        result = core.collect_evidence()
+        self.assertNotIn(secret, json.dumps(result))
+        self.assertIn("[REDACTED]", json.dumps(result))
+        self.assertEqual(result["error_count"], 1)
+        self.assertTrue(str(config.state_db_path()).startswith(str(self.root)))
+        self.assertTrue(str(journal.journal_path()).startswith(str(self.root)))
 
-        orig = core._open_db
-        core._open_db = _patched_db(db)
-        try:
-            result = core.refine_run(mock, reason="gate test")
-        finally:
-            core._open_db = orig
+    def test_recursive_sanitation_covers_every_journal_field(self):
+        entry_id = journal.log(
+            trigger="manual", reason='password: "p@ss:w,rd!"', session_id="session",
+            proposal={"action": "no_op", "reason": {"nested": ['"api_key":"aB!@#$[]"']}},
+            outcome="no_op", error='{"token":"abc.DEF+/=!?"}',
+        )
+        raw = journal.journal_path().read_text(encoding="utf-8")
+        for secret in ("p@ss:w,rd", "aB!@#$", "abc.DEF"):
+            self.assertNotIn(secret, raw)
+        self.assertIn("[REDACTED]", raw)
+        self.assertEqual(journal.get_entry(entry_id)["outcome"], "no_op")
 
-    assert_true(not mock.calls, "LLM was NOT called (no signal)")
-    assert_eq(result.get("llm_called"), False, "result reports llm_called=False")
-    assert_true(result.get("success") is True, "run still succeeds as a no_op")
+    def test_error_status_head_and_tail_classification(self):
+        self.assertFalse(core._is_error_content('{"success":true,"exit_code":0,"error":null}'))
+        self.assertTrue(core._is_error_content('{"success":false,"exit_code":2,"error":"boom"}'))
+        self.assertTrue(core._is_error_content("ERROR: failed" + "x" * 10000))
+        self.assertTrue(core._is_error_content("x" * 10000 + " timeout"))
+        self.assertFalse(core._is_error_content("exit_code: 0\ncompleted normally"))
 
+    def test_correction_requires_explicit_context(self):
+        routine = (
+            "Use the API for this task", "Do not forget the tests", "Try again tomorrow",
+            "Use JSON instead of YAML for this new file", "Перероби документ у короткому форматі",
+        )
+        explicit = (
+            "No, that is not right; use the other endpoint instead",
+            "You used the old API; use the new API instead",
+            "Це неправильно, перероби через інший endpoint",
+        )
+        self.assertTrue(all(not core._is_correction(item) for item in routine))
+        self.assertTrue(all(core._is_correction(item) for item in explicit))
 
-def test_dedup_guard():
-    """An identical proposal applied recently is refused."""
-    print("\nTest: dedup guard")
-    import journal as j
-    from core import _validate_proposal
+    def test_full_fingerprint_and_unbounded_audit_collection(self):
+        fingerprint = patterns.fingerprint("http", "ERROR 42 for /item/123")
+        self.assertEqual(len(fingerprint), 12)
+        rendered = patterns.format_patterns([{
+            "fingerprint": fingerprint, "count": 2, "sessions_seen": 1,
+            "tool": "http", "sample": "ERROR",
+        }])
+        self.assertIn(f"fp:{fingerprint}", rendered)
+        proposal = skill_proposal("fp-skill")
+        proposal["pattern_fingerprint"] = fingerprint
+        self.assertEqual(
+            llm.propose(MockLlm(proposal), "evidence", [], [])["pattern_fingerprint"],
+            fingerprint,
+        )
 
-    proposal = {
-        "action": "create", "kind": "skill", "name": "refine-dedup-probe",
-        "content": "---\nname: refine-dedup-probe\ndescription: x\n---\n\n# x",
-    }
-    h1 = j.proposal_hash(proposal)
-    h2 = j.proposal_hash(dict(proposal))
-    assert_eq(h1, h2, "hash is stable for identical proposals")
+        now = time.time()
+        words = [
+            "alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
+            "golf", "hotel", "india", "juliet", "kilo",
+        ]
+        FakeHost.make_db([
+            ("session", "tool", f"ERROR: unique failure {word}", "tool", now - index, 1)
+            for index, word in enumerate(words)
+        ])
+        found = core.collect_cross_session_patterns(
+            since_ts=now - 100, max_rows=None, max_sessions=None
+        )
+        self.assertEqual(len(found), 11)
 
-    other = dict(proposal, content=proposal["content"] + " changed")
-    assert_true(j.proposal_hash(other) != h1, "different content → different hash")
+    def test_skill_patch_gets_current_complete_content(self):
+        name = "existing-skill"
+        current = skill_content(name, "# Existing\n\nImportant old guidance.")
+        replacement = skill_content(name, "# Existing\n\nImportant old guidance.\n\nNew fix.")
+        FakeHost.add_skill(name, current)
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": "New fix only", "reason": "failure", "evidence": [],
+        }
+        model = MockLlm(initial, dict(initial, content=replacement))
+        result = llm.propose(
+            model, "evidence", [name], [], skill_content_loader=journal.read_skill_content
+        )
+        self.assertEqual(result["content"], replacement)
+        self.assertIn(current, model.calls[1]["input"][0].text)
 
-    # Write into a throwaway journal: a real "applied" entry would count
-    # against the live daily edit budget.
-    with tempfile.TemporaryDirectory() as td:
-        orig = j.journal_dir
-        j.journal_dir = lambda: Path(td)
-        try:
-            j.log(trigger="test", reason="dedup probe", session_id="test",
-                  proposal=proposal, outcome="applied")
-            err = _validate_proposal(proposal)
-        finally:
-            j.journal_dir = orig
-
-    assert_true(bool(err) and "already applied" in (err or ""),
-                f"repeat proposal rejected (got: {err})")
-
-
-def test_ledger_audit():
-    """Ledger records edits and the audit verdicts follow the evidence."""
-    print("\nTest: usefulness ledger + audit")
-    import ledger as L
-    import time as _t
-
-    # Throwaway stats file — never disturb the live ledger.
-    td = tempfile.TemporaryDirectory()
-    orig_dir = L.journal_dir
-    L.journal_dir = lambda: Path(td.name)
-    try:
-        fp = "deadbeef1234"
-        L._save_stats({
-            "helped-skill": {
-                "created_ts": _t.time() - 30 * 86400, "journal_id": "j1",
-                "kind": "skill", "action": "create", "pattern_fingerprint": fp,
-            },
-            "did-not-help": {
-                "created_ts": _t.time() - 30 * 86400, "journal_id": "j2",
-                "kind": "skill", "action": "create", "pattern_fingerprint": "cafebabe0000",
-            },
+    def test_patch_maps_to_edit_and_invalid_content_never_applies(self):
+        name = "patch-map"
+        FakeHost.add_skill(name, skill_content(name))
+        result = core._apply_skill({
+            "action": "patch", "kind": "skill", "name": name,
+            "content": skill_content(name, "# Updated"), "category": "",
         })
+        self.assertTrue(result["success"])
+        self.assertEqual(FakeHost.actions[-1]["action"], "edit")
+        self.assertIn("non-empty", core._validate_proposal({
+            "action": "patch", "kind": "skill", "name": "x", "content": ""
+        }))
+        self.assertIn("frontmatter", core._validate_proposal({
+            "action": "create", "kind": "skill", "name": "x", "content": "body"
+        }))
 
-        # The second skill's pattern showed up again after it was written.
-        current = [{"fingerprint": "cafebabe0000", "last_ts": _t.time(), "count": 3, "sessions_seen": 2}]
-        rows = {r["name"]: r for r in L.audit(current)}
+    def test_backup_and_prepare_failures_abort_before_mutation(self):
+        name = "backup-fail"
+        original = skill_content(name)
+        FakeHost.add_skill(name, original)
+        patch_proposal = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": skill_content(name, "# Changed"), "reason": "why", "evidence": [],
+        }
+        with patch.object(core._llm, "propose", return_value=patch_proposal), patch.object(
+            journal, "backup_skill", return_value=None
+        ):
+            result = core.refine_run(MockLlm())
+        self.assertFalse(result["success"])
+        self.assertEqual(FakeHost.skills[name], original)
+        self.assertFalse(FakeHost.actions)
 
-        assert_eq(rows["did-not-help"]["pattern_recurred"], True, "recurring pattern detected")
-        assert_eq(rows["did-not-help"]["verdict"], "did not help", "verdict follows recurrence")
-        assert_eq(rows["helped-skill"]["pattern_recurred"], False, "non-recurring pattern")
+        with patch.object(core._llm, "propose", return_value=skill_proposal("prepare-fail")), patch.object(
+            journal, "prepare", side_effect=OSError("disk full")
+        ):
+            result = core.refine_run(MockLlm(), reason='token="unsafe!value"')
+        self.assertFalse(result["success"])
+        self.assertNotIn("prepare-fail", FakeHost.skills)
+        self.assertNotIn("unsafe!value", json.dumps(result))
 
-        report = L.format_audit(list(rows.values()))
-        assert_in("did-not-help", report, "report lists the failing skill")
-        assert_in("Nothing was deleted", report, "report is explicitly read-only")
-    finally:
-        L.journal_dir = orig_dir
-        td.cleanup()
+    def test_journal_append_preserves_history_and_recovers_after_corrupt_tail(self):
+        first = journal.log(
+            trigger="test", reason="first", session_id="s",
+            proposal={"action": "no_op"}, outcome="no_op",
+        )
+        path = journal.journal_path()
+        with path.open("ab") as handle:
+            handle.write(b'{"id":"broken"')
+            handle.flush()
+        second = journal.log(
+            trigger="test", reason="second", session_id="s",
+            proposal={"action": "no_op"}, outcome="no_op",
+        )
+        raw = path.read_bytes()
+        self.assertIn(b'{"id":"broken"\n', raw)
+        self.assertEqual(journal.get_entry(first)["reason"], "first")
+        self.assertEqual(journal.get_entry(second)["reason"], "second")
+        self.assertNotIn("os.replace", inspect.getsource(journal._append_entry))
 
+    def test_finalize_failure_keeps_prepared_recovery(self):
+        original_finalize = journal.finalize
+        calls = 0
 
-# ── run ─────────────────────────────────────────────────────────────────────
+        def fail_once(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise OSError("finalize disk error")
+            return original_finalize(*args, **kwargs)
 
+        with patch.object(core._llm, "propose", return_value=skill_proposal("finalize-fail")), patch.object(
+            journal, "finalize", side_effect=fail_once
+        ):
+            result = core.refine_run(MockLlm())
+            self.assertFalse(result["success"])
+            self.assertEqual(journal.get_entry(result["journal_id"])["outcome"], "prepared")
+            rollback = core.refine_rollback(result["journal_id"])
+        self.assertTrue(rollback["success"])
+        self.assertNotIn("finalize-fail", FakeHost.skills)
 
-def main():
-    global _FAILURES, _ABS_TEST
-    _FAILURES = 0
+    def test_apply_failures_propagate_without_rollback_id(self):
+        FakeHost.fail_next = 'failed with "password":"bad!secret"'
+        result = self.run_proposal(
+            skill_proposal("apply-fail"), reason='manual token="reason!secret"'
+        )
+        self.assertFalse(result["success"])
+        self.assertNotIn("journal_id", result)
+        self.assertEqual(journal.get_entry(result["record_id"])["outcome"], "error")
+        raw = journal.journal_path().read_text(encoding="utf-8")
+        self.assertNotIn("bad!secret", raw)
+        self.assertNotIn("reason!secret", raw)
 
-    # Clean journal state from previous test runs (idempotency)
-    jp = Path.home() / ".hermes" / "plugins" / "refine" / "refine_journal.jsonl"
-    if jp.is_file():
-        jp.unlink()
-    # Also clear backup dir from E2E test leftovers
-    bk_d = Path.home() / ".hermes" / "plugins" / "refine" / "backups"
-    if bk_d.is_dir():
-        for f in bk_d.glob("*skill_e2e*"):
-            f.unlink(missing_ok=True)
+        with patch.object(core._llm, "propose", return_value=skill_proposal("bad-stage")), patch.object(
+            core, "_apply_skill", return_value={"success": False, "staged": True, "error": "denied"}
+        ):
+            staged = core.refine_run(MockLlm())
+        self.assertEqual(journal.get_entry(staged["record_id"])["outcome"], "error")
+        self.assertNotIn("bad-stage", ledger.load_stats())
 
-    tests = [
-        test_collect_evidence,
-        test_llm_proposal_valid,
-        test_llm_proposal_noop,
-        test_llm_proposal_invalid,
-        test_llm_trust_error,
-        test_journal_roundtrip,
-        test_guardrail_agent_created,
-        test_guardrail_reserved_prefix,
-        test_refine_e2e_noop,
-        test_refine_e2e_create_skill,
-        test_refine_rollback_nonexistent,
-        test_list_skill_names,
-        test_scrub_text,
-        test_scrub_new_patterns,
-        test_scrub_no_false_positives,
-        test_scrub_proposal,
-        test_evidence_scrubbed_from_db,
-        test_refine_run_output_scrubbed,
-        test_pattern_fingerprint,
-        test_pattern_aggregation,
-        test_signal_gate,
-        test_signal_gate_skips_llm,
-        test_dedup_guard,
-        test_ledger_audit,
-        test_guardrail_create,
-        test_refine_multipass,
-    ]
+    def test_create_rollback_deletes_only_unchanged_skill(self):
+        result = self.run_proposal(skill_proposal("created-skill"))
+        self.assertTrue(result["reversible"])
+        self.assertTrue(core.refine_rollback(result["journal_id"])["success"])
+        self.assertNotIn("created-skill", FakeHost.skills)
 
-    print("=" * 50)
-    print("Refine Plugin Tests")
-    print("=" * 50)
+        changed = self.run_proposal(skill_proposal("changed-after-create"))
+        later = skill_content("changed-after-create", "# User change")
+        FakeHost.add_skill("changed-after-create", later)
+        conflict = core.refine_rollback(changed["journal_id"])
+        self.assertFalse(conflict["success"])
+        self.assertEqual(FakeHost.skills["changed-after-create"], later)
 
-    for test_fn in tests:
+    def test_patch_rollback_restores_backup_without_overwriting_later_edit(self):
+        name = "patch-rollback"
+        old = skill_content(name, "# Old\n\nPreserve me.")
+        new = skill_content(name, "# Old\n\nPreserve me.\n\nFixed.")
+        proposal = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": new, "reason": "failure", "evidence": [],
+        }
+        FakeHost.add_skill(name, old)
+        result = self.run_proposal(proposal)
+        self.assertTrue(Path(result["backup_path"]).is_file())
+        self.assertTrue(core.refine_rollback(result["journal_id"])["success"])
+        self.assertEqual(FakeHost.skills[name], old)
+
+        FakeHost.add_skill(name, old)
+        changed = self.run_proposal(proposal)
+        later = skill_content(name, "# Manual later change")
+        FakeHost.add_skill(name, later)
+        conflict = core.refine_rollback(changed["journal_id"])
+        self.assertFalse(conflict["success"])
+        self.assertEqual(FakeHost.skills[name], later)
+
+    def test_memory_rollback_removes_exact_append_only(self):
+        FakeHost.memory_entries[:] = ["before"]
+        proposal = {
+            "action": "create", "kind": "memory", "name": "lesson",
+            "content": "exact appended lesson", "reason": "why", "evidence": [],
+        }
+        result = self.run_proposal(proposal)
+        FakeHost.memory_entries.append("unrelated later entry")
+        self.assertTrue(core.refine_rollback(result["journal_id"])["success"])
+        self.assertEqual(FakeHost.memory_entries, ["before", "unrelated later entry"])
+
+        result = self.run_proposal(dict(proposal, content="second lesson"))
+        FakeHost.memory_entries[0] = "changed before"
+        conflict = core.refine_rollback(result["journal_id"])
+        self.assertFalse(conflict["success"])
+        self.assertIn("second lesson", FakeHost.memory_entries)
+
+    def test_pending_consumes_budget_and_is_reported_as_pending(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 1
+        FakeHost.stage_writes = True
+        first = self.run_proposal(skill_proposal("pending-skill"))
+        second = self.run_proposal(skill_proposal("pending-other"))
+        self.assertTrue(first["success"])
+        self.assertFalse(first["reversible"])
+        self.assertFalse(second["success"])
+        self.assertEqual(journal.count_today_applied(), 1)
+        self.assertEqual(ledger.load_stats()["pending-skill"]["outcome"], "pending_approval")
+        self.assertEqual(ledger.audit([])[0]["verdict"], "pending approval")
+
+    def test_concurrent_runs_serialize_and_recheck_budget(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 1
+        barrier = threading.Barrier(3)
+        results = []
+
+        def worker(name):
+            barrier.wait()
+            results.append(core.refine_run(MockLlm(skill_proposal(name))))
+
+        threads = [threading.Thread(target=worker, args=(f"concurrent-{index}",)) for index in range(2)]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=5)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(sum(bool(result["success"]) for result in results), 1)
+        self.assertEqual(len(FakeHost.skills), 1)
+
+    def test_reason_and_multipass_context_reach_model(self):
+        FakeHost.entry_config()["max_edits_per_run"] = 2
+        model = MockLlm(skill_proposal("first-pass"), {"action": "no_op", "reason": "done"})
+        result = core.refine_run(model, reason="focus on command parsing")
+        self.assertTrue(result["success"])
+        self.assertIn("focus on command parsing", model.calls[0]["input"][0].text)
+        self.assertIn("Already completed or reserved", model.calls[1]["input"][0].text)
+        self.assertIn("first-pass", model.calls[1]["input"][0].text)
+
+    def test_command_parsing_is_exact_and_rollback_is_real(self):
+        with patch.object(plugin_init.core, "refine_audit", return_value={"report": "AUDIT"}), patch.object(
+            plugin_init.core, "refine_run", return_value={
+                "success": True, "message": "OK", "journal_id": "abcdef123456", "reversible": False
+            }
+        ) as run, patch.object(
+            plugin_init.core, "refine_rollback", return_value={"success": True, "message": "rolled"}
+        ) as rollback:
+            self.assertEqual(plugin_init._handle_refine_command("audit"), "AUDIT")
+            ordinary = plugin_init._handle_refine_command("audit logging failures")
+            self.assertEqual(run.call_args.kwargs["reason"], "audit logging failures")
+            self.assertNotIn("rollback:", ordinary)
+            plugin_init._handle_refine_command("rollback abcdef123456")
+            rollback.assert_called_once_with("abcdef123456")
+            plugin_init._handle_refine_command("rollback not-an-id")
+            self.assertEqual(run.call_args.kwargs["reason"], "rollback not-an-id")
+
+    def test_ledger_uses_only_supported_post_edit_evidence(self):
+        created = time.time() - 30 * 86400
+        base = {
+            "created_ts": created, "journal_id": "abcdef123456", "kind": "skill",
+            "action": "create", "pattern_fingerprint": "deadbeef1234",
+        }
+        FakeHost.usage_counts["old-skill"] = 4
+        ledger._save_stats({"old-skill": base})
+        row = ledger.audit([])[0]
+        self.assertEqual(row["usage_scope"], "all_time")
+        self.assertEqual(row["verdict"], "unclear")
+
+        usage = sys.modules["tools.skill_usage"]
+        original = usage.get_usage_count
+        usage.get_usage_count = lambda name, since_ts=None: 2
         try:
-            test_fn()
-        except Exception as exc:
-            fail(test_fn.__name__, f"unhandled exception: {exc}")
-            import traceback
-            traceback.print_exc()
+            row = ledger.audit([])[0]
+        finally:
+            usage.get_usage_count = original
+        self.assertEqual(row["usage_scope"], "since_exact")
+        self.assertEqual(row["verdict"], "working")
 
-    print("\n" + "=" * 50)
-    if _FAILURES == 0:
-        print("ALL TESTS PASSED 🎉")
-    else:
-        print(f"{_FAILURES} FAILURES ❌")
-    print("=" * 50)
+    def test_audit_requests_full_post_edit_period(self):
+        created = time.time() - 100
+        ledger._save_stats({"audit-skill": {
+            "created_ts": created, "journal_id": "abcdef123456", "kind": "skill",
+            "action": "create", "pattern_fingerprint": "deadbeef1234",
+        }})
+        with patch.object(core, "collect_cross_session_patterns", return_value=[]) as collect:
+            core.refine_audit()
+        collect.assert_called_once_with(since_ts=created, max_rows=None, max_sessions=None)
+    def test_sanitization_is_idempotent_and_all_prompt_inputs_are_scrubbed(self):
+        marker_text = 'token=[REDACTED] and password: "[REDACTED]"'
+        self.assertEqual(core.scrub_text(marker_text), marker_text)
+        secrets = [
+            "reason-secret-123!", "evidence-secret-123!", "name-secret-123!",
+            "correction-secret-123!", "pattern-secret-123!", "memory-secret-123!",
+        ]
+        model = MockLlm({"action": "no_op", "reason": "done"})
+        llm.propose(
+            model,
+            'api_key="evidence-secret-123!"',
+            ['token="name-secret-123!"'],
+            ['password="memory-secret-123!"'],
+            error_patterns=[{
+                "fingerprint": "deadbeef1234", "count": 2, "sessions_seen": 1,
+                "tool": "tool", "sample": 'secret="pattern-secret-123!"',
+            }],
+            user_corrections=['password="correction-secret-123!"'],
+            unused_skills=['token="name-secret-123!"'],
+            run_context='token="reason-secret-123!"',
+        )
+        sent = json.dumps(model.calls[0], default=lambda value: getattr(value, "text", str(value)))
+        for secret in secrets:
+            self.assertNotIn(secret, sent)
+        self.assertIn("[REDACTED]", sent)
 
-    return _FAILURES
+    def test_sensitive_current_skill_aborts_before_complete_patch_request(self):
+        name = "sensitive-current"
+        current = skill_content(name, '# Guidance\n\napi_key="current-secret-123!"')
+        FakeHost.add_skill(name, current)
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "reason": "failure", "evidence": [],
+        }
+        model = MockLlm(initial)
+        result = llm.propose(
+            model, "evidence", [name], [], skill_content_loader=journal.read_skill_content
+        )
+        self.assertEqual(result["action"], "no_op")
+        self.assertEqual(len(model.calls), 1)
+        self.assertNotIn("current-secret-123", model.calls[0]["input"][0].text)
+
+    def test_redacted_create_patch_and_memory_match_journal_and_rollback(self):
+        create = skill_proposal(
+            "redacted-create", '# Guidance\n\napi_key="create-secret-123!"'
+        )
+        created = self.run_proposal(create)
+        created_entry = journal.get_entry(created["journal_id"])
+        self.assertNotIn("create-secret-123", FakeHost.skills["redacted-create"])
+        self.assertEqual(created_entry["proposal"]["content"], FakeHost.skills["redacted-create"])
+        self.assertTrue(core.refine_rollback(created["journal_id"])["success"])
+
+        name = "redacted-patch"
+        original = skill_content(name, "# Guidance\n\nOriginal.")
+        FakeHost.add_skill(name, original)
+        patched = self.run_proposal({
+            "action": "patch", "kind": "skill", "name": name,
+            "content": skill_content(name, '# Guidance\n\ntoken="patch-secret-123!"'),
+            "reason": "why", "evidence": [],
+        })
+        patched_entry = journal.get_entry(patched["journal_id"])
+        self.assertEqual(patched_entry["proposal"]["content"], FakeHost.skills[name])
+        self.assertNotIn("patch-secret-123", FakeHost.skills[name])
+        self.assertTrue(core.refine_rollback(patched["journal_id"])["success"])
+        self.assertEqual(FakeHost.skills[name], original)
+
+        memory_result = self.run_proposal({
+            "action": "create", "kind": "memory", "name": "redacted-memory",
+            "content": 'password="memory-secret-123!"', "reason": "why", "evidence": [],
+        })
+        memory_entry = journal.get_entry(memory_result["journal_id"])
+        self.assertEqual(memory_entry["proposal"]["content"], FakeHost.memory_entries[-1])
+        self.assertNotIn("memory-secret-123", FakeHost.memory_entries[-1])
+        self.assertTrue(core.refine_rollback(memory_result["journal_id"])["success"])
+
+    def test_new_malformed_lock_is_not_deleted_until_mtime_is_stale(self):
+        lock_path = journal.ensure_dirs() / journal._LOCK_FILE_NAME
+        lock_path.write_bytes(b"")
+        modified = 1000.0
+        os_module = __import__("os")
+        os_module.utime(lock_path, (modified, modified))
+        with patch.object(journal.time, "time", return_value=modified + 299):
+            journal._try_clear_stale_lock(lock_path)
+        self.assertTrue(lock_path.exists())
+        with patch.object(journal.time, "time", return_value=modified + 301):
+            journal._try_clear_stale_lock(lock_path)
+        self.assertFalse(lock_path.exists())
+
+    def test_forward_approval_reconciles_approved_rejected_and_memory(self):
+        FakeHost.stage_writes = True
+        approved = self.run_proposal(skill_proposal("approved-skill"))
+        approved_entry = journal.get_entry(approved["journal_id"])
+        pending_id = approved_entry["pending_id"]
+        self.assertEqual(approved_entry["recovery"]["pending_id"], pending_id)
+        self.assertEqual(ledger.load_stats()["approved-skill"]["pending_id"], pending_id)
+        FakeHost.approve_pending("skills", pending_id)
+        core.refine_audit()
+        self.assertEqual(journal.get_entry(approved["journal_id"])["outcome"], "applied")
+        self.assertEqual(ledger.load_stats()["approved-skill"]["outcome"], "applied")
+        self.assertTrue(journal.is_reversible(journal.get_entry(approved["journal_id"])))
+
+        rejected = self.run_proposal(skill_proposal("rejected-skill"))
+        rejected_id = journal.get_entry(rejected["journal_id"])["pending_id"]
+        FakeHost.reject_pending("skills", rejected_id)
+        core.refine_audit()
+        self.assertEqual(journal.get_entry(rejected["journal_id"])["outcome"], "rejected")
+        self.assertEqual(ledger.load_stats()["rejected-skill"]["outcome"], "rejected")
+
+        memory_result = self.run_proposal({
+            "action": "create", "kind": "memory", "name": "pending-memory",
+            "content": "exact pending memory", "reason": "why", "evidence": [],
+        })
+        memory_pending = journal.get_entry(memory_result["journal_id"])["pending_id"]
+        FakeHost.approve_pending("memory", memory_pending)
+        core.refine_audit()
+        self.assertEqual(journal.get_entry(memory_result["journal_id"])["outcome"], "applied")
+        self.assertEqual(FakeHost.memory_entries, ["exact pending memory"])
+
+    def test_matching_target_does_not_bypass_unresolved_approval(self):
+        name = "already-matching"
+        content = skill_content(name, "# Guidance\n\nAlready current.")
+        FakeHost.add_skill(name, content)
+        FakeHost.stage_writes = True
+        pending = self.run_proposal({
+            "action": "patch", "kind": "skill", "name": name,
+            "content": content, "reason": "verify approval ordering", "evidence": [],
+        })
+        entry = journal.get_entry(pending["journal_id"])
+        core.refine_audit()
+        self.assertEqual(
+            journal.get_entry(pending["journal_id"])["outcome"], "pending_approval"
+        )
+        FakeHost.approve_pending("skills", entry["pending_id"])
+        core.refine_audit()
+        self.assertEqual(journal.get_entry(pending["journal_id"])["outcome"], "applied")
+
+        rollback = core.refine_rollback(pending["journal_id"])
+        rollback_entry = journal.get_entry(pending["journal_id"])
+        self.assertTrue(rollback["staged"])
+        core.refine_audit()
+        self.assertEqual(
+            journal.get_entry(pending["journal_id"])["outcome"], "pending_rollback"
+        )
+        FakeHost.approve_pending("skills", rollback_entry["pending_id"])
+        core.refine_audit()
+        self.assertEqual(journal.get_entry(pending["journal_id"])["outcome"], "rolled_back")
+
+    def test_removed_pending_record_waits_when_target_state_is_unavailable(self):
+        FakeHost.stage_writes = True
+        result = self.run_proposal(skill_proposal("unknown-target"))
+        entry = journal.get_entry(result["journal_id"])
+        FakeHost.reject_pending("skills", entry["pending_id"])
+        skills_module = sys.modules["tools.skills_tool"]
+        with patch.object(skills_module, "skill_view", side_effect=OSError("temporarily unavailable")):
+            core.refine_audit()
+        self.assertEqual(
+            journal.get_entry(result["journal_id"])["outcome"], "pending_approval"
+        )
+        core.refine_audit()
+        self.assertEqual(journal.get_entry(result["journal_id"])["outcome"], "rejected")
+
+    def test_staged_rollback_waits_for_target_proof_and_reconciles(self):
+        applied = self.run_proposal(skill_proposal("rollback-approved"))
+        FakeHost.stage_writes = True
+        pending = core.refine_rollback(applied["journal_id"])
+        entry = journal.get_entry(applied["journal_id"])
+        self.assertTrue(pending["staged"])
+        self.assertEqual(entry["outcome"], "pending_rollback")
+        self.assertEqual(
+            ledger.load_stats()["rollback-approved"]["pending_id"], entry["pending_id"]
+        )
+        self.assertIn("rollback-approved", FakeHost.skills)
+        FakeHost.approve_pending("skills", entry["pending_id"])
+        completed = core.refine_rollback(applied["journal_id"])
+        self.assertTrue(completed["success"])
+        self.assertEqual(journal.get_entry(applied["journal_id"])["outcome"], "rolled_back")
+
+        FakeHost.stage_writes = False
+        other = self.run_proposal(skill_proposal("rollback-rejected"))
+        FakeHost.stage_writes = True
+        core.refine_rollback(other["journal_id"])
+        other_entry = journal.get_entry(other["journal_id"])
+        FakeHost.reject_pending("skills", other_entry["pending_id"])
+        core.refine_audit()
+        restored = journal.get_entry(other["journal_id"])
+        self.assertEqual(restored["outcome"], "applied")
+        self.assertTrue(journal.is_reversible(restored))
+        self.assertIn("rollback-rejected", FakeHost.skills)
+
+    def test_rollback_finalization_failure_is_reconciled_from_target_state(self):
+        applied = self.run_proposal(skill_proposal("rollback-finalize-fail"))
+        original_finalize = journal.finalize
+        failed = False
+
+        def fail_rolled_back(entry_id, outcome, **kwargs):
+            nonlocal failed
+            if outcome == "rolled_back" and not failed:
+                failed = True
+                raise OSError("finalization failed")
+            return original_finalize(entry_id, outcome, **kwargs)
+
+        with patch.object(journal, "finalize", side_effect=fail_rolled_back):
+            result = core.refine_rollback(applied["journal_id"])
+        self.assertFalse(result["success"])
+        self.assertNotIn("rollback-finalize-fail", FakeHost.skills)
+        self.assertEqual(
+            journal.get_entry(applied["journal_id"])["outcome"], "rollback_prepared"
+        )
+        retried = core.refine_rollback(applied["journal_id"])
+        self.assertTrue(retried["success"])
+        self.assertEqual(journal.get_entry(applied["journal_id"])["outcome"], "rolled_back")
+
+    def test_partial_success_preserves_all_recovery_ids_and_command_warns(self):
+        FakeHost.entry_config()["max_edits_per_run"] = 2
+        model = MockLlm(
+            skill_proposal("partial-first"),
+            {
+                "action": "create", "kind": "skill", "name": "partial-bad",
+                "content": "not a skill", "reason": "later failure", "evidence": [],
+            },
+        )
+        result = core.refine_run(model)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["outcome"], "partial_success")
+        self.assertEqual(len(result["recoveries"]), 1)
+        recovery = result["recoveries"][0]
+        self.assertIn("rollback_command", recovery)
+        with patch.object(plugin_init.core, "refine_run", return_value=result):
+            output = plugin_init._handle_refine_command("")
+        self.assertIn("⚠️", output)
+        self.assertIn(recovery["journal_id"], output)
+        self.assertIn(recovery["rollback_command"], output)
+
+    def test_patch_selection_without_content_reaches_complete_replacement(self):
+        name = "contentless-patch"
+        current = skill_content(name, "# Existing\n\nKeep.")
+        replacement = skill_content(name, "# Existing\n\nKeep.\n\nFix.")
+        FakeHost.add_skill(name, current)
+        model = MockLlm(
+            {"action": "patch", "kind": "skill", "name": name, "reason": "why"},
+            {"action": "patch", "kind": "skill", "name": name, "content": replacement, "reason": "why"},
+        )
+        result = llm.propose(
+            model, "evidence", [name], [], skill_content_loader=journal.read_skill_content
+        )
+        self.assertEqual(result["content"], replacement)
+        self.assertEqual(len(model.calls), 2)
+
+    def test_oversized_current_skill_is_not_truncated_or_sent(self):
+        name = "oversized-skill"
+        current = skill_content(name, "x" * llm.MAX_CONTENT_CHARS)
+        FakeHost.add_skill(name, current)
+        model = MockLlm({
+            "action": "patch", "kind": "skill", "name": name, "reason": "why"
+        })
+        result = llm.propose(
+            model, "evidence", [name], [], skill_content_loader=journal.read_skill_content
+        )
+        self.assertEqual(result["action"], "no_op")
+        self.assertIn(str(llm.MAX_CONTENT_CHARS), result["reason"])
+        self.assertEqual(len(model.calls), 1)
+
+    def test_patch_retry_preserves_or_replaces_valid_evidence_metadata(self):
+        name = "metadata-patch"
+        current = skill_content(name, "# Existing\n\nKeep.")
+        replacement = skill_content(name, "# Existing\n\nKeep.\n\nFix.")
+        FakeHost.add_skill(name, current)
+        initial = {
+            "action": "patch", "kind": "skill", "name": name, "reason": "initial",
+            "evidence": ["initial evidence"], "pattern_fingerprint": "deadbeef1234",
+        }
+        preserved = llm.propose(
+            MockLlm(initial, {
+                "action": "patch", "kind": "skill", "name": name,
+                "content": replacement, "reason": "replacement",
+            }),
+            "evidence", [name], [], skill_content_loader=journal.read_skill_content,
+        )
+        self.assertEqual(preserved["evidence"], ["initial evidence"])
+        self.assertEqual(preserved["pattern_fingerprint"], "deadbeef1234")
+
+        replaced = llm.propose(
+            MockLlm(initial, {
+                "action": "patch", "kind": "skill", "name": name,
+                "content": replacement, "reason": "replacement",
+                "evidence": ["replacement evidence"],
+                "pattern_fingerprint": "cafebabefeed",
+            }),
+            "evidence", [name], [], skill_content_loader=journal.read_skill_content,
+        )
+        self.assertEqual(replaced["evidence"], ["replacement evidence"])
+        self.assertEqual(replaced["pattern_fingerprint"], "cafebabefeed")
+
+    def test_full_history_patterns_stream_without_fetchall(self):
+        self.assertNotIn("fetchall", inspect.getsource(core.collect_cross_session_patterns))
+        now = time.time()
+        labels = [chr(ord("a") + index) * 3 for index in range(20)]
+        rows = [
+            (f"session-{index}", "tool", f"ERROR: streamed failure {labels[index % 20]}",
+             "stream", now - index, 1)
+            for index in range(1000)
+        ]
+        FakeHost.make_db(rows)
+        found = core.collect_cross_session_patterns(
+            since_ts=now - 2000, max_rows=None, max_sessions=None
+        )
+        self.assertEqual(sum(item["count"] for item in found), 1000)
+        self.assertLessEqual(len(found), 20)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- make tests hermetic and protect live Hermes state
- harden journaling, rollback, approval reconciliation, and concurrency
- sanitize every model/journal boundary and preserve partial-success recovery IDs

## Validation
- python -B -m tests.run_tests (34 passed)
- in-memory compile (9 files)
- git diff --check