### PR TITLE
Refine Cycle: surface silent model failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ trajectory (state.db) → scrub → fingerprint + aggregate → signal gate
 | **1. Collect evidence** | Reads the last N messages of the selected session from `<HERMES_HOME>/state.db` with `mode=ro`. Credentials are redacted before downstream use. |
 | **2. Aggregate** | Normalizes errors to invariant shapes, records complete 12-character fingerprints, and counts recurrence within and across sessions. |
 | **3. Signal gate and reviewer** | Repeated patterns or explicit corrections reach the proposal model. If neither exists, a substantial session may receive one small, conservative reviewer call; a decline is a sanitized, journaled `no_op`. |
-| **4. LLM proposal** | Requests one structured `create`, `patch`, or `no_op` proposal. Kinds are `skill`, `memory`, and `prompt`. Every model-bound field is sanitized. Skill patches receive the current complete `SKILL.md` only when it is unchanged by scrubbing and no larger than 15,000 characters. |
+| **4. LLM proposal** | Requests one structured `create`, `patch`, or `no_op` proposal with an optional one-sentence, falsifiable `expected_outcome`. Kinds are `skill`, `memory`, and `prompt`. Every model-bound field is sanitized. The proposal output budget is derived locally from the shared 15,000-character content limit; the reviewer remains separately capped at 300 tokens. A cut-off, malformed, or reasoning-only reply is journaled as `llm_incomplete` rather than presented as a normal `no_op`. Skill patches receive the current complete `SKILL.md` only when it is unchanged by scrubbing and no larger than 15,000 characters. |
 | **5. Guardrails** | Enforces agent-created patch targets, fresh create names, content/frontmatter, prompt-note policy shape, size limits, daily budget, and recent-duplicate rejection. |
 | **6. Prepare** | Creates a durable skill backup, memory recovery metadata, or prompt-note recovery metadata, then appends and `fsync`s a `prepared` journal record before mutation. |
 | **7. Apply and reconcile** | Runs the standard host API for skills/memory (`patch` maps to host `edit`) or atomically writes the plugin-owned prompt-note store. It proves target state and records `applied`, `pending_approval`, or `error`. Host pending approvals reconcile lazily before later runs, audit, or rollback. |
@@ -214,18 +214,24 @@ removed host record without a target match becomes rejected.
 ```
 Refine-created entries (3):
 
-  name                           age     uses  recurred  verdict
-  gmail-scope-fix                12d        5        no  working
-  prisma-migrate-note             9d       ~0         —  too early
-  bash-path-hint                  3d        2       yes  did not help
+  name                           age  ver     uses  recurred  verdict
+  gmail-scope-fix                12d   v2        5        no  working
+      expects: Gmail sends stop returning insufficient_scope
+  prisma-migrate-note             9d   v1       ~0         —  too early
+      expects: —
+  bash-path-hint                  3d   v3        2       yes  did not help
+      expects: PATH errors stop appearing before shell commands
 
 Candidates for removal:
   bash-path-hint — /refine rollback 8c1d2e3f4a5b
 ```
 
 The audit deletes nothing. It prints a rollback command only for recorded
-candidates. Skills that remain unused are fed into later proposals as negative
-examples.
+candidates. Every row shows the model's sanitized expected outcome (`—` when
+omitted) alongside its observed result. Later edits of the same entry advance a
+version; version 3 or later is labelled `churning` only when the normal verdict
+would otherwise be `unclear`. Skills that remain unused are fed into later
+proposals as negative examples.
 
 ### Agent-invocable tool
 
@@ -248,6 +254,9 @@ All keys live under `plugins.entries.refine`:
 | `max_edits_per_day` | int | `3` | Maximum applied, pending, or prepared edits per UTC day. |
 | `only_agent_created` | bool | `true` | Only patch agent-created skills. |
 | `journal_dir` | path | `<HERMES_HOME>/plugins/refine` | Journal, lock, ledger, backups, and prompt notes. |
+| `overview_max_entries` | int | `40` | Existing skills and memory snippets listed per kind in a proposal prompt. |
+| `overview_max_chars` | int | `240` | Maximum characters in each structured overview or history line. |
+| `history_max_entries` | int | `20` | Recent create/patch outcomes fed back into a proposal prompt. |
 | `min_signal_required` | bool | `true` | Require a signal before the proposal call; may enable reviewer fallback. |
 | `min_pattern_count` | int | `2` | Repeats before a failure counts as a mechanical signal. |
 | `reviewer_fallback_enabled` | bool | `true` | Allow one reviewer call when the mechanical gate finds nothing. |
@@ -284,6 +293,11 @@ llm:
   responsible for the agent's whole compaction strategy and conflict with any
   real context-engine plugin. A safe integration needs an observer-only
   `VALID_HOOKS` member fired at the compaction boundary.
+- **No plugin-level reasoning-effort control:** Hermes's structured plugin call
+  exposes no provider reasoning/thinking setting. A model that returns only
+  reasoning and no final text is reported as `llm_incomplete`; pin a
+  non-reasoning model for refine with `plugins.entries.refine.llm` (`model` /
+  `provider`) under the existing trust policy when that mitigation is needed.
 - **No host approval for the prompt-note store:** it is a plugin-owned atomic
   file, not a host memory or skill write. Host-managed skill and memory changes
   still respect staged approvals and reconciliation.
@@ -361,15 +375,24 @@ refine/
 ## What gets sent to the model
 
 Refine sends sanitized aggregated error patterns, explicit correction excerpts,
-existing skill and memory names/snippets, the optional manual reason/prior-pass
-note, and up to 8,000 characters of sanitized recent trajectory to the
-configured provider. If the mechanical signal gate has no signal, the reviewer
-receives only the bounded sanitized trajectory and returns a tiny verdict. When
-a skill patch is selected, a second structured request receives the target's
-current complete `SKILL.md` only if it is safe and no larger than the shared
-15,000-character input/output limit. Unsafe or oversized current skill content
-becomes `no_op`; it is never redacted, truncated, or used to generate a
-destructive replacement.
+a bounded structured overview of existing skills (name, description, category,
+and a known local version) and memory snippets, the optional manual
+reason/prior-pass note, and up to 8,000 characters of sanitized recent
+trajectory to the configured provider. Each overview line is bounded by
+`overview_max_chars`; each kind is capped by `overview_max_entries`, with a
+visible `+N more` marker. It also sends up to `history_max_entries` of its own
+most recent create/patch outcomes, including expected outcomes, so prior results
+can inform the next proposal. Empty history sends no history block; the existing
+negative examples for unused skills remain separate.
+
+If the mechanical signal gate has no signal, the reviewer receives only the
+bounded sanitized trajectory and returns a tiny verdict. When a skill patch is
+selected, a second structured request receives the target's current complete
+`SKILL.md` only if it is safe and no larger than the shared 15,000-character
+input/output limit. The proposal budget derives from that limit locally because
+Hermes exposes no model output-limit capability. Unsafe or oversized current
+skill content becomes `no_op`; it is never redacted, truncated, or used to
+generate a destructive replacement.
 
 Credentials are redacted first, but remaining content is ordinary conversation
 or skill content. Keep `auto_enabled: false` if model-bound session analysis
@@ -383,6 +406,12 @@ must be manually initiated.
   verdicts, host errors, prompt notes, and recursively nested journal fields.
 - **Signal gate and reviewer** reject one-off noise; reviewer failures and
   malformed output decline safely without a proposal call.
+- **Incomplete model replies are visible:** a malformed, token-limited, or
+  reasoning-only reply becomes a non-budget-consuming `llm_incomplete` journal
+  outcome, never a false "nothing to propose" result.
+- **Shared proposal limit:** the proposal token budget derives from the
+  15,000-character content guardrail, while the reviewer uses its independent
+  300-token cap.
 - **Agent-created skills only** for patches; creates require a free normalized
   name and cannot use the reserved `hermes-` prefix.
 - **No autonomous skill delete** — skill deletion is used only by an explicit

--- a/README.md
+++ b/README.md
@@ -278,7 +278,12 @@ llm:
 - **No plugin-level post-compaction hook:** Hermes exposes no normal plugin hook
   for `session:compress`; that event is gateway-only. `on_session_reset` is
   used to expire session-scoped notes, not as a claim that refinement runs after
-  context compaction.
+  context compaction. The only plugin-side compaction registration,
+  `register_context_engine`, replaces Hermes's built-in `ContextCompressor` and
+  permits only one engine per install. Taking it over would make Refine Cycle
+  responsible for the agent's whole compaction strategy and conflict with any
+  real context-engine plugin. A safe integration needs an observer-only
+  `VALID_HOOKS` member fired at the compaction boundary.
 - **No host approval for the prompt-note store:** it is a plugin-owned atomic
   file, not a host memory or skill write. Host-managed skill and memory changes
   still respect staged approvals and reconciliation.

