### PR TITLE
fix: turn trigger, note injection and lock timeout defects from the port review

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,15 @@ the manual reason.
 
 ### Automatic refinement
 
-`post_llm_call` counts assistant turns and starts at most one background
-refinement attempt at a configured interval. The hook itself does not mutate or
-queue work. It skips an attempt when another pass owns the lock, and derives its
-cooldown from durable journal records, so the cooldown is visible across
-processes. `on_session_end` remains a background fallback based on the minimum
-message count.
+`post_llm_call` counts the assistant messages in the history Hermes supplies and
+starts at most one background refinement attempt once that count has grown by
+`auto_turn_interval` since this session's previous attempt. It compares a delta
+rather than an exact multiple, because a single tool-using turn appends several
+assistant messages and would otherwise step straight over the boundary. The hook
+itself does not mutate or queue work. It skips an attempt when another pass owns
+the lock, and derives its cooldown from durable journal records, so the cooldown
+is visible across processes. `on_session_end` remains a background fallback based
+on the minimum message count.
 
 ```yaml
 plugins:
@@ -176,6 +179,9 @@ writes the base system prompt. Injection is bounded by
 whole oldest notes, never partial text. Empty, unavailable, unsafe, or
 out-of-scope note stores inject nothing and do not raise on the user path.
 
+Injection prefers the mutation lock but does not depend on it: the store is only
+ever replaced atomically, so a running refine pass never costs a turn its notes.
+
 New prompt notes use `prompt_notes_default_scope`:
 
 - `global` (the default) is injected in every session.
@@ -183,6 +189,11 @@ New prompt notes use `prompt_notes_default_scope`:
   injects only when the hook receives that same identifier. Session notes are
   removed from the plugin-owned store after `on_session_end` or
   `on_session_reset` for that session.
+
+Cleanup runs on the host's callback thread, so it waits only briefly for the
+mutation lock instead of the full lock timeout. If a refine pass still owns the
+lock, the note is left in place — it can no longer be injected, because its
+session is gone — and it is removed at the next end or reset for that id.
 
 The prompt-note store is plugin-owned, so there is **no host approval gate** for
 these notes. Creation, target-state proof, audit rows, and conflict-aware
@@ -231,7 +242,7 @@ All keys live under `plugins.entries.refine`:
 |---|---|---:|---|
 | `auto_enabled` | bool | `false` | Enable automatic turn and session-end attempts. |
 | `auto_min_messages` | int | `15` | Minimum messages for session-end auto-analysis. |
-| `auto_turn_interval` | int | `25` | Assistant turns between automatic attempts; `0` disables only the turn trigger. |
+| `auto_turn_interval` | int | `25` | Assistant messages added since this session's last automatic attempt; `0` disables only the turn trigger. |
 | `auto_cooldown_minutes` | int | `20` | Minimum durable journal-derived gap between automatic attempts. |
 | `max_edits_per_run` | int | `1` | Maximum applied or reserved edits per run. |
 | `max_edits_per_day` | int | `3` | Maximum applied, pending, or prepared edits per UTC day. |
@@ -374,7 +385,9 @@ must be manually initiated.
 - **Bounded ephemeral prompt context** is labelled, sanitized, whole-note
   bounded, scoped, and never changes the base system prompt.
 - **Serialized budget** counts applied, pending-approval, and unresolved
-  prepared records after acquiring the process-safe mutation lock.
+  prepared records after acquiring the process-safe mutation lock. Lock
+  acquisition is bounded for both in-process and cross-process contention, so a
+  contended run reports a timeout instead of hanging its caller.
 - **Durable append journal** writes one locked, fsynced JSON line per state
   transition without rewriting history. A corrupt trailing line is skipped and
   isolated before the next valid record; backup, ledger, and note-store writes

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,15 @@ _AUTO_PENDING_SESSION_ENDS: set[str] = set()
 _AUTO_PENDING_LOCK = threading.Lock()
 _REGISTERED_LLM: Optional[PluginLlm] = None
 
+# Assistant-message count observed when each session last started an attempt.
+# One host turn can append several assistant messages, so the trigger compares a
+# delta instead of an exact multiple; an exact multiple is silently skipped
+# whenever a tool-using turn steps over it.
+_AUTO_TURN_MARKS: dict[str, int] = {}
+_AUTO_TURN_MARKS_LOCK = threading.Lock()
+_AUTO_TURN_MARKS_MAX = 64
+_HOST_PATH_LOCK_TIMEOUT = 2.0
+
 
 def _defer_session_end(session_id: str) -> None:
     """Coalesce session-end fallbacks without creating blocked worker threads."""
@@ -52,7 +61,11 @@ def _get_llm(ctx) -> PluginLlm:
 
 
 def _assistant_turn_count(conversation_history: Any) -> int:
-    """Count assistant turns from host callback history without assuming its shape."""
+    """Count assistant messages in host callback history without assuming its shape.
+
+    One host turn can contribute several assistant messages, so this is a
+    monotonic progress measure, not a count of user-visible turns.
+    """
     if not isinstance(conversation_history, (list, tuple)):
         return 0
     count = 0
@@ -70,32 +83,40 @@ def _cooldown_elapsed() -> bool:
     return time.time() - last_attempt >= config.auto_cooldown_minutes() * 60
 
 
-def _auto_refine_allowed(assistant_turns: int, *, require_turn_interval: bool) -> bool:
-    """Return whether an automatic attempt may start without mutating state."""
-    if not config.auto_enabled() or not _cooldown_elapsed():
-        return False
-    if not require_turn_interval:
-        return True
+def _turn_interval_reached(session_id: str, assistant_turns: int) -> bool:
+    """Compare assistant messages added since this session's last attempt."""
     interval = config.auto_turn_interval()
-    return (
-        interval > 0
-        and assistant_turns >= interval
-        and assistant_turns % interval == 0
-    )
+    if interval <= 0:
+        return False
+    with _AUTO_TURN_MARKS_LOCK:
+        return assistant_turns - _AUTO_TURN_MARKS.get(session_id, 0) >= interval
 
 
-def _run_auto_refine(
-    session_id: str,
-    assistant_turns: int,
-    *,
-    require_turn_interval: bool,
-    cleanup_session_notes: bool = False,
-) -> None:
+def _mark_turn_attempt(session_id: str, assistant_turns: int) -> None:
+    """Record the attempt point, keeping the per-session marks bounded."""
+    with _AUTO_TURN_MARKS_LOCK:
+        if (
+            session_id not in _AUTO_TURN_MARKS
+            and len(_AUTO_TURN_MARKS) >= _AUTO_TURN_MARKS_MAX
+        ):
+            _AUTO_TURN_MARKS.pop(next(iter(_AUTO_TURN_MARKS)), None)
+        _AUTO_TURN_MARKS[session_id] = assistant_turns
+
+
+def _forget_turn_marks(session_id: str) -> None:
+    with _AUTO_TURN_MARKS_LOCK:
+        _AUTO_TURN_MARKS.pop(session_id, None)
+
+
+def _auto_refine_allowed() -> bool:
+    """Return whether an automatic attempt may start without mutating state."""
+    return config.auto_enabled() and _cooldown_elapsed()
+
+
+def _run_auto_refine(session_id: str, *, cleanup_session_notes: bool = False) -> None:
     """Run one guarded automatic pass after its worker thread has started."""
     try:
-        if not _auto_refine_allowed(
-            assistant_turns, require_turn_interval=require_turn_interval
-        ):
+        if not _auto_refine_allowed():
             if cleanup_session_notes:
                 _clear_session_prompt_notes(session_id)
             return
@@ -113,19 +134,22 @@ def _run_auto_refine(
     finally:
         _finish_auto_worker()
 
-def _start_auto_refine(
-    session_id: str, assistant_turns: int, *, require_turn_interval: bool = True
-) -> None:
+
+def _start_auto_refine(session_id: str, assistant_turns: int) -> None:
     """Start at most one non-queued automatic attempt when its gates permit it."""
-    if not _auto_refine_allowed(
-        assistant_turns, require_turn_interval=require_turn_interval
-    ) or not _AUTO_THREAD_GUARD.acquire(blocking=False):
+    if (
+        not _auto_refine_allowed()
+        or not _turn_interval_reached(session_id, assistant_turns)
+        or not _AUTO_THREAD_GUARD.acquire(blocking=False)
+    ):
         return
+    # Charge the attempt to this turn point before the worker starts, so a
+    # skipped or failed attempt cannot retry on every following turn.
+    _mark_turn_attempt(session_id, assistant_turns)
     try:
         threading.Thread(
             target=_run_auto_refine,
-            args=(session_id, assistant_turns),
-            kwargs={"require_turn_interval": require_turn_interval},
+            args=(session_id,),
             daemon=True,
             name="refine-auto",
         ).start()
@@ -140,9 +164,10 @@ def _on_pre_llm_call(**kwargs) -> Optional[dict]:
         if not config.prompt_notes_enabled():
             return None
         session_id = journal.normalize_prompt_note_session_id(kwargs.get("session_id", ""))
-        with journal.try_mutation_lock() as acquired:
-            if not acquired:
-                return None
+        # Prefer reading under the lock, but never drop notes for a whole turn
+        # just because a refine pass owns it: the store is only ever replaced
+        # atomically, so a lock-free read still sees one complete generation.
+        with journal.try_mutation_lock():
             notes = journal.load_prompt_notes()
         if not notes:
             return None
@@ -171,17 +196,23 @@ def _on_pre_llm_call(**kwargs) -> Optional[dict]:
     return None
 
 
-def _clear_session_prompt_notes(session_id: str) -> None:
-    """Clear plugin-owned session notes before releasing the session worker."""
+def _clear_session_prompt_notes(
+    session_id: str, *, timeout: Optional[float] = None
+) -> None:
+    """Clear plugin-owned session notes without stalling a host callback."""
     try:
-        journal.clear_session_prompt_notes(session_id)
+        if timeout is None:
+            journal.clear_session_prompt_notes(session_id)
+        else:
+            journal.clear_session_prompt_notes(session_id, timeout=timeout)
     except Exception:
         logger.debug("refine session prompt-note cleanup failed", exc_info=True)
 
 
 def _on_session_reset(session_id: str = "", **kwargs) -> None:
     """Expire only notes owned by the session Hermes reset."""
-    _clear_session_prompt_notes(session_id)
+    _forget_turn_marks(session_id)
+    _clear_session_prompt_notes(session_id, timeout=_HOST_PATH_LOCK_TIMEOUT)
 
 
 def _on_post_llm_call(
@@ -271,8 +302,9 @@ def _on_session_end(
     **kwargs,
 ) -> None:
     """Run the session-end fallback without blocking or dropping it behind a turn run."""
+    _forget_turn_marks(session_id)
     if not config.auto_enabled() or interrupted:
-        _clear_session_prompt_notes(session_id)
+        _clear_session_prompt_notes(session_id, timeout=_HOST_PATH_LOCK_TIMEOUT)
         return
     if not _AUTO_THREAD_GUARD.acquire(blocking=False):
         _defer_session_end(session_id)
@@ -287,12 +319,7 @@ def _on_session_end(
                 logger.debug("refine auto: not enough messages (%d)", len(messages))
                 return
             handed_off = True
-            _run_auto_refine(
-                session_id,
-                _assistant_turn_count(messages),
-                require_turn_interval=False,
-                cleanup_session_notes=True,
-            )
+            _run_auto_refine(session_id, cleanup_session_notes=True)
         except Exception:
             logger.exception("refine auto session-end hook failed")
         finally:

--- a/journal.py
+++ b/journal.py
@@ -190,12 +190,18 @@ def add_prompt_note(note: Dict[str, str]) -> Dict[str, Any]:
         return {"success": True, "note_id": safe_note["id"]}
 
 
-def clear_session_prompt_notes(session_id: str) -> Optional[int]:
-    """Remove all notes scoped to one ended/reset session; None means no mutation occurred."""
+def clear_session_prompt_notes(
+    session_id: str, *, timeout: float = 30.0
+) -> Optional[int]:
+    """Remove all notes scoped to one ended/reset session; None means no mutation occurred.
+
+    Host callbacks pass a short ``timeout`` so a running refine pass cannot stall
+    the user's session-end or session-reset path behind the mutation lock.
+    """
     safe_session_id = normalize_prompt_note_session_id(session_id)
     if not safe_session_id:
         return None
-    with mutation_lock():
+    with mutation_lock(timeout=timeout):
         notes = _load_prompt_notes()
         if notes is None:
             return None
@@ -262,8 +268,18 @@ def _try_clear_stale_lock(path: Path) -> None:
 
 @contextmanager
 def _acquire_mutation_lock(*, wait: bool, timeout: float = 0.0) -> Iterator[bool]:
-    """Acquire the re-entrant thread/process lock, optionally without waiting."""
-    if not _THREAD_LOCK.acquire(blocking=wait):
+    """Acquire the re-entrant thread/process lock, optionally without waiting.
+
+    ``timeout`` bounds the whole acquisition, in-process contention included.
+    Bounding only the lock file would let a caller on a host callback thread wait
+    forever behind another thread of the same process.
+    """
+    deadline = time.monotonic() + timeout
+    if wait:
+        acquired_thread = _THREAD_LOCK.acquire(timeout=timeout if timeout > 0 else -1)
+    else:
+        acquired_thread = _THREAD_LOCK.acquire(blocking=False)
+    if not acquired_thread:
         yield False
         return
     try:
@@ -279,7 +295,6 @@ def _acquire_mutation_lock(*, wait: bool, timeout: float = 0.0) -> Iterator[bool
         lock_path = ensure_dirs() / _LOCK_FILE_NAME
         token = uuid.uuid4().hex
         payload = json.dumps({"pid": os.getpid(), "created": time.time(), "token": token})
-        deadline = time.monotonic() + timeout
         while True:
             try:
                 fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
@@ -330,7 +345,7 @@ def _acquire_mutation_lock(*, wait: bool, timeout: float = 0.0) -> Iterator[bool
 def mutation_lock(timeout: float = 30.0) -> Iterator[None]:
     """Serialize refine mutations across threads and processes."""
     with _acquire_mutation_lock(wait=True, timeout=timeout) as acquired:
-        if not acquired:  # Defensive: blocking acquisition always either succeeds or raises.
+        if not acquired:  # Another thread of this process still owns the lock.
             raise TimeoutError("Timed out waiting for refine mutation lock")
         yield
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -348,6 +348,9 @@ class RefineTests(unittest.TestCase):
         self.temp = tempfile.TemporaryDirectory()
         self.root = Path(self.temp.name)
         FakeHost.reset(self.root)
+        # Turn marks are process-lifetime state keyed by session id; clear them so
+        # one test's attempt point cannot suppress the next test's trigger.
+        plugin_init._AUTO_TURN_MARKS.clear()
 
     def tearDown(self):
         self.temp.cleanup()
@@ -1029,6 +1032,39 @@ class RefineTests(unittest.TestCase):
             plugin_init._on_post_llm_call("session", history * 2)
         self.assertEqual(refine.call_count, 1)
 
+    def test_turn_trigger_fires_when_a_turn_adds_several_assistant_messages(self):
+        FakeHost.entry_config().update({"auto_enabled": True, "auto_turn_interval": 3})
+        called = threading.Event()
+
+        def run(**kwargs):
+            called.set()
+            return {"success": True}
+
+        with patch.object(plugin_init.core, "refine_run", side_effect=run) as refine:
+            # One tool-using host turn appends several assistant messages, so the
+            # count steps over the interval instead of landing on a multiple.
+            plugin_init._on_post_llm_call("session", [{"role": "assistant"}] * 2)
+            self.assertFalse(called.wait(0.05))
+            plugin_init._on_post_llm_call("session", [{"role": "assistant"}] * 4)
+            self.assertTrue(called.wait(1))
+            deadline = time.monotonic() + 1
+            while plugin_init._AUTO_THREAD_GUARD.locked() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertFalse(plugin_init._AUTO_THREAD_GUARD.locked())
+            # The attempt is charged to turn 4, so the next one waits for turn 7.
+            plugin_init._on_post_llm_call("session", [{"role": "assistant"}] * 6)
+            time.sleep(0.05)
+            self.assertEqual(refine.call_count, 1)
+            plugin_init._on_post_llm_call("session", [{"role": "assistant"}] * 9)
+            deadline = time.monotonic() + 1
+            while refine.call_count < 2 and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertEqual(refine.call_count, 2)
+            deadline = time.monotonic() + 1
+            while plugin_init._AUTO_THREAD_GUARD.locked() and time.monotonic() < deadline:
+                time.sleep(0.01)
+        self.assertFalse(plugin_init._AUTO_THREAD_GUARD.locked())
+
     def test_auto_cooldown_reads_preexisting_durable_journal_record(self):
         FakeHost.entry_config().update({"auto_enabled": True, "auto_turn_interval": 1})
         journal.log(
@@ -1200,9 +1236,14 @@ class RefineTests(unittest.TestCase):
         with patch.object(plugin_init.journal, "try_mutation_lock", observing_try_lock), patch.object(
             plugin_init.core, "refine_run"
         ) as refine, journal.mutation_lock():
-            history = [{"role": "assistant"}]
-            plugin_init._on_post_llm_call("session", history)
-            plugin_init._on_post_llm_call("session", history)
+            # Both calls must clear the turn gate so each really attempts the
+            # lock; a second attempt has to be skipped, never blocked or queued.
+            plugin_init._on_post_llm_call("session", [{"role": "assistant"}])
+            self.assertTrue(attempted.wait(1))
+            self.assertTrue(finished.wait(1))
+            attempted.clear()
+            finished.clear()
+            plugin_init._on_post_llm_call("session", [{"role": "assistant"}] * 2)
             self.assertTrue(attempted.wait(1))
             self.assertTrue(finished.wait(1))
         refine.assert_not_called()
@@ -1515,8 +1556,8 @@ class RefineTests(unittest.TestCase):
         cleared = threading.Event()
         original_clear = journal.clear_session_prompt_notes
 
-        def observe_clear(session_id):
-            result = original_clear(session_id)
+        def observe_clear(session_id, **kwargs):
+            result = original_clear(session_id, **kwargs)
             cleared.set()
             return result
 
@@ -1539,6 +1580,61 @@ class RefineTests(unittest.TestCase):
         self.assertNotIn(
             "reset request", plugin_init._on_pre_llm_call(session_id="session")["context"]
         )
+
+    def test_prompt_notes_still_inject_while_a_refine_pass_owns_the_lock(self):
+        policy = "When retrying a locked request, verify the endpoint."
+        self.assertTrue(self.run_proposal(prompt_proposal(policy))["success"])
+        held = threading.Event()
+        release = threading.Event()
+
+        def hold():
+            with journal.mutation_lock():
+                held.set()
+                release.wait(10)
+
+        holder = threading.Thread(target=hold, daemon=True)
+        holder.start()
+        try:
+            self.assertTrue(held.wait(2))
+            injected = plugin_init._on_pre_llm_call(session_id="session")
+        finally:
+            release.set()
+            holder.join(10)
+        self.assertEqual(injected, {"context": f"Refine notes:\n- {policy}"})
+
+    def test_host_callbacks_do_not_wait_out_the_full_lock_timeout(self):
+        FakeHost.entry_config()["prompt_notes_default_scope"] = "session"
+        policy = "When retrying a blocked request, verify its response."
+        self.assertTrue(
+            self.run_proposal(prompt_proposal(policy), session_id="session")["success"]
+        )
+        held = threading.Event()
+        release = threading.Event()
+
+        def hold():
+            with journal.mutation_lock():
+                held.set()
+                release.wait(30)
+
+        holder = threading.Thread(target=hold, daemon=True)
+        holder.start()
+        try:
+            self.assertTrue(held.wait(2))
+            # In-process contention must honour the timeout, not block forever.
+            with self.assertRaises(TimeoutError):
+                with journal.mutation_lock(timeout=0.2):
+                    pass
+            started = time.monotonic()
+            plugin_init._on_session_reset(session_id="session")
+            elapsed = time.monotonic() - started
+        finally:
+            release.set()
+            holder.join(30)
+        self.assertLess(elapsed, plugin_init._HOST_PATH_LOCK_TIMEOUT + 2)
+        # The note survives a skipped cleanup and is removed on the next reset.
+        self.assertIn(policy, plugin_init._on_pre_llm_call(session_id="session")["context"])
+        plugin_init._on_session_reset(session_id="session")
+        self.assertIsNone(plugin_init._on_pre_llm_call(session_id="session"))
 
     def test_session_scoped_prompt_note_rejects_missing_or_unsafe_identity(self):
         proposal = prompt_proposal("When retrying a scoped request, verify its target.")


### PR DESCRIPTION
Review of the Prime-ideas port (PR #2). Four defects the suite did not cover, each
now reproduced by a test that failed before the fix.

## Fixed

**1. Turn trigger could silently never fire (high).**
`_auto_refine_allowed` required `assistant_turns % interval == 0`. One
tool-using host turn appends several assistant messages, so the count steps over
the boundary. Probed with interval 3 and counts 2/4/8/10: zero attempts. Now the
trigger compares the count against the point where this session last attempted a
pass, and charges the attempt to that point so it still cannot retry every turn.

**2. Prompt notes were dropped for whole turns (medium).**
`pre_llm_call` returned `None` whenever `try_mutation_lock` failed, i.e. for
the entire duration of every background refine pass -- exactly when auto
refinement is on. The store is only ever replaced atomically, so the read no
longer depends on the lock.

**3. `mutation_lock(timeout=...)` did not bound in-process contention (medium).**
Only the lock-file loop honoured the timeout; `_THREAD_LOCK.acquire(blocking=True)`
had none. A host callback could wait indefinitely behind another thread of the
same process. Measured: `on_session_reset` blocked 30s (the caller-visible
symptom) while another thread held the lock. The timeout now bounds the whole
acquisition, and the session-note cleanup on the `on_session_end` /
`on_session_reset` host path passes a short timeout instead of stalling the user.

**4. Worker guard could be stranded for the process lifetime (low).**
`on_session_end` set `handed_off = True` before evaluating
`_assistant_turn_count(messages)`; an exception there would have skipped
`_finish_auto_worker()` forever. That path no longer counts turns at all.

Also removes the `require_turn_interval` plumbing, constant at every call site
after fix 1.

## Tests

62 (was 59). New: `test_turn_trigger_fires_when_a_turn_adds_several_assistant_messages`,
`test_prompt_notes_still_inject_while_a_refine_pass_owns_the_lock`,
`test_host_callbacks_do_not_wait_out_the_full_lock_timeout`.
`test_held_mutation_lock_skips_concurrent_auto_triggers_without_stranding` now
advances the turn count so both attempts really reach the lock instead of the
second being filtered by the gate. `setUp` clears the per-session turn marks.
No existing test was deleted or weakened. Suite run 5x, stable. Compile check: 9 files.

## Known, not fixed in this batch

- `was_applied_recently` can never match a prompt note: validation hashes
  `name=""` while the journal stores `name=<note_id>`. The active-duplicate
  check covers the practical case, so `dedup_window_days` is simply inert for
  notes.
- Audit rows for prompt notes carry an opaque 12-hex id and run the skill-usage
  LIKE query against it, so every note reads `~0` and is listed as a removal
  candidate after 14 days.
- A contended host-path cleanup now skips instead of stalling; the note is inert
  (its session is gone) and is removed at the next end/reset for that id.
- Phase 4 identity (hook `session_id` vs `state.db` session id) is still
  assumed from the documented contract, not verified against a live Hermes.