--- a/config.py
+++ b/config.py
@@ -167,6 +167,11 @@ def overview_max_chars() -> int:
     return get_int("overview_max_chars", 240, min_val=1)
 
 
+def history_max_entries() -> int:
+    """Maximum prior create/patch outcomes included in a proposal prompt."""
+    return get_int("history_max_entries", 20, min_val=1)
+
+
 def journal_dir() -> Path:
     default = hermes_home() / "plugins" / "refine"
     return Path(get_str("journal_dir", str(default)))

--- a/config.py
+++ b/config.py
@@ -157,6 +157,16 @@ def dedup_window_days() -> int:
     return get_int("dedup_window_days", 7, min_val=1)
 
 
+def overview_max_entries() -> int:
+    """Maximum existing entries of each kind included in a proposal prompt."""
+    return get_int("overview_max_entries", 40, min_val=1)
+
+
+def overview_max_chars() -> int:
+    """Maximum characters in each structured overview line."""
+    return get_int("overview_max_chars", 240, min_val=1)
+
+
 def journal_dir() -> Path:
     default = hermes_home() / "plugins" / "refine"
     return Path(get_str("journal_dir", str(default)))

--- a/core.py
+++ b/core.py
@@ -612,6 +612,36 @@ def _refine_once(
         skill_content_loader=journal.read_skill_content,
     )
     proposal = sanitize(proposal)
+    failure = scrub_text(str(proposal.get("failure", "")).strip())
+    if failure:
+        failure_messages = {
+            "truncated": "The refine proposal was cut off before it completed.",
+            "malformed": "The refine proposal was malformed and could not be read.",
+            "no_final_text": "The model returned no final refine proposal.",
+        }
+        failure_message = failure_messages.get(
+            failure, "The refine proposal could not be completed."
+        )
+        entry_id = _journal_nonmutation(
+            trigger=trigger,
+            reason=safe_reason or failure_message,
+            session_id=session,
+            proposal=proposal,
+            outcome="llm_incomplete",
+            error=failure_message,
+        )
+        response = {
+            "success": False,
+            "message": failure_message,
+            "llm_called": True,
+            "failure": failure,
+            "proposal": proposal,
+            "evidence": evidence,
+            "reversible": False,
+        }
+        if entry_id:
+            response["journal_id"] = entry_id
+        return response
     if proposal.get("kind") == "prompt":
         scope = config.prompt_notes_default_scope()
         proposal = dict(

--- a/core.py
+++ b/core.py
@@ -617,7 +617,9 @@ def _refine_once(
         failure_messages = {
             "truncated": "The refine proposal was cut off before it completed.",
             "malformed": "The refine proposal was malformed and could not be read.",
-            "no_final_text": "The model returned no final refine proposal.",
+            "no_final_text": (
+                "The model returned only reasoning and no final refine proposal."
+            ),
         }
         failure_message = failure_messages.get(
             failure, "The refine proposal could not be completed."

--- a/core.py
+++ b/core.py
@@ -251,20 +251,60 @@ def collect_cross_session_patterns(
 # ── host context ───────────────────────────────────────────────────────────
 
 
-def list_skill_names() -> List[str]:
+def _skill_items() -> List[Any]:
+    """Read the host's one skill listing without opening individual skills."""
     try:
         from tools.skills_tool import skills_list
 
         raw = skills_list()
         result = raw if not isinstance(raw, str) else json.loads(raw)
         skills = result.get("skills", []) if isinstance(result, dict) else result
-        return [
-            scrub_text(str(item.get("name", "")))
-            for item in skills
-            if isinstance(item, dict)
-        ]
+        return skills if isinstance(skills, list) else []
     except Exception:
         return []
+
+
+def list_skill_names() -> List[str]:
+    names: List[str] = []
+    for item in _skill_items():
+        raw_name = item.get("name", "") if isinstance(item, dict) else item
+        name = scrub_text(str(raw_name)).strip()
+        if name:
+            names.append(name)
+    return names
+
+
+def list_skill_entries() -> List[Dict[str, Any]]:
+    """Return safe host metadata with a local version when the ledger knows it."""
+    try:
+        stats = ledger.load_stats()
+    except Exception:
+        stats = {}
+    entries: List[Dict[str, Any]] = []
+    for item in _skill_items():
+        raw_name = item.get("name", "") if isinstance(item, dict) else item
+        name = scrub_text(str(raw_name)).strip()
+        if not name:
+            continue
+        entry: Dict[str, Any] = {
+            "name": name,
+            "description": scrub_text(str(item.get("description", ""))).strip()
+            if isinstance(item, dict)
+            else "",
+            "category": scrub_text(str(item.get("category", ""))).strip()
+            if isinstance(item, dict)
+            else "",
+        }
+        metadata = stats.get(name) if isinstance(stats, dict) else None
+        if isinstance(metadata, dict):
+            try:
+                version = int(metadata.get("version", 0) or 0)
+            except (TypeError, ValueError):
+                version = 0
+            if version >= 1:
+                entry["version"] = version
+        entries.append(entry)
+    return entries
 
 
 def list_memory_snippets() -> List[str]:
@@ -611,7 +651,7 @@ def _refine_once(
     proposal = _llm.propose(
         llm=llm,
         evidence_text=evidence_text,
-        existing_skills=list_skill_names(),
+        existing_skills=list_skill_entries(),
         existing_memories=list_memory_snippets(),
         error_patterns=error_patterns,
         user_corrections=[item.get("snippet", "") for item in corrections],

--- a/core.py
+++ b/core.py
@@ -544,7 +544,11 @@ def _refine_once(
                 trigger="reviewer",
                 reason=reviewer_reason,
                 session_id=session,
-                proposal={"action": "no_op", "reason": reviewer_reason},
+                proposal={
+                    "action": "no_op",
+                    "reason": reviewer_reason,
+                    "expected_outcome": "",
+                },
                 outcome="no_op",
             )
             if not reviewer_entry_id:
@@ -557,7 +561,11 @@ def _refine_once(
                     "reversible": False,
                 }
             if not reviewer.get("should_refine"):
-                proposal = {"action": "no_op", "reason": reviewer_reason}
+                proposal = {
+                    "action": "no_op",
+                    "reason": reviewer_reason,
+                    "expected_outcome": "",
+                }
                 return {
                     "success": True,
                     "message": f"No actionable improvement found. {reviewer_reason}",
@@ -576,6 +584,7 @@ def _refine_once(
             proposal = {
                 "action": "no_op",
                 "reason": f"No repeated failure (min {config.min_pattern_count()}x) and no explicit correction.",
+                "expected_outcome": "",
             }
             entry_id = _journal_nonmutation(
                 trigger=trigger,
@@ -612,6 +621,12 @@ def _refine_once(
         skill_content_loader=journal.read_skill_content,
     )
     proposal = sanitize(proposal)
+    proposal = dict(
+        proposal,
+        expected_outcome=_llm.normalize_expected_outcome(
+            proposal.get("expected_outcome")
+        ),
+    )
     failure = scrub_text(str(proposal.get("failure", "")).strip())
     if failure:
         failure_messages = {

--- a/core.py
+++ b/core.py
@@ -656,6 +656,7 @@ def _refine_once(
         error_patterns=error_patterns,
         user_corrections=[item.get("snippet", "") for item in corrections],
         unused_skills=_unused_skills_safe(),
+        refinement_history=journal.recent_refinements(config.history_max_entries()),
         purpose="refine",
         run_context=proposal_context,
         skill_content_loader=journal.read_skill_content,

--- a/journal.py
+++ b/journal.py
@@ -412,6 +412,30 @@ def entries() -> List[Dict[str, Any]]:
     return _load_entries()
 
 
+def recent_refinements(limit: int) -> List[Dict[str, Any]]:
+    """Return capped create/patch outcomes in chronological order for model feedback."""
+    try:
+        capped_limit = max(0, int(limit))
+    except (TypeError, ValueError):
+        return []
+    if not capped_limit:
+        return []
+    included_outcomes = {
+        "applied", "pending_approval", "error", "rejected", "rolled_back"
+    }
+    refinements: List[Dict[str, Any]] = []
+    for entry in entries():
+        proposal = entry.get("proposal", {})
+        if not isinstance(proposal, dict):
+            continue
+        if (
+            proposal.get("action") in ("create", "patch")
+            and entry.get("outcome") in included_outcomes
+        ):
+            refinements.append(entry)
+    return refinements[-capped_limit:]
+
+
 def last_attempt_ts(trigger: Optional[str] = None) -> Optional[float]:
     """Return the most recent durable attempt timestamp, optionally by trigger."""
     latest: Optional[float] = None

--- a/ledger.py
+++ b/ledger.py
@@ -70,13 +70,15 @@ def record_edit(
     with journal.mutation_lock():
         stats = load_stats()
         previous = stats.get(name, {})
-        created_ts = (
-            previous.get("created_ts", time.time())
-            if previous.get("journal_id") == journal_id
-            else time.time()
-        )
+        now = time.time()
+        same_edit = previous.get("journal_id") == journal_id
+        created_ts = previous.get("created_ts", now) if same_edit else now
+        previous_version = previous.get("version", 1 if previous else 0)
+        version = previous_version if same_edit else previous_version + 1
         stats[name] = {
             "created_ts": created_ts,
+            "updated_ts": now,
+            "version": version,
             "journal_id": journal_id,
             "kind": proposal.get("kind", "skill"),
             "action": proposal.get("action", ""),
@@ -190,6 +192,14 @@ def audit(current_patterns: Optional[List[Dict[str, Any]]] = None) -> List[Dict[
     for name, meta in sorted(load_stats().items()):
         created = meta.get("created_ts", 0) or now
         age_days = max(0, int((now - created) // 86400))
+        try:
+            version = max(1, int(meta.get("version", 1) or 1))
+        except (TypeError, ValueError):
+            version = 1
+        try:
+            updated_ts = float(meta.get("updated_ts", created) or created)
+        except (TypeError, ValueError):
+            updated_ts = created
         outcome = meta.get("outcome", "applied")
         fingerprint = str(meta.get("pattern_fingerprint", "") or "")
         recurred: Optional[bool] = None
@@ -226,10 +236,15 @@ def audit(current_patterns: Optional[List[Dict[str, Any]]] = None) -> List[Dict[
             else:
                 verdict = "too early" if age_days < 14 else "unclear"
 
+        if version >= 3 and verdict == "unclear":
+            verdict = "churning"
+
         rows.append({
             "name": name,
             "kind": meta.get("kind", "skill"),
             "age_days": age_days,
+            "version": version,
+            "updated_ts": updated_ts,
             "uses": uses,
             "usage_scope": usage_scope,
             "pattern_recurred": recurred,
@@ -249,7 +264,9 @@ def format_audit(rows: List[Dict[str, Any]]) -> str:
     if not rows:
         return "No refine-created skills recorded yet."
     lines = [f"Refine-created entries ({len(rows)}):", ""]
-    lines.append(f"  {'name':<28} {'age':>5}  {'uses':>7}  {'recurred':>8}  verdict")
+    lines.append(
+        f"  {'name':<28} {'age':>5}  {'ver':>3}  {'uses':>7}  {'recurred':>8}  verdict"
+    )
     for row in rows:
         scope = row.get("usage_scope")
         if row["uses"] is None:
@@ -263,7 +280,8 @@ def format_audit(rows: List[Dict[str, Any]]) -> str:
         recurred = {True: "yes", False: "no", None: "—"}[row["pattern_recurred"]]
         lines.append(
             f"  {row['name'][:28]:<28} {str(row['age_days']) + 'd':>5}  "
-            f"{uses:>7}  {recurred:>8}  {row['verdict']}"
+            f"{'v' + str(row.get('version', 1)):>3}  {uses:>7}  "
+            f"{recurred:>8}  {row['verdict']}"
         )
         expected_outcome = str(row.get("expected_outcome", "") or "—")
         lines.append(f"      expects: {expected_outcome[:57]}")

--- a/ledger.py
+++ b/ledger.py
@@ -12,9 +12,11 @@ from typing import Any, Dict, List, Optional, Tuple
 try:
     from . import journal
     from .config import journal_dir, state_db_path
+    from .sanitization import scrub_text
 except ImportError:
     import journal  # type: ignore
     from config import journal_dir, state_db_path  # noqa: F811
+    from sanitization import scrub_text  # type: ignore
 
 logger = logging.getLogger(__name__)
 _STATS_FILE_NAME = "skill_stats.json"
@@ -79,6 +81,11 @@ def record_edit(
             "kind": proposal.get("kind", "skill"),
             "action": proposal.get("action", ""),
             "pattern_fingerprint": proposal.get("pattern_fingerprint", ""),
+            "expected_outcome": (
+                scrub_text(proposal["expected_outcome"]).strip()
+                if isinstance(proposal.get("expected_outcome"), str)
+                else ""
+            ),
             "outcome": outcome,
             "pending_id": pending_id,
         }
@@ -229,6 +236,11 @@ def audit(current_patterns: Optional[List[Dict[str, Any]]] = None) -> List[Dict[
             "verdict": verdict,
             "journal_id": meta.get("journal_id", ""),
             "outcome": outcome,
+            "expected_outcome": (
+                scrub_text(meta["expected_outcome"]).strip()
+                if isinstance(meta.get("expected_outcome"), str)
+                else ""
+            ),
         })
     return rows
 
@@ -253,6 +265,8 @@ def format_audit(rows: List[Dict[str, Any]]) -> str:
             f"  {row['name'][:28]:<28} {str(row['age_days']) + 'd':>5}  "
             f"{uses:>7}  {recurred:>8}  {row['verdict']}"
         )
+        expected_outcome = str(row.get("expected_outcome", "") or "—")
+        lines.append(f"      expects: {expected_outcome[:57]}")
 
     candidates = [row for row in rows if row["verdict"] in ("unused", "did not help")]
     if candidates:

--- a/llm.py
+++ b/llm.py
@@ -18,7 +18,18 @@ except ImportError:
     from sanitization import sanitize, scrub_text  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+# A complete skill can be this large. Keep the output budget derived from the
+# same source of truth: JSON-escaped Markdown tokenizes worse than prose, and
+# under-budgeting silently truncates the proposals this limit permits.
 MAX_CONTENT_CHARS = 15000
+_CHARS_PER_TOKEN = 3
+_PROPOSAL_ENVELOPE_TOKENS = 1024
+PROPOSAL_MAX_TOKENS = (
+    MAX_CONTENT_CHARS // _CHARS_PER_TOKEN + _PROPOSAL_ENVELOPE_TOKENS
+)
+# Reviewer fallback must remain materially cheaper than a full proposal pass.
+REVIEWER_MAX_TOKENS = 300
 
 REFINE_PROPOSAL_SCHEMA: Dict[str, Any] = {
     "type": "object",
@@ -111,7 +122,7 @@ def _propose_structured(
         schema_name="refine_proposal",
         purpose="refine",
         temperature=0.0,
-        max_tokens=4096,
+        max_tokens=PROPOSAL_MAX_TOKENS,
     )
     system_prompt = scrub_text(REFINE_SYSTEM_PROMPT)
     try:
@@ -167,7 +178,7 @@ def review_fallback(llm: PluginLlm, evidence_text: str) -> Dict[str, Any]:
             schema_name="refine_reviewer",
             purpose="refine",
             temperature=0.0,
-            max_tokens=300,
+            max_tokens=REVIEWER_MAX_TOKENS,
         )
         parsed = _ensure_dict(_salvage_parsed(result))
     except Exception as exc:

--- a/llm.py
+++ b/llm.py
@@ -148,6 +148,11 @@ def _salvage_parsed(result: Any, *, requested_max_tokens: int) -> _Reply:
     output_tokens = _output_tokens(result)
     if not text:
         if output_tokens:
+            model = scrub_text(str(getattr(result, "model", "")))
+            logger.warning(
+                "Refine model returned output but no final text (model=%s)",
+                model or "unknown",
+            )
             return _Reply(
                 None,
                 "no_final_text",
@@ -254,6 +259,18 @@ def review_fallback(llm: PluginLlm, evidence_text: str) -> Dict[str, Any]:
             max_tokens=REVIEWER_MAX_TOKENS,
         )
         reply = _salvage_parsed(result, requested_max_tokens=REVIEWER_MAX_TOKENS)
+        if reply.failure:
+            rationale = (
+                "Reviewer returned no final answer."
+                if reply.failure == "no_final_text"
+                else "Reviewer unavailable or returned invalid output."
+            )
+            return {
+                "should_refine": False,
+                "rationale": rationale,
+                "instructions": "",
+                "failure": reply.failure,
+            }
         parsed = _ensure_dict(reply.parsed)
     except Exception as exc:
         logger.warning("Reviewer fallback failed: %s", scrub_text(str(exc)))

--- a/llm.py
+++ b/llm.py
@@ -13,8 +13,10 @@ from agent.plugin_llm import (
 )
 
 try:
+    from . import config
     from .sanitization import sanitize, scrub_text
 except ImportError:
+    import config  # type: ignore
     from sanitization import sanitize, scrub_text  # type: ignore
 
 logger = logging.getLogger(__name__)
@@ -353,11 +355,78 @@ def _valid_fingerprint(value: Any) -> str:
     return candidate if re.fullmatch(r"[0-9a-f]{12}", candidate) else ""
 
 
+def _overview_text(value: Any) -> str:
+    """Sanitize untrusted host metadata into one physical prompt-line value."""
+    return re.sub(r"[\x00-\x1f\x7f]+", " ", scrub_text(str(value))).strip()
+
+
+def _truncate_overview_line(value: str, limit: int) -> str:
+    """Keep a bounded line readable without leaving an incomplete escape."""
+    if len(value) <= limit:
+        return value
+    if limit <= 1:
+        return "…"
+    prefix = value[:limit - 1]
+    last_escape = prefix.rfind("\\")
+    if last_escape >= 0:
+        escape = prefix[last_escape:]
+        if escape == "\\" or (escape.startswith("\\u") and len(escape) < 6):
+            prefix = prefix[:last_escape]
+    return prefix + "…"
+
+
+def _render_overview(
+    entries: List[Any], *, entry_kind: str, max_entries: int, max_chars: int
+) -> str:
+    """Render safe, bounded existing-context entries for the proposal prompt."""
+    indent = "  " if max_chars > 2 else ""
+    text_limit = max_chars - len(indent)
+    lines: List[str] = []
+    for entry in entries[:max_entries]:
+        if entry_kind == "skill":
+            if isinstance(entry, dict):
+                name = _overview_text(entry.get("name", ""))
+                description = _overview_text(entry.get("description", ""))
+                category = _overview_text(entry.get("category", ""))
+                version = entry.get("version")
+            else:
+                name = _overview_text(entry)
+                description = ""
+                category = ""
+                version = None
+            if not name:
+                continue
+            details = [category] if category else []
+            if isinstance(version, int) and version >= 1:
+                details.append(f"v{version}")
+            line = f"[skill:{name}]"
+            if description:
+                line += f" {description}"
+            if details:
+                line += f" ({', '.join(details)})"
+        else:
+            if isinstance(entry, dict):
+                raw_snippet = entry.get("snippet", entry.get("content", ""))
+            else:
+                raw_snippet = entry
+            snippet = _overview_text(raw_snippet)
+            if not snippet:
+                continue
+            line = f"[memory] {snippet}"
+        lines.append(indent + _truncate_overview_line(line, text_limit))
+    remaining = max(0, len(entries) - max_entries)
+    if remaining:
+        lines.append(indent + _truncate_overview_line(f"… +{remaining} more", text_limit))
+    if lines:
+        return "\n".join(lines)
+    return indent + _truncate_overview_line("(none)", text_limit)
+
+
 def propose(
     llm: PluginLlm,
     evidence_text: str,
-    existing_skills: List[str],
-    existing_memories: List[str],
+    existing_skills: List[Any],
+    existing_memories: List[Any],
     *,
     error_patterns: Optional[List[Dict[str, Any]]] = None,
     user_corrections: Optional[List[str]] = None,
@@ -375,20 +444,28 @@ def propose(
     # Sanitize independently at this final model boundary even when callers have
     # already sanitized their evidence. This keeps every prompt piece safe.
     evidence_text = scrub_text(str(evidence_text))
-    existing_skills = [scrub_text(str(item)) for item in existing_skills]
-    existing_memories = [scrub_text(str(item)) for item in existing_memories]
+    existing_skills = list(existing_skills or [])
+    existing_memories = list(existing_memories or [])
     error_patterns = sanitize(error_patterns or [])
     user_corrections = [scrub_text(str(item)) for item in (user_corrections or [])]
     unused_skills = [scrub_text(str(item)) for item in (unused_skills or [])]
     run_context = scrub_text(str(run_context))
+    overview_max_entries = config.overview_max_entries()
+    overview_max_chars = config.overview_max_chars()
     del purpose  # The host purpose is fixed to the plugin's trusted purpose.
 
-    skills_list = "\n".join(
-        f"  - {name}" for name in sorted(existing_skills)[:50]
-    ) or "  (none)"
-    mems_list = "\n".join(
-        f"  - {item[:100]}" for item in existing_memories[:30]
-    ) or "  (none)"
+    skills_list = _render_overview(
+        existing_skills,
+        entry_kind="skill",
+        max_entries=overview_max_entries,
+        max_chars=overview_max_chars,
+    )
+    mems_list = _render_overview(
+        existing_memories,
+        entry_kind="memory",
+        max_entries=overview_max_entries,
+        max_chars=overview_max_chars,
+    )
     corrections = "\n".join(
         f"  - {item[:200]}" for item in user_corrections[:5]
     ) or "  (none)"

--- a/llm.py
+++ b/llm.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import re
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
 from agent.plugin_llm import (
     PluginLlm,
@@ -89,10 +89,50 @@ REVIEWER_FALLBACK_SYSTEM_PROMPT = (
 )
 
 
-def _salvage_parsed(result: Any) -> Any:
+class _Reply(NamedTuple):
+    """Structured reply plus a failure that must not be disguised as no_op."""
+
+    parsed: Optional[Dict[str, Any]]
+    failure: str = ""
+    detail: str = ""
+
+
+def _output_tokens(result: Any) -> int:
+    """Read optional host usage without requiring test doubles to expose it."""
+    usage = getattr(result, "usage", None)
+    try:
+        return max(0, int(getattr(usage, "output_tokens", 0) or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _has_incomplete_json_structure(text: str) -> bool:
+    """Detect unclosed strings/braces without attempting to repair model JSON."""
+    depth = 0
+    in_string = False
+    escaped = False
+    for char in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+    return in_string or depth > 0
+
+
+def _salvage_parsed(result: Any, *, requested_max_tokens: int) -> _Reply:
+    """Parse one reply and name incomplete output instead of returning a false no_op."""
     parsed = getattr(result, "parsed", None)
     if isinstance(parsed, dict):
-        return parsed
+        return _Reply(parsed)
     text = getattr(result, "text", "") or ""
     if isinstance(parsed, str) and not text:
         text = parsed
@@ -100,10 +140,41 @@ def _salvage_parsed(result: Any) -> Any:
         match = re.search(r"\{.*\}", text, re.S)
         if match:
             try:
-                return json.loads(match.group(0))
+                value = json.loads(match.group(0))
+                if isinstance(value, dict):
+                    return _Reply(value)
             except json.JSONDecodeError:
                 pass
-    return parsed
+    output_tokens = _output_tokens(result)
+    if not text:
+        if output_tokens:
+            return _Reply(
+                None,
+                "no_final_text",
+                "Model returned output but no final structured answer.",
+            )
+        return _Reply(None, "malformed", "Model returned no structured answer.")
+    if output_tokens >= requested_max_tokens:
+        return _Reply(
+            None,
+            "truncated",
+            "Model output reached its token limit before the proposal completed.",
+        )
+    if _has_incomplete_json_structure(text):
+        return _Reply(
+            None,
+            "truncated",
+            "Model output ended before the proposal JSON completed.",
+        )
+    return _Reply(None, "malformed", "Model returned malformed structured output.")
+
+
+def _incomplete_proposal(reply: _Reply) -> Dict[str, Any]:
+    return {
+        "action": "no_op",
+        "failure": reply.failure,
+        "reason": reply.detail,
+    }
 
 
 def _propose_structured(
@@ -131,7 +202,8 @@ def _propose_structured(
             json_schema=sanitize(REFINE_PROPOSAL_SCHEMA),
             **common,
         )
-        return _salvage_parsed(result)
+        reply = _salvage_parsed(result, requested_max_tokens=PROPOSAL_MAX_TOKENS)
+        return reply.parsed or _incomplete_proposal(reply)
     except PluginLlmTrustError:
         raise
     except Exception as first_exc:
@@ -145,7 +217,8 @@ def _propose_structured(
             json_mode=True,
             **common,
         )
-        return _salvage_parsed(result)
+        reply = _salvage_parsed(result, requested_max_tokens=PROPOSAL_MAX_TOKENS)
+        return reply.parsed or _incomplete_proposal(reply)
 
 
 def _ensure_dict(parsed: Any) -> Optional[Dict[str, Any]]:
@@ -180,7 +253,8 @@ def review_fallback(llm: PluginLlm, evidence_text: str) -> Dict[str, Any]:
             temperature=0.0,
             max_tokens=REVIEWER_MAX_TOKENS,
         )
-        parsed = _ensure_dict(_salvage_parsed(result))
+        reply = _salvage_parsed(result, requested_max_tokens=REVIEWER_MAX_TOKENS)
+        parsed = _ensure_dict(reply.parsed)
     except Exception as exc:
         logger.warning("Reviewer fallback failed: %s", scrub_text(str(exc)))
         parsed = None
@@ -320,6 +394,8 @@ def propose(
         )
         if parsed is None:
             return {"action": "no_op", "reason": "LLM returned non-object output"}
+        if parsed.get("failure"):
+            return sanitize(parsed)
 
         action, kind, name, content, category = _normalize_fields(parsed)
         if action == "create" and not content:
@@ -328,6 +404,8 @@ def propose(
                 _propose_structured(llm, short, [PluginLlmTextInput(text=retry_text)])
             )
             if retry is not None:
+                if retry.get("failure"):
+                    return sanitize(retry)
                 parsed = retry
                 action, kind, name, content, category = _normalize_fields(parsed)
 
@@ -389,6 +467,8 @@ def propose(
             )
             if retry is None:
                 return {"action": "no_op", "reason": "LLM did not return a complete skill replacement"}
+            if retry.get("failure"):
+                return sanitize(retry)
             retry_action, retry_kind, retry_name, retry_content, retry_category = _normalize_fields(retry)
             if (retry_action, retry_kind, retry_name) != ("patch", "skill", name) or not retry_content:
                 return {"action": "no_op", "reason": "Patch retry changed target or omitted complete content"}

--- a/llm.py
+++ b/llm.py
@@ -422,6 +422,39 @@ def _render_overview(
     return indent + _truncate_overview_line("(none)", text_limit)
 
 
+def _render_refinement_history(
+    records: List[Dict[str, Any]], *, max_entries: int, max_chars: int
+) -> str:
+    """Render durable edit outcomes as safe, bounded model feedback."""
+    if not records:
+        return ""
+    indent = "  " if max_chars > 2 else ""
+    text_limit = max_chars - len(indent)
+    lines: List[str] = []
+    for record in records[-max_entries:]:
+        proposal = record.get("proposal", {})
+        if not isinstance(proposal, dict):
+            continue
+        outcome = _overview_text(record.get("outcome", "")) or "unknown"
+        kind = _overview_text(proposal.get("kind", "")) or "—"
+        name = _overview_text(proposal.get("name", "")) or "—"
+        reason = _overview_text(record.get("reason", "")) or _overview_text(
+            proposal.get("reason", "")
+        ) or "—"
+        expected = _overview_text(proposal.get("expected_outcome", "")) or "—"
+        try:
+            version = int(record.get("version", proposal.get("version", 0)) or 0)
+        except (TypeError, ValueError):
+            version = 0
+        version_text = f"v{version}" if version >= 1 else "—"
+        line = (
+            f"{outcome:<10} — expects: {expected} — {kind:<6} {name} "
+            f"{version_text} — reason: {reason}"
+        )
+        lines.append(indent + _truncate_overview_line(line, text_limit))
+    return "\n".join(lines)
+
+
 def propose(
     llm: PluginLlm,
     evidence_text: str,
@@ -431,6 +464,7 @@ def propose(
     error_patterns: Optional[List[Dict[str, Any]]] = None,
     user_corrections: Optional[List[str]] = None,
     unused_skills: Optional[List[str]] = None,
+    refinement_history: Optional[List[Dict[str, Any]]] = None,
     purpose: str = "refine",
     run_context: str = "",
     skill_content_loader: Optional[Callable[[str], Optional[str]]] = None,
@@ -449,9 +483,11 @@ def propose(
     error_patterns = sanitize(error_patterns or [])
     user_corrections = [scrub_text(str(item)) for item in (user_corrections or [])]
     unused_skills = [scrub_text(str(item)) for item in (unused_skills or [])]
+    refinement_history = sanitize(refinement_history or [])
     run_context = scrub_text(str(run_context))
     overview_max_entries = config.overview_max_entries()
     overview_max_chars = config.overview_max_chars()
+    history_max_entries = config.history_max_entries()
     del purpose  # The host purpose is fixed to the plugin's trusted purpose.
 
     skills_list = _render_overview(
@@ -476,6 +512,16 @@ def propose(
             + "\n".join(f"  - {name}" for name in unused_skills[:10])
             + "\nDo not create more skills of this ineffective shape.\n"
         )
+    history_lines = _render_refinement_history(
+        refinement_history,
+        max_entries=history_max_entries,
+        max_chars=overview_max_chars,
+    )
+    history_block = (
+        "\n=== PREVIOUS REFINEMENTS ===\n" + history_lines + "\n"
+        if history_lines
+        else ""
+    )
     context_block = run_context.strip() or "(none)"
     instructions = (
         "Ground the proposal in one repeated failure or explicit correction.\n\n"
@@ -489,7 +535,8 @@ def propose(
         f"{skills_list}\n\n"
         "=== EXISTING MEMORIES ===\n"
         f"{mems_list}\n"
-        f"{unused_block}\n"
+        f"{unused_block}"
+        f"{history_block}\n"
         "=== RECENT TRAJECTORY ===\n"
         f"{evidence_text[-8000:]}\n\n"
         "Return one JSON object. Copy the full 12-character fp exactly when applicable."

--- a/llm.py
+++ b/llm.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 # same source of truth: JSON-escaped Markdown tokenizes worse than prose, and
 # under-budgeting silently truncates the proposals this limit permits.
 MAX_CONTENT_CHARS = 15000
+MAX_EXPECTED_OUTCOME_CHARS = 300
 _CHARS_PER_TOKEN = 3
 _PROPOSAL_ENVELOPE_TOKENS = 1024
 PROPOSAL_MAX_TOKENS = (
@@ -43,6 +44,10 @@ REFINE_PROPOSAL_SCHEMA: Dict[str, Any] = {
         },
         "category": {"type": "string"},
         "reason": {"type": "string"},
+        "expected_outcome": {
+            "type": "string",
+            "description": "One-sentence falsifiable prediction of what this edit should improve.",
+        },
         "evidence": {"type": "array", "items": {"type": "string"}},
         "pattern_fingerprint": {
             "type": "string",
@@ -66,7 +71,9 @@ REFINE_SYSTEM_PROMPT = (
     "exact format 'When <specific condition>, <one action>.' It must be a narrow behavioral "
     "policy, never a procedure, broad/global instruction, memory, skill, or replacement system prompt.\n"
     "7. Return no_op when no worthwhile edit exists.\n"
-    "8. Use exactly: action, kind, name, content, category, reason, evidence, and optional "
+    "8. expected_outcome is optional; when present, make it one falsifiable sentence about "
+    "what the edit should improve and how to check it. It must not restate reason.\n"
+    "9. Use exactly: action, kind, name, content, category, reason, expected_outcome, evidence, and optional "
     "pattern_fingerprint. Never combine action and kind.\n"
 )
 
@@ -304,6 +311,13 @@ def review_fallback(llm: PluginLlm, evidence_text: str) -> Dict[str, Any]:
     }
 
 
+def normalize_expected_outcome(value: Any) -> str:
+    """Return a compact, sanitized prediction or an empty optional value."""
+    if not isinstance(value, str):
+        return ""
+    return scrub_text(value).strip()[:MAX_EXPECTED_OUTCOME_CHARS]
+
+
 def _normalize_fields(parsed: Dict[str, Any]) -> Tuple[str, str, str, str, str]:
     action = str(parsed.get("action", "no_op")).strip().lower()
     for verb in ("create", "patch"):
@@ -436,6 +450,9 @@ def propose(
                 "content": "",
                 "category": "",
                 "reason": str(parsed.get("reason", "No actionable improvement found")),
+                "expected_outcome": normalize_expected_outcome(
+                    parsed.get("expected_outcome")
+                ),
                 "evidence": _ensure_list(parsed.get("evidence")),
                 "pattern_fingerprint": "",
             })
@@ -449,6 +466,9 @@ def propose(
         initial_evidence = _ensure_list(parsed.get("evidence"))
         initial_fingerprint = _valid_fingerprint(parsed.get("pattern_fingerprint"))
         initial_reason = str(parsed.get("reason", ""))
+        initial_expected_outcome = normalize_expected_outcome(
+            parsed.get("expected_outcome")
+        )
 
         if action == "patch" and kind == "skill":
             loader = skill_content_loader or _default_skill_loader
@@ -502,6 +522,10 @@ def propose(
             if "evidence" in retry:
                 initial_evidence = _ensure_list(retry.get("evidence"))
             initial_reason = str(retry.get("reason", initial_reason))
+            if "expected_outcome" in retry:
+                initial_expected_outcome = normalize_expected_outcome(
+                    retry.get("expected_outcome")
+                )
 
         result = {
             "action": action,
@@ -510,6 +534,7 @@ def propose(
             "content": content,
             "category": category,
             "reason": initial_reason,
+            "expected_outcome": initial_expected_outcome,
             "evidence": initial_evidence,
             "pattern_fingerprint": initial_fingerprint,
         }

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -812,6 +812,157 @@ class RefineTests(unittest.TestCase):
                 core.list_skill_names(), ["versioned-skill", "bare-skill"]
             )
 
+    def test_recent_refinements_filters_orders_and_caps_records(self):
+        def record(name, outcome, action="create"):
+            return journal.log(
+                trigger="test",
+                reason=f"Reason for {name}",
+                session_id="session",
+                proposal={
+                    "action": action,
+                    "kind": "skill",
+                    "name": name,
+                    "expected_outcome": f"Expected {name}",
+                },
+                outcome=outcome,
+            )
+
+        record("applied", "applied")
+        record("pending", "pending_approval")
+        record("error", "error", action="patch")
+        record("rejected", "rejected")
+        record("rolled-back", "rolled_back")
+        record("ordinary-noop", "no_op", action="no_op")
+        record("incomplete", "llm_incomplete")
+
+        refinements = journal.recent_refinements(20)
+        self.assertEqual(
+            [item["proposal"]["name"] for item in refinements],
+            ["applied", "pending", "error", "rejected", "rolled-back"],
+        )
+        self.assertEqual(
+            [item["proposal"]["name"] for item in journal.recent_refinements(2)],
+            ["rejected", "rolled-back"],
+        )
+
+    def test_refinement_history_prompt_is_bounded_sanitized_and_keeps_unused_block(self):
+        self.assertEqual(config.history_max_entries(), 20)
+        secret = "history-secret-123!"
+        journal.log(
+            trigger="test",
+            reason="Oldest history record",
+            session_id="session",
+            proposal={
+                "action": "create", "kind": "skill", "name": "oldest",
+                "expected_outcome": "Oldest expected outcome",
+            },
+            outcome="applied",
+        )
+        journal.log(
+            trigger="test",
+            reason=f'token="{secret}" must not reach the model',
+            session_id="session",
+            proposal={
+                "action": "patch", "kind": "memory", "name": "applied-memory",
+                "expected_outcome": "The applied memory outcome is visible",
+                "version": 2,
+            },
+            outcome="applied",
+        )
+        journal.log(
+            trigger="test",
+            reason="The later edit was reverted",
+            session_id="session",
+            proposal={
+                "action": "create", "kind": "skill", "name": "rolled-back",
+                "expected_outcome": "The later expected outcome is visible",
+            },
+            outcome="rolled_back",
+        )
+        journal.log(
+            trigger="test",
+            reason="not a lesson",
+            session_id="session",
+            proposal={"action": "no_op", "kind": "", "name": "ignored-noop"},
+            outcome="no_op",
+        )
+        FakeHost.entry_config().update({
+            "history_max_entries": 2,
+            "overview_max_chars": 160,
+        })
+        history = journal.recent_refinements(config.history_max_entries())
+        model = MockLlm({"action": "no_op", "reason": "none"})
+        llm.propose(
+            model,
+            "evidence",
+            [],
+            [],
+            unused_skills=["old-unused-skill"],
+            refinement_history=history,
+        )
+        prompt = model.calls[0]["input"][0].text
+        history_block = prompt.split("=== PREVIOUS REFINEMENTS ===\n", 1)[1].split(
+            "\n=== RECENT TRAJECTORY ===", 1
+        )[0]
+        self.assertNotIn("oldest", history_block)
+        self.assertNotIn("ignored-noop", history_block)
+        self.assertLess(
+            history_block.index("applied-memory"), history_block.index("rolled-back")
+        )
+        self.assertIn("expects: The applied memory outcome is visible", history_block)
+        self.assertIn("applied", history_block)
+        self.assertIn("rolled_back", history_block)
+        self.assertIn("v2", history_block)
+        self.assertNotIn(secret, prompt)
+        self.assertIn("[REDACTED]", prompt)
+        self.assertTrue(all(len(line) <= 160 for line in history_block.splitlines()))
+        long_name_block = llm._render_refinement_history(
+            [{
+                "outcome": "error",
+                "reason": "failed",
+                "proposal": {
+                    "action": "patch",
+                    "kind": "memory",
+                    "name": "memory-" + ("x" * 300),
+                    "expected_outcome": "The expected outcome remains visible.",
+                },
+            }],
+            max_entries=1,
+            max_chars=240,
+        )
+        self.assertIn("expects: The expected outcome remains visible.", long_name_block)
+        self.assertLessEqual(len(long_name_block), 240)
+        self.assertIn("=== PREVIOUS UNUSED SKILLS ===", prompt)
+        self.assertIn("old-unused-skill", prompt)
+
+    def test_empty_refinement_history_omits_its_prompt_block(self):
+        self.assertEqual(journal.recent_refinements(20), [])
+        model = MockLlm({"action": "no_op", "reason": "none"})
+        result = llm.propose(
+            model, "evidence", [], [], refinement_history=journal.recent_refinements(20)
+        )
+        self.assertEqual(result["action"], "no_op")
+        self.assertNotIn("=== PREVIOUS REFINEMENTS ===", model.calls[0]["input"][0].text)
+
+    def test_core_passes_bounded_refinement_history_to_propose(self):
+        for name in ("older", "newer"):
+            journal.log(
+                trigger="test",
+                reason=name,
+                session_id="session",
+                proposal={"action": "create", "kind": "skill", "name": name},
+                outcome="applied",
+            )
+        FakeHost.entry_config()["history_max_entries"] = 1
+        with patch.object(
+            core._llm,
+            "propose",
+            return_value={"action": "no_op", "reason": "none"},
+        ) as propose:
+            core.refine_run(MockLlm())
+        history = propose.call_args.kwargs["refinement_history"]
+        self.assertEqual([item["proposal"]["name"] for item in history], ["newer"])
+
     def test_skill_patch_gets_current_complete_content(self):
         name = "existing-skill"
         current = skill_content(name, "# Existing\n\nImportant old guidance.")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -513,6 +513,46 @@ class RefineTests(unittest.TestCase):
         self.assertTrue(genuine_noop["success"])
         self.assertEqual(journal.get_entry(genuine_noop["journal_id"])["outcome"], "no_op")
 
+    def test_reasoning_only_reply_and_reviewer_decline_are_distinct(self):
+        with self.assertLogs(llm.logger, "WARNING") as proposal_logs:
+            proposal = core.refine_run(MockLlm(MockResult(
+                None, text="", output_tokens=800, model="reasoning-test-model"
+            )))
+        self.assertFalse(proposal["success"])
+        self.assertEqual(proposal["failure"], "no_final_text")
+        self.assertIn("only reasoning", proposal["message"].lower())
+        self.assertIn("reasoning-test-model", "\n".join(proposal_logs.output))
+        self.assertFalse(FakeHost.actions)
+
+        now = time.time()
+        FakeHost.make_db([
+            ("session", "user", f"Routine context {index}", "", now - index, 1)
+            for index in range(20)
+        ])
+        FakeHost.entry_config().update({
+            "min_signal_required": True,
+            "reviewer_fallback_enabled": True,
+            "reviewer_min_messages": 20,
+        })
+        reviewer_model = MockLlm(MockResult(
+            None, text="", output_tokens=200, model="reviewer-reasoning-model"
+        ))
+        with self.assertLogs(llm.logger, "WARNING") as reviewer_logs:
+            reviewer_result = core.refine_run(reviewer_model)
+        self.assertTrue(reviewer_result["success"])
+        self.assertEqual(reviewer_result["reviewer"], "declined")
+        self.assertEqual(len(reviewer_model.calls), 1)
+        self.assertIn("no final answer", reviewer_result["message"].lower())
+        self.assertIn("reviewer-reasoning-model", "\n".join(reviewer_logs.output))
+        self.assertEqual(
+            journal.get_entry(reviewer_result["journal_id"])["outcome"], "no_op"
+        )
+
+        empty_without_output = llm.propose(
+            MockLlm(MockResult(None, text="", output_tokens=0)), "evidence", [], []
+        )
+        self.assertEqual(empty_without_output["failure"], "malformed")
+
     def test_skill_patch_gets_current_complete_content(self):
         name = "existing-skill"
         current = skill_content(name, "# Existing\n\nImportant old guidance.")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -682,6 +682,136 @@ class RefineTests(unittest.TestCase):
         self.assertIn("ver", report)
         self.assertIn("v3", report)
 
+    def test_structured_overview_is_bounded_sanitized_and_versioned(self):
+        self.assertEqual(config.overview_max_entries(), 40)
+        self.assertEqual(config.overview_max_chars(), 240)
+        FakeHost.entry_config()["overview_max_chars"] = 80
+        secret = "overview-secret-123!"
+        skills = [{
+            "name": "long-skill",
+            "description": f'api_key="{secret}" Long guidance ' + ("x" * 300),
+            "category": "integrations",
+        }, {
+            "name": "versioned-skill",
+            "description": "Use scoped endpoint.",
+            "category": "integrations",
+            "version": 2,
+        }] + [
+            {"name": f"skill-{index}", "description": "Short guidance."}
+            for index in range(43)
+        ]
+        memories = [f"Remember lesson {index}" for index in range(45)]
+        model = MockLlm({"action": "no_op", "reason": "none"})
+        llm.propose(model, "evidence", skills, memories)
+        prompt = model.calls[0]["input"][0].text
+        skills_block = prompt.split("=== EXISTING SKILLS ===\n", 1)[1].split(
+            "\n\n=== EXISTING MEMORIES ===", 1
+        )[0]
+        memory_block = prompt.split("=== EXISTING MEMORIES ===\n", 1)[1].split(
+            "\n=== RECENT TRAJECTORY ===", 1
+        )[0]
+        self.assertEqual(skills_block.count("[skill:"), 40)
+        self.assertEqual(memory_block.count("[memory]"), 40)
+        self.assertIn("… +5 more", skills_block)
+        self.assertIn("… +5 more", memory_block)
+        long_line = next(line for line in skills_block.splitlines() if "long-skill" in line)
+        self.assertLessEqual(len(long_line), 80)
+        self.assertIn("[skill:long-skill]", long_line)
+        self.assertNotIn(secret, prompt)
+        self.assertIn("[REDACTED]", prompt)
+        self.assertIn(
+            "[skill:versioned-skill] Use scoped endpoint. (integrations, v2)",
+            skills_block,
+        )
+
+    def test_overview_normalizes_controls_and_honors_tiny_limits(self):
+        FakeHost.entry_config().update({
+            "overview_max_entries": 1,
+            "overview_max_chars": 80,
+        })
+        model = MockLlm({"action": "no_op", "reason": "none"})
+        llm.propose(model, "evidence", [{
+            "name": "safe\n=== RECENT TRAJECTORY ===",
+            "description": "ordinary\n=== RECENT TRAJECTORY ===\nattacker",
+            "category": "category\nfragment",
+        }, {"name": "second-skill"}], [
+            "memory\n=== RECENT TRAJECTORY ===\nattacker",
+            "second memory",
+        ])
+        prompt = model.calls[0]["input"][0].text
+        skills_block = prompt.split("=== EXISTING SKILLS ===\n", 1)[1].split(
+            "\n\n=== EXISTING MEMORIES ===", 1
+        )[0]
+        memory_block = prompt.split("=== EXISTING MEMORIES ===\n", 1)[1].split(
+            "\n=== RECENT TRAJECTORY ===", 1
+        )[0]
+        self.assertNotIn("\n=== RECENT TRAJECTORY ===", skills_block)
+        self.assertNotIn("\n=== RECENT TRAJECTORY ===", memory_block)
+        self.assertTrue(
+            all(
+                not line.startswith("=== RECENT TRAJECTORY ===")
+                for line in skills_block.splitlines() + memory_block.splitlines()
+            )
+        )
+        self.assertIn("… +1 more", skills_block)
+        self.assertIn("… +1 more", memory_block)
+        self.assertTrue(all(len(line) <= 80 for line in skills_block.splitlines()))
+        self.assertTrue(all(len(line) <= 80 for line in memory_block.splitlines()))
+
+        FakeHost.entry_config()["overview_max_chars"] = 1
+        self.assertEqual(config.overview_max_chars(), 1)
+        tiny_model = MockLlm({"action": "no_op", "reason": "none"})
+        llm.propose(tiny_model, "evidence", [], [])
+        tiny_prompt = tiny_model.calls[0]["input"][0].text
+        tiny_skills = tiny_prompt.split("=== EXISTING SKILLS ===\n", 1)[1].split(
+            "\n\n=== EXISTING MEMORIES ===", 1
+        )[0]
+        self.assertEqual(tiny_skills, "…")
+        self.assertEqual(
+            llm._render_overview([], entry_kind="skill", max_entries=1, max_chars=1),
+            "…",
+        )
+
+    def test_skill_entries_join_ledger_versions_with_bare_name_fallback(self):
+        ledger._save_stats({"versioned-skill": {"version": 2}})
+        skills_module = sys.modules["tools.skills_tool"]
+        calls = 0
+
+        def skills_list():
+            nonlocal calls
+            calls += 1
+            return json.dumps({"skills": [
+                {
+                    "name": "versioned-skill",
+                    "description": "Use the scoped endpoint.",
+                    "category": "integrations",
+                },
+                "bare-skill",
+            ]})
+
+        with patch.object(skills_module, "skills_list", side_effect=skills_list), patch.object(
+            skills_module, "skill_view"
+        ) as skill_view:
+            entries = core.list_skill_entries()
+        self.assertEqual(calls, 1)
+        skill_view.assert_not_called()
+        self.assertEqual(entries[0]["version"], 2)
+        self.assertEqual(entries[1], {
+            "name": "bare-skill", "description": "", "category": ""
+        })
+
+        model = MockLlm({"action": "no_op", "reason": "none"})
+        llm.propose(model, "evidence", entries, [])
+        prompt = model.calls[0]["input"][0].text
+        self.assertIn("[skill:versioned-skill] Use the scoped endpoint. (integrations, v2)", prompt)
+        self.assertIn("[skill:bare-skill]", prompt)
+        self.assertNotIn("v0", prompt)
+
+        with patch.object(skills_module, "skills_list", side_effect=skills_list):
+            self.assertEqual(
+                core.list_skill_names(), ["versioned-skill", "bare-skill"]
+            )
+
     def test_skill_patch_gets_current_complete_content(self):
         name = "existing-skill"
         current = skill_content(name, "# Existing\n\nImportant old guidance.")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -618,6 +618,70 @@ class RefineTests(unittest.TestCase):
         self.assertNotIn(secret, audit["report"])
         self.assertIn("[REDACTED]", audit["report"])
 
+    def test_ledger_versions_edits_without_bumping_on_reconciliation(self):
+        name = "versioned-skill"
+        created = self.run_proposal(skill_proposal(name))
+        created_stats = ledger.load_stats()[name]
+        self.assertEqual(created_stats["version"], 1)
+        self.assertGreaterEqual(created_stats["updated_ts"], created_stats["created_ts"])
+
+        patched = self.run_proposal({
+            "action": "patch", "kind": "skill", "name": name,
+            "content": skill_content(name, "# Guidance\n\nUpdated guidance."),
+            "reason": "A repeated failure needs a narrower instruction.",
+            "evidence": [],
+        })
+        patched_stats = ledger.load_stats()[name]
+        self.assertEqual(patched_stats["version"], 2)
+        self.assertGreaterEqual(patched_stats["updated_ts"], patched_stats["created_ts"])
+
+        ledger.record_journal_state(journal.get_entry(patched["journal_id"]))
+        reconciled_stats = ledger.load_stats()[name]
+        self.assertEqual(reconciled_stats["version"], 2)
+        self.assertEqual(reconciled_stats["created_ts"], patched_stats["created_ts"])
+        self.assertGreaterEqual(
+            reconciled_stats["updated_ts"], patched_stats["updated_ts"]
+        )
+
+    def test_ledger_reports_churn_and_loads_legacy_stats(self):
+        created = time.time() - (30 * 86400)
+        ledger.stats_path().write_text(json.dumps({
+            "legacy-skill": {
+                "created_ts": created,
+                "journal_id": "legacy-entry",
+                "kind": "skill",
+                "action": "create",
+                "pattern_fingerprint": "",
+                "outcome": "applied",
+                "pending_id": "",
+            },
+            "churning-skill": {
+                "created_ts": created,
+                "updated_ts": created + 1,
+                "version": 3,
+                "journal_id": "churning-entry",
+                "kind": "skill",
+                "action": "patch",
+                "pattern_fingerprint": "",
+                "outcome": "applied",
+                "pending_id": "",
+            },
+        }), encoding="utf-8")
+        FakeHost.usage_counts["churning-skill"] = 2
+
+        rows = {row["name"]: row for row in ledger.audit([])}
+        self.assertEqual(rows["legacy-skill"]["version"], 1)
+        self.assertEqual(rows["legacy-skill"]["updated_ts"], created)
+        ledger.record_edit(
+            {"name": "legacy-skill", "kind": "skill", "action": "patch"},
+            "legacy-edit",
+        )
+        self.assertEqual(ledger.load_stats()["legacy-skill"]["version"], 2)
+        self.assertEqual(rows["churning-skill"]["verdict"], "churning")
+        report = ledger.format_audit(list(rows.values()))
+        self.assertIn("ver", report)
+        self.assertIn("v3", report)
+
     def test_skill_patch_gets_current_complete_content(self):
         name = "existing-skill"
         current = skill_content(name, "# Existing\n\nImportant old guidance.")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -547,11 +547,76 @@ class RefineTests(unittest.TestCase):
         self.assertEqual(
             journal.get_entry(reviewer_result["journal_id"])["outcome"], "no_op"
         )
+        self.assertEqual(
+            journal.get_entry(reviewer_result["journal_id"])["proposal"]["expected_outcome"],
+            "",
+        )
 
         empty_without_output = llm.propose(
             MockLlm(MockResult(None, text="", output_tokens=0)), "evidence", [], []
         )
         self.assertEqual(empty_without_output["failure"], "malformed")
+
+    def test_expected_outcome_is_normalized_persisted_and_audited(self):
+        expected_outcome = "A repeat Gmail send no longer returns insufficient scope."
+        no_op = llm.propose(MockLlm({
+            "action": "no_op", "reason": "nothing to add",
+            "expected_outcome": expected_outcome,
+        }), "evidence", [], [])
+        self.assertEqual(no_op["expected_outcome"], expected_outcome)
+
+        proposal = skill_proposal("expected-outcome")
+        proposal["expected_outcome"] = expected_outcome
+        result = self.run_proposal(proposal)
+        entry = journal.get_entry(result["journal_id"])
+        self.assertEqual(entry["proposal"]["expected_outcome"], expected_outcome)
+        self.assertEqual(
+            ledger.load_stats()["expected-outcome"]["expected_outcome"],
+            expected_outcome,
+        )
+        audit = core.refine_audit()
+        self.assertEqual(audit["rows"][0]["expected_outcome"], expected_outcome)
+        self.assertIn(f"expects: {expected_outcome}", audit["report"])
+
+    def test_missing_expected_outcome_is_accepted_and_displays_dash(self):
+        result = self.run_proposal(skill_proposal("no-expected-outcome"))
+        entry = journal.get_entry(result["journal_id"])
+        self.assertEqual(entry["proposal"]["expected_outcome"], "")
+        self.assertEqual(
+            ledger.load_stats()["no-expected-outcome"]["expected_outcome"], ""
+        )
+        audit = core.refine_audit()
+        self.assertEqual(audit["rows"][0]["expected_outcome"], "")
+        self.assertIn("expects: —", audit["report"])
+
+        now = time.time()
+        FakeHost.make_db([
+            ("session", "user", "Routine context only", "", now - 3, 1),
+            ("session", "assistant", "Routine response", "", now - 2, 1),
+            ("session", "assistant", "Still routine", "", now - 1, 1),
+        ])
+        FakeHost.entry_config().update({
+            "min_signal_required": True,
+            "reviewer_fallback_enabled": False,
+        })
+        early_no_op = core.refine_run(MockLlm())
+        self.assertEqual(
+            journal.get_entry(early_no_op["journal_id"])["proposal"]["expected_outcome"],
+            "",
+        )
+
+    def test_expected_outcome_is_capped_and_scrubbed_in_journal_and_report(self):
+        secret = "expected-outcome-secret-123!"
+        proposal = skill_proposal("scrubbed-expected-outcome")
+        proposal["expected_outcome"] = f'api_key="{secret}" ' + ("x" * 400)
+        result = self.run_proposal(proposal)
+        entry = journal.get_entry(result["journal_id"])
+        stored = entry["proposal"]["expected_outcome"]
+        self.assertLessEqual(len(stored), llm.MAX_EXPECTED_OUTCOME_CHARS)
+        self.assertNotIn(secret, stored)
+        audit = core.refine_audit()
+        self.assertNotIn(secret, audit["report"])
+        self.assertIn("[REDACTED]", audit["report"])
 
     def test_skill_patch_gets_current_complete_content(self):
         name = "existing-skill"
@@ -561,13 +626,30 @@ class RefineTests(unittest.TestCase):
         initial = {
             "action": "patch", "kind": "skill", "name": name,
             "content": "New fix only", "reason": "failure", "evidence": [],
+            "expected_outcome": "The recurring failure stops.",
         }
-        model = MockLlm(initial, dict(initial, content=replacement))
+        preserved_retry = dict(initial, content=replacement)
+        preserved_retry.pop("expected_outcome")
+        model = MockLlm(initial, preserved_retry)
         result = llm.propose(
             model, "evidence", [name], [], skill_content_loader=journal.read_skill_content
         )
         self.assertEqual(result["content"], replacement)
+        self.assertEqual(result["expected_outcome"], "The recurring failure stops.")
         self.assertIn(current, model.calls[1]["input"][0].text)
+
+        updated_model = MockLlm(initial, dict(
+            initial,
+            content=replacement,
+            expected_outcome="The specific request succeeds without retry.",
+        ))
+        updated = llm.propose(
+            updated_model, "evidence", [name], [], skill_content_loader=journal.read_skill_content
+        )
+        self.assertEqual(
+            updated["expected_outcome"],
+            "The specific request succeeds without retry.",
+        )
 
     def test_patch_maps_to_edit_and_invalid_content_never_applies(self):
         name = "patch-map"

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -435,6 +435,29 @@ class RefineTests(unittest.TestCase):
         )
         self.assertEqual(len(found), 11)
 
+    def test_proposal_and_reviewer_budgets_are_derived_and_distinct(self):
+        self.assertGreaterEqual(
+            llm.PROPOSAL_MAX_TOKENS * llm._CHARS_PER_TOKEN,
+            llm.MAX_CONTENT_CHARS,
+        )
+        self.assertLess(llm.REVIEWER_MAX_TOKENS, llm.PROPOSAL_MAX_TOKENS // 4)
+
+        proposal_model = MockLlm({"action": "no_op", "reason": "none"})
+        llm.propose(proposal_model, "evidence", [], [])
+        self.assertEqual(
+            proposal_model.calls[0]["max_tokens"], llm.PROPOSAL_MAX_TOKENS
+        )
+
+        reviewer_model = MockLlm({
+            "shouldRefine": False,
+            "rationale": "No durable lesson.",
+            "instructions": "",
+        })
+        llm.review_fallback(reviewer_model, "evidence")
+        self.assertEqual(
+            reviewer_model.calls[0]["max_tokens"], llm.REVIEWER_MAX_TOKENS
+        )
+
     def test_skill_patch_gets_current_complete_content(self):
         name = "existing-skill"
         current = skill_content(name, "# Existing\n\nImportant old guidance.")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -43,10 +43,18 @@ class PluginLlmTextInput(PluginLlmInput):
         self.text = text
 
 
+class MockUsage:
+    def __init__(self, output_tokens=0):
+        self.output_tokens = output_tokens
+
+
 class MockResult:
-    def __init__(self, parsed):
+    def __init__(self, parsed=None, *, text="", output_tokens=None, model="test-model"):
         self.parsed = parsed
-        self.text = ""
+        self.text = text
+        self.model = model
+        if output_tokens is not None:
+            self.usage = MockUsage(output_tokens)
 
 
 class PluginLlm:
@@ -67,6 +75,8 @@ class MockLlm:
         response = self.responses.pop(0) if len(self.responses) > 1 else self.responses[0]
         if isinstance(response, Exception):
             raise response
+        if isinstance(response, MockResult):
+            return response
         return MockResult(response)
 
 
@@ -457,6 +467,51 @@ class RefineTests(unittest.TestCase):
         self.assertEqual(
             reviewer_model.calls[0]["max_tokens"], llm.REVIEWER_MAX_TOKENS
         )
+
+    def test_incomplete_reply_is_journaled_distinctly_and_stops_the_run(self):
+        FakeHost.entry_config()["max_edits_per_run"] = 2
+        raw = json.dumps(skill_proposal("cut-off-proposal"))
+        model = MockLlm(MockResult(None, text=raw[:-12]))
+        result = core.refine_run(model)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["failure"], "truncated")
+        self.assertIn("cut off", result["message"].lower())
+        self.assertEqual(len(model.calls), 1)
+        self.assertFalse(FakeHost.actions)
+        self.assertEqual(journal.count_today_applied(), 0)
+        entry = journal.get_entry(result["journal_id"])
+        self.assertEqual(entry["outcome"], "llm_incomplete")
+        self.assertEqual(entry["proposal"]["failure"], "truncated")
+        self.assertFalse(journal.is_reversible(entry))
+        with patch.object(plugin_init.core, "refine_run", return_value=result):
+            self.assertIn("cut off", plugin_init._handle_refine_command("").lower())
+
+    def test_reply_parse_failures_are_not_disguised_as_noop(self):
+        malformed = core.refine_run(MockLlm(MockResult(
+            None, text='{"action":"no_op","reason": invalid}'
+        )))
+        self.assertFalse(malformed["success"])
+        self.assertEqual(malformed["failure"], "malformed")
+        self.assertEqual(
+            journal.get_entry(malformed["journal_id"])["outcome"], "llm_incomplete"
+        )
+
+        limit_hit = llm.propose(MockLlm(MockResult(
+            None,
+            text='{"action":"create"',
+            output_tokens=llm.PROPOSAL_MAX_TOKENS,
+        )), "evidence", [], [])
+        self.assertEqual(limit_hit["failure"], "truncated")
+
+        no_usage = llm.propose(MockLlm(MockResult(
+            None, text='{"action": invalid}'
+        )), "evidence", [], [])
+        self.assertEqual(no_usage["failure"], "malformed")
+
+        genuine_noop = core.refine_run(MockLlm({"action": "no_op", "reason": "none"}))
+        self.assertTrue(genuine_noop["success"])
+        self.assertEqual(journal.get_entry(genuine_noop["journal_id"])["outcome"], "no_op")
 
     def test_skill_patch_gets_current_complete_content(self):
         name = "existing-skill"


### PR DESCRIPTION
## Summary
- Derive proposal budget from the shared content limit and distinguish incomplete model replies.
- Add expected outcomes, audit versions/churn, and bounded structured overview/history feedback.
- Document reasoning and compaction integration limits.

## Validation
- python -B -m tests.run_tests (78 tests)
- compiled 9 Python files
- git diff --check

## Deliberately out of scope
- B4 multi-edit proposals
- C1 snapshot-based rollback