### PR TITLE
Refine Cycle: multi-edit transactions and snapshot rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,12 +368,20 @@ journal record, and as a `.bak` file under `journal_dir/backups`. Both come from
 one host read, so they cannot disagree. Rollback prefers the snapshot, so losing
 the backup file no longer costs the rollback.
 
-The snapshot carries a SHA-256 digest of the real pre-edit content. The journal
-redacts credentials from everything it writes, so a snapshot of a skill that
-contained a secret would come back altered; the digest makes that detectable and
-the raw `.bak` file is used instead, rather than writing redacted text over the
-skill. If neither source survives, rollback refuses with an explicit error and
-changes nothing.
+Credential scrubbing needs two layers here, because the journal redacts
+credentials from everything it writes — including a snapshot. The first layer is
+the proposal path: a skill whose current `SKILL.md` is changed by scrubbing is
+never patched at all, and the patch becomes a `no_op` before the model is
+called. The second is a SHA-256 digest of the real pre-edit content stored beside
+the snapshot. If the stored text no longer matches that digest, the snapshot is
+refused and the raw `.bak` file is used instead, so redacted text is never
+written over a skill.
+
+`is_reversible` asks the restore path the same question rollback does, so an
+entry is never advertised as reversible when neither source survives. In that
+case rollback refuses with an explicit error and changes nothing, and a staged
+rollback whose state cannot be proven stays `pending_rollback` rather than being
+declared rejected.
 
 Records written before snapshots existed carry only `backup_path` and keep
 rolling back from it unchanged.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ trajectory (state.db) → scrub → fingerprint + aggregate → signal gate
 | **1. Collect evidence** | Reads the last N messages of the selected session from `<HERMES_HOME>/state.db` with `mode=ro`. Credentials are redacted before downstream use. |
 | **2. Aggregate** | Normalizes errors to invariant shapes, records complete 12-character fingerprints, and counts recurrence within and across sessions. |
 | **3. Signal gate and reviewer** | Repeated patterns or explicit corrections reach the proposal model. If neither exists, a substantial session may receive one small, conservative reviewer call; a decline is a sanitized, journaled `no_op`. |
-| **4. LLM proposal** | Requests one structured `create`, `patch`, or `no_op` proposal with an optional one-sentence, falsifiable `expected_outcome`. Kinds are `skill`, `memory`, and `prompt`. Every model-bound field is sanitized. The proposal output budget is derived locally from the shared 15,000-character content limit; the reviewer remains separately capped at 300 tokens. A cut-off, malformed, or reasoning-only reply is journaled as `llm_incomplete` rather than presented as a normal `no_op`. Skill patches receive the current complete `SKILL.md` only when it is unchanged by scrubbing and no larger than 15,000 characters. |
-| **5. Guardrails** | Enforces agent-created patch targets, fresh create names, content/frontmatter, prompt-note policy shape, size limits, daily budget, and recent-duplicate rejection. |
-| **6. Prepare** | Creates a durable skill backup, memory recovery metadata, or prompt-note recovery metadata, then appends and `fsync`s a `prepared` journal record before mutation. |
+| **4. LLM proposal** | Requests one structured `create`, `patch`, or `no_op` proposal with an optional one-sentence, falsifiable `expected_outcome`. Kinds are `skill`, `memory`, and `prompt`. A proposal may instead carry an `edits` array of inseparable edits under one shared reason, `expected_outcome`, and `summary`. Every model-bound field is sanitized. The proposal output budget is derived locally from the shared 15,000-character content limit and scales with `max_edits_per_proposal`; the reviewer remains separately capped at 300 tokens. A cut-off, malformed, or reasoning-only reply is journaled as `llm_incomplete` rather than presented as a normal `no_op`. Skill patches receive the current complete `SKILL.md` only when it is unchanged by scrubbing and no larger than 15,000 characters. |
+| **5. Guardrails** | Enforces agent-created patch targets, fresh create names, content/frontmatter, prompt-note policy shape, size limits, daily budget, and recent-duplicate rejection. Every check runs per edit, so a later edit of a transaction is measured against the edits already applied before it. |
+| **6. Prepare** | Captures a skill's pre-edit content as both a journal snapshot and a readable `.bak` file, or memory/prompt-note recovery metadata, then appends and `fsync`s a `prepared` journal record before mutation. |
 | **7. Apply and reconcile** | Runs the standard host API for skills/memory (`patch` maps to host `edit`) or atomically writes the plugin-owned prompt-note store. It proves target state and records `applied`, `pending_approval`, or `error`. Host pending approvals reconcile lazily before later runs, audit, or rollback. |
 | **8. Rollback** | Journals `rollback_prepared` before a rollback side effect. A rollback is finalized only after target-state proof; staged host rollbacks remain `pending_rollback` until approval reconciliation. |
 
@@ -200,6 +200,37 @@ these notes. Creation, target-state proof, audit rows, and conflict-aware
 rollback are still journaled; host approval remains in force for host-managed
 skills and memory.
 
+### Multi-edit transactions
+
+Some lessons are not one edit. A new skill and the memory entry that says when to
+reach for it are inseparable: applied separately, the state between them is
+inconsistent. A proposal may therefore carry an `edits` array under one shared
+reason, `expected_outcome`, and `summary`, capped by `max_edits_per_proposal`.
+
+Durably, nothing new was invented. Each edit still gets its own journal record,
+its own recovery metadata, and its own rollback ID, tied together only by an
+additive `group` field (`id`, `index`, `size`, `summary`, and `dropped` when
+edits were discarded). That is what keeps `/refine rollback <id>`, approval
+reconciliation, dedup, and the ledger working exactly as before — and it is why
+the daily budget counts edits rather than proposals.
+
+Edits apply in order and the run stops at the first failure. A partial
+transaction is never reported as clean:
+
+- Applied and reserved edits are `applied` / `pending_approval` as usual.
+- An edit whose host write landed but whose journal finalization failed still
+  owns a recovery ID and is listed as one.
+- Edits the daily budget refused, and edits not attempted after an earlier
+  failure, are journaled as `rejected`, which consumes no budget.
+- Edits discarded while shaping the proposal — past the cap, unusable, or
+  repeating a target already claimed in the same proposal — are counted, block a
+  `completed` verdict, and are reported in `group.dropped`.
+
+So which edits of a transaction landed is readable from the journal alone, not
+only from a message that automatic runs discard.
+
+There is no `delete` action: a transaction can only create or patch.
+
 ### Auditing what refine wrote
 
 `/refine audit` reports whether refine-created entries were used and whether the
@@ -250,8 +281,9 @@ All keys live under `plugins.entries.refine`:
 | `auto_min_messages` | int | `15` | Minimum messages for session-end auto-analysis. |
 | `auto_turn_interval` | int | `25` | Assistant messages added since this session's last automatic attempt; `0` disables only the turn trigger. |
 | `auto_cooldown_minutes` | int | `20` | Minimum durable journal-derived gap between automatic attempts. |
-| `max_edits_per_run` | int | `1` | Maximum applied or reserved edits per run. |
-| `max_edits_per_day` | int | `3` | Maximum applied, pending, or prepared edits per UTC day. |
+| `max_edits_per_run` | int | `1` | Maximum proposal passes per run. |
+| `max_edits_per_proposal` | int | `3` | Maximum inseparable edits one proposal may apply as a single transaction. `1` disables transactions. |
+| `max_edits_per_day` | int | `3` | Maximum applied, pending, or prepared **edits** per UTC day. This is the blast-radius limit and is re-checked before every edit. |
 | `only_agent_created` | bool | `true` | Only patch agent-created skills. |
 | `journal_dir` | path | `<HERMES_HOME>/plugins/refine` | Journal, lock, ledger, backups, and prompt notes. |
 | `overview_max_entries` | int | `40` | Existing skills and memory snippets listed per kind in a proposal prompt. |
@@ -301,6 +333,15 @@ llm:
 - **No host approval for the prompt-note store:** it is a plugin-owned atomic
   file, not a host memory or skill write. Host-managed skill and memory changes
   still respect staged approvals and reconciliation.
+- **Rollback is not modeled as an ordinary proposal:** rolling back a skill
+  `create` means deleting it, and the no-delete guardrail rejects any proposal
+  carrying a delete. Routing rollback through the proposal path would therefore
+  need a privileged bypass of that guardrail. It would also replace the
+  `rollback_prepared` / `pending_rollback` / `rolled_back` transitions that
+  approval reconciliation and `/refine rollback <id>` idempotence depend on, and
+  break rollback for every record written before the change. Rollback keeps its
+  own path; what it gained is journal snapshots, so it no longer depends on a
+  file surviving on disk.
 
 ---
 
@@ -315,10 +356,35 @@ actually reversible:
 
 Create rollback deletes a skill only if current content still exactly matches
 the refine proposal. Patch rollback refuses to overwrite a later change before
-restoring its durable backup. Memory rollback removes only the exact appended
+restoring its pre-edit content. Memory rollback removes only the exact appended
 entry and preserves unrelated later entries. Prompt-note rollback removes only
 its exact unchanged note and preserves later notes; a changed or missing note is
 a conflict and is left untouched.
+
+### Where the restored content comes from
+
+A skill patch records its pre-edit content twice: as a `snapshot` inside the
+journal record, and as a `.bak` file under `journal_dir/backups`. Both come from
+one host read, so they cannot disagree. Rollback prefers the snapshot, so losing
+the backup file no longer costs the rollback.
+
+The snapshot carries a SHA-256 digest of the real pre-edit content. The journal
+redacts credentials from everything it writes, so a snapshot of a skill that
+contained a secret would come back altered; the digest makes that detectable and
+the raw `.bak` file is used instead, rather than writing redacted text over the
+skill. If neither source survives, rollback refuses with an explicit error and
+changes nothing.
+
+Records written before snapshots existed carry only `backup_path` and keep
+rolling back from it unchanged.
+
+### Rolling back a transaction
+
+Each edit of a multi-edit transaction owns its own journal record and its own
+rollback ID; there is no transaction-level undo. Recovery IDs are listed
+**newest first**, which is the order to follow: memory recovery is positional, so
+undoing an earlier append before a later one shifts the later entry and its
+rollback fails closed as a conflict.
 
 If mutation succeeded but journal finalization failed, the returned recovery ID
 points to the durable `prepared` record. Pending forward approvals consume budget

--- a/__init__.py
+++ b/__init__.py
@@ -259,7 +259,18 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
     if result.get("outcome") == "partial_success":
         summary = "⚠️ " + summary
     proposal = result.get("proposal", {})
-    if proposal.get("action") not in (None, "no_op"):
+    edits = proposal.get("edits")
+    if isinstance(edits, list) and edits:
+        if proposal.get("summary"):
+            summary += f"\n📝 {proposal['summary']}"
+        for edit in edits:
+            if not isinstance(edit, dict):
+                continue
+            summary += (
+                f"\n   • {edit.get('action', '?')} {edit.get('kind', '?')} "
+                f"\"{edit.get('name', '?')}\""
+            )
+    elif proposal.get("action") not in (None, "no_op"):
         summary += (
             f"\n📝 {proposal.get('action', '?')} {proposal.get('kind', '?')} "
             f"\"{proposal.get('name', '?')}\""

--- a/config.py
+++ b/config.py
@@ -107,6 +107,11 @@ def max_edits_per_run() -> int:
     return get_int("max_edits_per_run", 1, min_val=1)
 
 
+def max_edits_per_proposal() -> int:
+    """Maximum inseparable edits one proposal may apply as a single transaction."""
+    return get_int("max_edits_per_proposal", 3, min_val=1)
+
+
 def max_edits_per_day() -> int:
     return get_int("max_edits_per_day", 3, min_val=1)
 

--- a/core.py
+++ b/core.py
@@ -5,6 +5,7 @@ import logging
 import re
 import sqlite3
 import time
+import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.plugin_llm import PluginLlm
@@ -700,18 +701,24 @@ def _refine_once(
         if entry_id:
             response["journal_id"] = entry_id
         return response
-    if proposal.get("kind") == "prompt":
-        scope = config.prompt_notes_default_scope()
-        proposal = dict(
+    evidence_summary = {
+        "session_id": session,
+        "messages": len(evidence.get("messages", [])),
+        "errors": evidence.get("error_count", 0),
+    }
+
+    if proposal.get("action") == "multi":
+        transaction = _apply_transaction(
             proposal,
-            content=journal.normalize_prompt_note_content(proposal.get("content", "")),
-            scope=scope,
-            session_id=(
-                journal.normalize_prompt_note_session_id(session)
-                if scope == "session"
-                else ""
-            ),
+            trigger=trigger,
+            safe_reason=safe_reason,
+            session=session,
+            started=started,
         )
+        transaction["evidence"] = evidence_summary
+        return transaction
+
+    proposal = _normalize_edit(proposal, session)
 
     if proposal.get("action") == "no_op":
         entry_id = _journal_nonmutation(
@@ -736,6 +743,31 @@ def _refine_once(
             "reversible": False,
         }
 
+    response = _apply_edit(
+        proposal,
+        trigger=trigger,
+        safe_reason=safe_reason,
+        session=session,
+        started=started,
+    )
+    response["evidence"] = evidence_summary
+    return response
+
+
+def _apply_edit(
+    proposal: Dict[str, Any],
+    *,
+    trigger: str,
+    safe_reason: str,
+    session: str,
+    started: float,
+    group: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Validate, back up, apply, and finalize exactly one edit.
+
+    Guardrails read live host and journal state, so an edit inside a transaction
+    is checked against the edits that were already applied before it.
+    """
     guardrail_error = _validate_proposal(proposal)
     if guardrail_error:
         entry_id = _journal_nonmutation(
@@ -745,12 +777,14 @@ def _refine_once(
             proposal=proposal,
             outcome="rejected",
             error=guardrail_error,
+            group=group,
         )
         result = {
             "success": False,
             "message": f"Proposal rejected by guardrails: {guardrail_error}",
             "proposal": proposal,
             "reversible": False,
+            "edits_applied": 0,
         }
         if entry_id:
             result["record_id"] = entry_id
@@ -773,12 +807,14 @@ def _refine_once(
                 proposal=proposal,
                 outcome="error",
                 error=error,
+                group=group,
             )
             return {
                 "success": False,
                 "message": error,
                 "proposal": proposal,
                 "reversible": False,
+                "edits_applied": 0,
             }
         backup_path = str(backup)
         recovery = {"type": "skill_patch", "name": name}
@@ -799,12 +835,14 @@ def _refine_once(
                 proposal=proposal,
                 outcome="error",
                 error=error,
+                group=group,
             )
             return {
                 "success": False,
                 "message": error,
                 "proposal": proposal,
                 "reversible": False,
+                "edits_applied": 0,
             }
         proposal = dict(proposal, name=prompt_note["id"], note_id=prompt_note["id"])
         name = prompt_note["id"]
@@ -821,12 +859,14 @@ def _refine_once(
                 proposal=proposal,
                 outcome="error",
                 error=error,
+                group=group,
             )
             return {
                 "success": False,
                 "message": error,
                 "proposal": proposal,
                 "reversible": False,
+                "edits_applied": 0,
             }
         recovery = memory_recovery
 
@@ -838,6 +878,7 @@ def _refine_once(
             proposal=proposal,
             backup_path=backup_path,
             recovery=recovery,
+            group=group,
         )
     except Exception as exc:
         return {
@@ -845,6 +886,7 @@ def _refine_once(
             "message": f"Journal preparation failed; mutation aborted: {scrub_text(str(exc))}",
             "proposal": proposal,
             "reversible": False,
+            "edits_applied": 0,
         }
 
     try:
@@ -899,6 +941,10 @@ def _refine_once(
                 "result": sanitize(apply_result),
                 "backup_path": backup_path,
                 "reversible": not staged,
+                # The mutation landed and its prepared record already consumed
+                # budget, so this edit still owns a recovery id even though the
+                # run must stop.
+                "edits_applied": 1,
             }
         return {
             "success": False,
@@ -906,6 +952,7 @@ def _refine_once(
             "proposal": proposal,
             "result": sanitize(apply_result),
             "reversible": False,
+            "edits_applied": 0,
         }
 
     if outcome in ("applied", "pending_approval"):
@@ -938,17 +985,246 @@ def _refine_once(
         "reversible": bool(
             success and outcome == "applied" and journal.is_reversible(finalized)
         ),
-        "evidence": {
-            "session_id": session,
-            "messages": len(evidence.get("messages", [])),
-            "errors": evidence.get("error_count", 0),
-        },
+        "outcome": outcome,
+        # The daily budget counts edits, so a transaction reports each applied or
+        # reserved edit rather than one proposal.
+        "edits_applied": 1 if success else 0,
     }
     if success:
         response["journal_id"] = entry_id
     else:
         response["record_id"] = entry_id
     return response
+
+
+def _normalize_edit(proposal: Dict[str, Any], session: str) -> Dict[str, Any]:
+    """Apply the boundary normalization every edit needs before guardrails run."""
+    normalized = dict(
+        proposal,
+        expected_outcome=_llm.normalize_expected_outcome(
+            proposal.get("expected_outcome")
+        ),
+    )
+    if normalized.get("kind") == "prompt":
+        scope = config.prompt_notes_default_scope()
+        normalized = dict(
+            normalized,
+            content=journal.normalize_prompt_note_content(normalized.get("content", "")),
+            scope=scope,
+            session_id=(
+                journal.normalize_prompt_note_session_id(session)
+                if scope == "session"
+                else ""
+            ),
+        )
+    return normalized
+
+
+def _apply_transaction(
+    proposal: Dict[str, Any],
+    *,
+    trigger: str,
+    safe_reason: str,
+    session: str,
+    started: float,
+) -> Dict[str, Any]:
+    """Apply one multi-edit proposal as a sequence of independent durable edits.
+
+    Each edit keeps its own journal record, recovery metadata, and rollback id, so
+    the existing single-edit rollback and approval machinery is reused unchanged.
+    Edits are applied in order and the run stops at the first failure, leaving a
+    journal that states exactly which edits applied and which did not.
+    """
+    edits = [edit for edit in proposal.get("edits", []) if isinstance(edit, dict)]
+    if not edits:
+        error = "Transaction contained no usable edit"
+        _journal_nonmutation(
+            trigger=trigger,
+            reason=safe_reason or error,
+            session_id=session,
+            proposal=proposal,
+            outcome="rejected",
+            error=error,
+        )
+        return {
+            "success": False,
+            "outcome": "failed",
+            "message": error,
+            "proposal": proposal,
+            "results": [],
+            "recoveries": [],
+            "journal_ids": [],
+            "reversible": False,
+            "edits_applied": 0,
+        }
+    group_id = uuid.uuid4().hex[:12]
+    summary = scrub_text(str(proposal.get("summary", ""))).strip()[
+        : _llm.MAX_SUMMARY_CHARS
+    ]
+    shared_reason = scrub_text(str(proposal.get("reason", "")))
+    shared_expected = _llm.normalize_expected_outcome(proposal.get("expected_outcome"))
+    shared_fingerprint = str(proposal.get("pattern_fingerprint", "") or "")
+    dropped = int(proposal.get("dropped_edits", 0) or 0)
+
+    def edit_proposal(edit: Dict[str, Any]) -> Dict[str, Any]:
+        """Give one edit the transaction's shared justification, then normalize it."""
+        merged = dict(edit)
+        if not str(merged.get("reason", "")).strip():
+            merged["reason"] = shared_reason
+        if not str(merged.get("expected_outcome", "") or "").strip():
+            merged["expected_outcome"] = shared_expected
+        if not str(merged.get("pattern_fingerprint", "") or ""):
+            merged["pattern_fingerprint"] = shared_fingerprint
+        return _normalize_edit(sanitize(merged), session)
+
+    def edit_group(index: int) -> Dict[str, Any]:
+        group = {
+            "id": group_id,
+            "index": index,
+            "size": len(edits),
+            "summary": summary,
+        }
+        if dropped:
+            group["dropped"] = dropped
+        return group
+
+    results: List[Dict[str, Any]] = []
+    stop_reason = ""
+    for index, edit in enumerate(edits):
+        # Re-read the durable budget between edits: it counts edits, so a long
+        # transaction can legitimately exhaust it part way through.
+        if journal.daily_limit_reached():
+            stop_reason = (
+                f"Daily edit limit reached ({config.max_edits_per_day()}) "
+                "before this edit was attempted"
+            )
+            break
+        item = _apply_edit(
+            edit_proposal(edit),
+            trigger=trigger,
+            safe_reason=safe_reason,
+            session=session,
+            started=started,
+            group=edit_group(index),
+        )
+        results.append(item)
+        if not item.get("success"):
+            stop_reason = (
+                f"An earlier edit of transaction {group_id} did not complete"
+            )
+            break
+
+    # Every edit of a transaction leaves a durable trace, so a partial
+    # application is readable from the journal alone rather than only from a
+    # message that automatic runs discard. ``rejected`` consumes no daily budget.
+    for index in range(len(results), len(edits)):
+        _journal_nonmutation(
+            trigger=trigger,
+            reason=safe_reason,
+            session_id=session,
+            proposal=edit_proposal(edits[index]),
+            outcome="rejected",
+            error=stop_reason or "Edit was not attempted",
+            group=edit_group(index),
+        )
+
+    # "Recoverable" is deliberately wider than "successful": an edit whose host
+    # mutation landed but whose journal finalization then failed still owns a
+    # recovery id and must appear in the list the message points the user at.
+    recoverable = [item for item in results if int(item.get("edits_applied", 0) or 0)]
+    succeeded = [item for item in results if item.get("success")]
+    recoveries = _recoveries_for(recoverable)
+    skipped = len(edits) - len(results)
+    elapsed = time.time() - started
+
+    if len(succeeded) == len(edits) and not dropped:
+        success, outcome = True, "completed"
+        message = (
+            f"transaction {group_id}: {len(succeeded)} edit(s) applied or reserved "
+            f"({elapsed:.1f}s)"
+        )
+    elif recoverable:
+        success, outcome = False, "partial_success"
+        message = (
+            f"PARTIAL SUCCESS: transaction {group_id} applied or reserved "
+            f"{len(recoverable)} of {len(edits)} edit(s) and then stopped. "
+            "Use the recovery IDs listed below, newest first."
+        )
+    else:
+        success, outcome = False, "failed"
+        message = f"transaction {group_id}: no edit was applied"
+    if results and not results[-1].get("success"):
+        message += f" | stopped: {scrub_text(str(results[-1].get('message', '')))[:160]}"
+    elif skipped:
+        message += (
+            f" | stopped: daily edit limit reached ({config.max_edits_per_day()}); "
+            f"{skipped} edit(s) not attempted"
+        )
+    if dropped:
+        message += f" | {dropped} proposed edit(s) discarded before apply"
+    if summary:
+        message += f" | {summary}"
+
+    return {
+        "success": success,
+        "outcome": outcome,
+        "message": message,
+        "proposal": proposal,
+        "results": results,
+        "recoveries": recoveries,
+        "journal_ids": [item["journal_id"] for item in recoveries],
+        "reversible": any(item.get("reversible") for item in recoveries),
+        "edits_applied": len(recoverable),
+    }
+
+
+def _completed_targets(result: Dict[str, Any]) -> List[str]:
+    """Name what a pass already reserved, so the next pass cannot repeat it."""
+    items = result.get("results")
+    proposals = (
+        [
+            item.get("proposal", {})
+            for item in items
+            if isinstance(item, dict) and item.get("success")
+        ]
+        if isinstance(items, list)
+        else [result.get("proposal", {})]
+    )
+    targets: List[str] = []
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        action = scrub_text(str(proposal.get("action", "")))
+        if action in ("", "no_op", "multi"):
+            continue
+        kind = scrub_text(str(proposal.get("kind", "")))
+        name = scrub_text(str(proposal.get("name", "")))
+        targets.append(f"{action} {kind} '{name}'")
+    return targets
+
+
+def _recoveries_for(applied: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Describe every durable recovery id an applied or reserved edit left behind.
+
+    Newest first, because that is the only safe rollback order: memory recovery
+    is positional, so undoing an earlier append before a later one shifts the
+    later entry and its rollback fails closed as a conflict.
+    """
+    recoveries: List[Dict[str, Any]] = []
+    for item in reversed(applied):
+        journal_id = item.get("journal_id")
+        if not journal_id:
+            continue
+        durable = journal.get_entry(str(journal_id)) or {}
+        recovery: Dict[str, Any] = {
+            "journal_id": str(journal_id),
+            "outcome": durable.get("outcome", item.get("outcome", "unknown")),
+            "reversible": bool(item.get("reversible")),
+        }
+        if item.get("reversible"):
+            recovery["rollback_command"] = f"/refine rollback {journal_id}"
+        recoveries.append(recovery)
+    return recoveries
 
 
 def refine_run(
@@ -963,6 +1239,9 @@ def refine_run(
     with journal.mutation_lock():
         _reconcile_pending()
         runs: List[Dict[str, Any]] = []
+        # ``max_edits_per_run`` bounds proposal passes; ``max_edits_per_proposal``
+        # bounds edits inside one transaction; the daily edit budget bounds edits
+        # overall and is re-checked before every single edit.
         max_runs = max(1, config.max_edits_per_run())
         run_reason = scrub_text(reason)
         for _ in range(max_runs):
@@ -972,14 +1251,13 @@ def refine_run(
                 llm, reason=run_reason, session_id=session_id, auto=auto
             )
             runs.append(result)
-            action = result.get("proposal", {}).get("action")
-            accepted = bool(result.get("result", {}).get("success"))
-            if not result.get("success") or action in (None, "no_op") or not accepted:
+            if not result.get("success") or not int(result.get("edits_applied", 0) or 0):
                 break
-            done_name = scrub_text(str(result.get("proposal", {}).get("name", "")))
-            done_kind = scrub_text(str(result.get("proposal", {}).get("kind", "")))
+            targets = _completed_targets(result)
+            if not targets:
+                break
             note = (
-                f"Already completed or reserved {action} {done_kind} '{done_name}' in this run; "
+                f"Already completed or reserved {'; '.join(targets)} in this run; "
                 "propose a different edit or no_op."
             )
             run_reason = f"{reason}\n{note}".strip() if reason else note
@@ -996,21 +1274,15 @@ def refine_run(
 
         recoveries: List[Dict[str, Any]] = []
         for item in runs:
-            journal_id = item.get("journal_id")
-            if not journal_id or not item.get("result", {}).get("success"):
+            inner = item.get("recoveries")
+            if isinstance(inner, list) and inner:
+                recoveries.extend(inner)
                 continue
-            durable = journal.get_entry(str(journal_id)) or {}
-            recovery_item: Dict[str, Any] = {
-                "journal_id": str(journal_id),
-                "outcome": durable.get("outcome", "unknown"),
-                "reversible": bool(item.get("reversible")),
-            }
-            if item.get("reversible"):
-                recovery_item["rollback_command"] = f"/refine rollback {journal_id}"
-            recoveries.append(recovery_item)
+            if item.get("journal_id") and int(item.get("edits_applied", 0) or 0):
+                recoveries.extend(_recoveries_for([item]))
 
         failed_after_success = bool(
-            recoveries and any(not item.get("success") for item in runs[1:])
+            recoveries and any(not item.get("success") for item in runs)
         )
         last = runs[-1]
         if failed_after_success:
@@ -1037,6 +1309,7 @@ def refine_run(
             "journal_ids": [item["journal_id"] for item in recoveries],
             "evidence": runs[0].get("evidence", {}),
             "reversible": any(item.get("reversible") for item in recoveries),
+            "edits_applied": len(recoveries),
         }
         return response
 

--- a/core.py
+++ b/core.py
@@ -794,11 +794,12 @@ def _apply_edit(
     action = proposal["action"]
     name = proposal.get("name", "")
     backup_path = ""
+    snapshot: Optional[Dict[str, Any]] = None
     recovery: Dict[str, Any] = {}
     prompt_note: Optional[Dict[str, str]] = None
     if kind == "skill" and action == "patch":
-        backup = journal.backup_skill(name)
-        if backup is None:
+        captured = journal.prepare_skill_recovery(name, proposal.get("content", ""))
+        if captured is None:
             error = f"Cannot create durable backup for skill '{name}'; mutation aborted"
             _journal_nonmutation(
                 trigger=trigger,
@@ -816,7 +817,8 @@ def _apply_edit(
                 "reversible": False,
                 "edits_applied": 0,
             }
-        backup_path = str(backup)
+        backup_path = str(captured["backup_path"])
+        snapshot = captured["snapshot"]
         recovery = {"type": "skill_patch", "name": name}
     elif kind == "skill":
         recovery = {"type": "skill_create", "name": name}
@@ -879,6 +881,7 @@ def _apply_edit(
             backup_path=backup_path,
             recovery=recovery,
             group=group,
+            snapshot=snapshot,
         )
     except Exception as exc:
         return {
@@ -913,6 +916,7 @@ def _apply_edit(
             "proposal": proposal,
             "recovery": recovery,
             "backup_path": backup_path,
+            "snapshot": snapshot or {},
         }
         if not journal.target_matches_applied(prepared_entry):
             apply_result = {

--- a/core.py
+++ b/core.py
@@ -798,7 +798,7 @@ def _apply_edit(
     recovery: Dict[str, Any] = {}
     prompt_note: Optional[Dict[str, str]] = None
     if kind == "skill" and action == "patch":
-        captured = journal.prepare_skill_recovery(name, proposal.get("content", ""))
+        captured = journal.prepare_skill_recovery(name)
         if captured is None:
             error = f"Cannot create durable backup for skill '{name}'; mutation aborted"
             _journal_nonmutation(

--- a/journal.py
+++ b/journal.py
@@ -484,8 +484,9 @@ def _new_entry(
     backup_path: str = "",
     error: str = "",
     recovery: Optional[Dict[str, Any]] = None,
+    group: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    return {
+    entry = {
         "id": uuid.uuid4().hex[:12],
         "ts": time.time(),
         "trigger": trigger,
@@ -497,6 +498,12 @@ def _new_entry(
         "recovery": recovery or {},
         "error": error,
     }
+    # A multi-edit transaction stays one durable record per edit, so rollback,
+    # reconciliation, dedup, and the daily edit budget keep working unchanged.
+    # ``group`` only reports which edits belonged together.
+    if group:
+        entry["group"] = group
+    return entry
 
 
 def log(
@@ -509,6 +516,7 @@ def log(
     backup_path: str = "",
     error: str = "",
     recovery: Optional[Dict[str, Any]] = None,
+    group: Optional[Dict[str, Any]] = None,
 ) -> str:
     entry = _new_entry(
         trigger=trigger,
@@ -519,6 +527,7 @@ def log(
         backup_path=backup_path,
         error=error,
         recovery=recovery,
+        group=group,
     )
     _append_entry(entry)
     return entry["id"]
@@ -532,6 +541,7 @@ def prepare(
     proposal: Dict[str, Any],
     backup_path: str = "",
     recovery: Optional[Dict[str, Any]] = None,
+    group: Optional[Dict[str, Any]] = None,
 ) -> str:
     return log(
         trigger=trigger,
@@ -541,6 +551,7 @@ def prepare(
         outcome="prepared",
         backup_path=backup_path,
         recovery=recovery,
+        group=group,
     )
 
 

--- a/journal.py
+++ b/journal.py
@@ -485,6 +485,7 @@ def _new_entry(
     error: str = "",
     recovery: Optional[Dict[str, Any]] = None,
     group: Optional[Dict[str, Any]] = None,
+    snapshot: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     entry = {
         "id": uuid.uuid4().hex[:12],
@@ -498,6 +499,10 @@ def _new_entry(
         "recovery": recovery or {},
         "error": error,
     }
+    # Carrying the pre-edit content in the record itself is what makes rollback
+    # independent of a backup file still being on disk.
+    if snapshot:
+        entry["snapshot"] = snapshot
     # A multi-edit transaction stays one durable record per edit, so rollback,
     # reconciliation, dedup, and the daily edit budget keep working unchanged.
     # ``group`` only reports which edits belonged together.
@@ -517,6 +522,7 @@ def log(
     error: str = "",
     recovery: Optional[Dict[str, Any]] = None,
     group: Optional[Dict[str, Any]] = None,
+    snapshot: Optional[Dict[str, Any]] = None,
 ) -> str:
     entry = _new_entry(
         trigger=trigger,
@@ -528,6 +534,7 @@ def log(
         error=error,
         recovery=recovery,
         group=group,
+        snapshot=snapshot,
     )
     _append_entry(entry)
     return entry["id"]
@@ -542,6 +549,7 @@ def prepare(
     backup_path: str = "",
     recovery: Optional[Dict[str, Any]] = None,
     group: Optional[Dict[str, Any]] = None,
+    snapshot: Optional[Dict[str, Any]] = None,
 ) -> str:
     return log(
         trigger=trigger,
@@ -552,6 +560,7 @@ def prepare(
         backup_path=backup_path,
         recovery=recovery,
         group=group,
+        snapshot=snapshot,
     )
 
 
@@ -595,7 +604,7 @@ def is_reversible(entry: Optional[Dict[str, Any]]) -> bool:
     if kind == "skill" and action == "create":
         return bool(proposal.get("name") and proposal.get("content"))
     if kind == "skill" and action == "patch":
-        return bool(entry.get("backup_path"))
+        return snapshot_has_before(entry) or bool(entry.get("backup_path"))
     if kind in ("memory", "user"):
         return bool(entry.get("recovery"))
     if kind == "prompt":
@@ -700,17 +709,84 @@ def read_skill_content(name: str) -> Optional[str]:
     return content if known else None
 
 
-def backup_skill(name: str) -> Optional[Path]:
-    content = read_skill_content(name)
-    if content is None:
+def _content_digest(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8", "replace")).hexdigest()
+
+
+def prepare_skill_recovery(name: str, after: str) -> Optional[Dict[str, Any]]:
+    """Capture a skill's pre-edit state as a journal snapshot and a backup file.
+
+    One host read serves both, so the two records cannot disagree. The snapshot
+    makes rollback independent of a file surviving on disk; the ``.bak`` file
+    stays because it is human-readable and because entries journaled before
+    snapshots existed still restore from it.
+
+    ``before_sha256`` is taken from the real content. The journal scrubs
+    credentials out of everything it writes, so a snapshot of a skill that
+    contained a secret would come back altered — the digest makes that
+    detectable instead of restoring redacted text over the user's skill.
+    """
+    known, before = _read_skill_state(name)
+    if not known or before is None:
         return None
     backup = backups_dir() / f"{int(time.time() * 1000)}_skill_{name}.bak"
     try:
-        _atomic_write_text(backup, content)
+        _atomic_write_text(backup, before)
     except Exception as exc:
         logger.warning("Cannot back up skill '%s': %s", name, scrub_text(str(exc)))
         return None
-    return backup
+    return {
+        "backup_path": str(backup),
+        "snapshot": {
+            "kind": "skill",
+            "name": name,
+            "before": before,
+            "before_sha256": _content_digest(before),
+            "after_sha256": _content_digest(after),
+        },
+    }
+
+
+def _snapshot_of(entry: Dict[str, Any]) -> Dict[str, Any]:
+    snapshot = entry.get("snapshot")
+    return snapshot if isinstance(snapshot, dict) else {}
+
+
+def snapshot_has_before(entry: Dict[str, Any]) -> bool:
+    """Report whether this entry carries its own restorable pre-edit content."""
+    snapshot = _snapshot_of(entry)
+    return isinstance(snapshot.get("before"), str) and bool(
+        snapshot.get("before_sha256")
+    )
+
+
+def snapshot_before_content(entry: Dict[str, Any]) -> Optional[str]:
+    """Return the verified pre-edit content, preferring the journal snapshot.
+
+    Falls back to the backup file both for entries written before snapshots
+    existed and for a snapshot whose digest no longer matches its content.
+    """
+    snapshot = _snapshot_of(entry)
+    before = snapshot.get("before")
+    digest = str(snapshot.get("before_sha256", ""))
+    if isinstance(before, str) and digest:
+        if _content_digest(before) == digest:
+            return before
+        logger.warning(
+            "Refine journal snapshot for '%s' does not match its digest; "
+            "falling back to the backup file",
+            scrub_text(str(snapshot.get("name", ""))),
+        )
+    backup_path = Path(str(entry.get("backup_path", "")))
+    if not backup_path.is_file():
+        return None
+    try:
+        return backup_path.read_text(encoding="utf-8")
+    except Exception as exc:
+        logger.warning(
+            "Cannot read refine backup %s: %s", backup_path, scrub_text(str(exc))
+        )
+        return None
 
 
 def _memory_entries(target: str) -> Optional[List[str]]:
@@ -801,12 +877,8 @@ def rollback_target_matches(entry: Dict[str, Any]) -> Optional[bool]:
         if proposal.get("action") == "create":
             known, content = _read_skill_state(name)
             return (content is None) if known else None
-        backup_path = Path(str(entry.get("backup_path", "")))
-        if not backup_path.is_file():
-            return False
-        try:
-            expected = backup_path.read_text(encoding="utf-8")
-        except Exception:
+        expected = snapshot_before_content(entry)
+        if expected is None:
             return False
         known, current = _read_skill_state(name)
         return (current == expected) if known else None
@@ -920,10 +992,16 @@ def rollback_skill(entry_id: str) -> Dict[str, Any]:
         return {"success": False, "error": f"Rollback conflict: skill '{name}' changed after refine applied it"}
     backup_content = ""
     if action != "create":
-        backup_path = Path(str(entry.get("backup_path", "")))
-        if not backup_path.is_file():
-            return {"success": False, "error": f"Backup file not found: {backup_path}"}
-        backup_content = backup_path.read_text(encoding="utf-8")
+        restored = snapshot_before_content(entry)
+        if restored is None:
+            return {
+                "success": False,
+                "error": (
+                    f"Cannot restore skill '{name}': the journal carries no verified "
+                    "snapshot and its backup file is missing or unreadable"
+                ),
+            }
+        backup_content = restored
 
     try:
         if entry.get("outcome") != "rollback_prepared":

--- a/journal.py
+++ b/journal.py
@@ -604,7 +604,9 @@ def is_reversible(entry: Optional[Dict[str, Any]]) -> bool:
     if kind == "skill" and action == "create":
         return bool(proposal.get("name") and proposal.get("content"))
     if kind == "skill" and action == "patch":
-        return snapshot_has_before(entry) or bool(entry.get("backup_path"))
+        # Ask the restore path itself rather than checking for a path string, so
+        # "reversible" cannot promise more than rollback can actually deliver.
+        return snapshot_before_content(entry) is not None
     if kind in ("memory", "user"):
         return bool(entry.get("recovery"))
     if kind == "prompt":
@@ -713,7 +715,7 @@ def _content_digest(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8", "replace")).hexdigest()
 
 
-def prepare_skill_recovery(name: str, after: str) -> Optional[Dict[str, Any]]:
+def prepare_skill_recovery(name: str) -> Optional[Dict[str, Any]]:
     """Capture a skill's pre-edit state as a journal snapshot and a backup file.
 
     One host read serves both, so the two records cannot disagree. The snapshot
@@ -742,7 +744,6 @@ def prepare_skill_recovery(name: str, after: str) -> Optional[Dict[str, Any]]:
             "name": name,
             "before": before,
             "before_sha256": _content_digest(before),
-            "after_sha256": _content_digest(after),
         },
     }
 
@@ -750,14 +751,6 @@ def prepare_skill_recovery(name: str, after: str) -> Optional[Dict[str, Any]]:
 def _snapshot_of(entry: Dict[str, Any]) -> Dict[str, Any]:
     snapshot = entry.get("snapshot")
     return snapshot if isinstance(snapshot, dict) else {}
-
-
-def snapshot_has_before(entry: Dict[str, Any]) -> bool:
-    """Report whether this entry carries its own restorable pre-edit content."""
-    snapshot = _snapshot_of(entry)
-    return isinstance(snapshot.get("before"), str) and bool(
-        snapshot.get("before_sha256")
-    )
 
 
 def snapshot_before_content(entry: Dict[str, Any]) -> Optional[str]:
@@ -879,7 +872,11 @@ def rollback_target_matches(entry: Dict[str, Any]) -> Optional[bool]:
             return (content is None) if known else None
         expected = snapshot_before_content(entry)
         if expected is None:
-            return False
+            # Without a restore source there is nothing to compare against, so
+            # the rollback state is unknown rather than proven false. Returning
+            # False here would let ``reconcile`` declare an approved staged
+            # rollback rejected and push the record back to ``applied``.
+            return None
         known, current = _read_skill_state(name)
         return (current == expected) if known else None
     if kind in ("memory", "user"):

--- a/ledger.py
+++ b/ledger.py
@@ -67,20 +67,27 @@ def record_edit(
     name = str(proposal.get("name", "")).strip()
     if not name:
         return
+    kind = str(proposal.get("kind", "skill") or "skill")
+    # Skills keep their bare name as the key so existing statistics, the audit
+    # table, and the prompt overview keep resolving. Other kinds are namespaced,
+    # because one transaction can legitimately create a skill and a same-named
+    # memory entry, and a shared key would hide one of them from the audit.
+    key = name if kind == "skill" else f"{kind}:{name}"
     with journal.mutation_lock():
         stats = load_stats()
-        previous = stats.get(name, {})
+        previous = stats.get(key, {})
         now = time.time()
         same_edit = previous.get("journal_id") == journal_id
         created_ts = previous.get("created_ts", now) if same_edit else now
         previous_version = previous.get("version", 1 if previous else 0)
         version = previous_version if same_edit else previous_version + 1
-        stats[name] = {
+        stats[key] = {
             "created_ts": created_ts,
             "updated_ts": now,
             "version": version,
             "journal_id": journal_id,
-            "kind": proposal.get("kind", "skill"),
+            "name": name,
+            "kind": kind,
             "action": proposal.get("action", ""),
             "pattern_fingerprint": proposal.get("pattern_fingerprint", ""),
             "expected_outcome": (
@@ -189,7 +196,9 @@ def audit(current_patterns: Optional[List[Dict[str, Any]]] = None) -> List[Dict[
     }
     now = time.time()
     rows: List[Dict[str, Any]] = []
-    for name, meta in sorted(load_stats().items()):
+    for key, meta in sorted(load_stats().items()):
+        # Legacy rows have no explicit name; their key is the name.
+        name = str(meta.get("name") or key)
         created = meta.get("created_ts", 0) or now
         age_days = max(0, int((now - created) // 86400))
         try:

--- a/llm.py
+++ b/llm.py
@@ -26,11 +26,23 @@ logger = logging.getLogger(__name__)
 # under-budgeting silently truncates the proposals this limit permits.
 MAX_CONTENT_CHARS = 15000
 MAX_EXPECTED_OUTCOME_CHARS = 300
+MAX_SUMMARY_CHARS = 300
 _CHARS_PER_TOKEN = 3
 _PROPOSAL_ENVELOPE_TOKENS = 1024
-PROPOSAL_MAX_TOKENS = (
-    MAX_CONTENT_CHARS // _CHARS_PER_TOKEN + _PROPOSAL_ENVELOPE_TOKENS
-)
+
+
+def proposal_max_tokens(edit_count: int = 1) -> int:
+    """Budget output for the largest reply the content guardrail actually permits.
+
+    A transaction may carry one permitted content body per edit, so a budget
+    sized for a single edit truncates exactly the multi-edit proposals that
+    matter most. The two limits stay derived from one constant.
+    """
+    edits = max(1, int(edit_count))
+    return MAX_CONTENT_CHARS * edits // _CHARS_PER_TOKEN + _PROPOSAL_ENVELOPE_TOKENS
+
+
+PROPOSAL_MAX_TOKENS = proposal_max_tokens(1)
 # Reviewer fallback must remain materially cheaper than a full proposal pass.
 REVIEWER_MAX_TOKENS = 300
 
@@ -55,6 +67,30 @@ REFINE_PROPOSAL_SCHEMA: Dict[str, Any] = {
             "type": "string",
             "description": "Exact 12-character fp value from the repeated-failures list.",
         },
+        "summary": {
+            "type": "string",
+            "description": "One line naming the coherent change, used only with edits.",
+        },
+        "edits": {
+            "type": "array",
+            "description": (
+                "Two or more inseparable edits applied as one transaction under the "
+                "shared reason and expected_outcome. Omit entirely for a single edit."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": ["create", "patch"]},
+                    "kind": {"type": "string", "enum": ["skill", "memory", "prompt"]},
+                    "name": {"type": "string"},
+                    "content": {"type": "string"},
+                    "category": {"type": "string"},
+                    "reason": {"type": "string"},
+                    "expected_outcome": {"type": "string"},
+                },
+                "required": ["action", "kind"],
+            },
+        },
     },
     "required": ["action", "reason"],
 }
@@ -63,7 +99,9 @@ REFINE_SYSTEM_PROMPT = (
     "You are a self-improvement mechanic for an AI agent named Hermes. Read the "
     "trajectory and propose ONE evidence-grounded, minimal edit.\n\n"
     "RULES:\n"
-    "1. Return only one create, patch, or no_op proposal.\n"
+    "1. Return one create, patch, or no_op proposal. Use the edits array only when two or "
+    "more edits are inseparable, such as a new skill plus the memory entry that records "
+    "when to reach for it; never use it to batch unrelated ideas.\n"
     "2. Never guess or duplicate an existing skill, memory, or prompt note.\n"
     "3. Never edit built-in or bundled skills.\n"
     "4. For every skill create or patch, content is the COMPLETE SKILL.md, not a diff. "
@@ -77,6 +115,10 @@ REFINE_SYSTEM_PROMPT = (
     "what the edit should improve and how to check it. It must not restate reason.\n"
     "9. Use exactly: action, kind, name, content, category, reason, expected_outcome, evidence, and optional "
     "pattern_fingerprint. Never combine action and kind.\n"
+    "10. For a transaction, set edits to the full edit objects and keep reason, "
+    "expected_outcome, evidence, and summary at the top level. Every edit still obeys every "
+    "rule above, and each one is applied, journaled, and reverted on its own. There is no "
+    "delete action: never propose removing anything.\n"
 )
 
 REVIEWER_FALLBACK_SCHEMA: Dict[str, Any] = {
@@ -192,7 +234,11 @@ def _incomplete_proposal(reply: _Reply) -> Dict[str, Any]:
 
 
 def _propose_structured(
-    llm: PluginLlm, instructions: str, input_blocks: List[PluginLlmInput]
+    llm: PluginLlm,
+    instructions: str,
+    input_blocks: List[PluginLlmInput],
+    *,
+    max_tokens: int = PROPOSAL_MAX_TOKENS,
 ) -> Any:
     """Invoke the model only with recursively sanitized text inputs."""
     safe_blocks: List[PluginLlmInput] = []
@@ -207,7 +253,7 @@ def _propose_structured(
         schema_name="refine_proposal",
         purpose="refine",
         temperature=0.0,
-        max_tokens=PROPOSAL_MAX_TOKENS,
+        max_tokens=max_tokens,
     )
     system_prompt = scrub_text(REFINE_SYSTEM_PROMPT)
     try:
@@ -216,7 +262,7 @@ def _propose_structured(
             json_schema=sanitize(REFINE_PROPOSAL_SCHEMA),
             **common,
         )
-        reply = _salvage_parsed(result, requested_max_tokens=PROPOSAL_MAX_TOKENS)
+        reply = _salvage_parsed(result, requested_max_tokens=max_tokens)
         return reply.parsed or _incomplete_proposal(reply)
     except PluginLlmTrustError:
         raise
@@ -231,7 +277,7 @@ def _propose_structured(
             json_mode=True,
             **common,
         )
-        reply = _salvage_parsed(result, requested_max_tokens=PROPOSAL_MAX_TOKENS)
+        reply = _salvage_parsed(result, requested_max_tokens=max_tokens)
         return reply.parsed or _incomplete_proposal(reply)
 
 
@@ -455,6 +501,232 @@ def _render_refinement_history(
     return "\n".join(lines)
 
 
+def _finalize_edit(
+    llm: PluginLlm,
+    short: str,
+    instructions: str,
+    parsed: Dict[str, Any],
+    *,
+    skill_content_loader: Optional[Callable[[str], Optional[str]]] = None,
+    allow_content_retry: bool = True,
+) -> Dict[str, Any]:
+    """Normalize and complete exactly one edit, shared by single and multi proposals.
+
+    Returns a flat edit, a ``no_op`` with the reason it was not usable, or a
+    reply carrying ``failure`` so an incomplete sub-call is never disguised.
+    """
+    action, kind, name, content, category = _normalize_fields(parsed)
+    if allow_content_retry and action == "create" and not content:
+        retry_text = instructions + "\n\nA create requires non-empty complete content. Return it now."
+        retry = _ensure_dict(
+            _propose_structured(llm, short, [PluginLlmTextInput(text=retry_text)])
+        )
+        if retry is not None:
+            if retry.get("failure"):
+                return sanitize(retry)
+            parsed = retry
+            action, kind, name, content, category = _normalize_fields(parsed)
+
+    if action not in ("create", "patch", "no_op"):
+        return {"action": "no_op", "reason": f"Invalid action: {action}"}
+    if action == "no_op":
+        return sanitize({
+            "action": "no_op",
+            "kind": "",
+            "name": "",
+            "content": "",
+            "category": "",
+            "reason": str(parsed.get("reason", "No actionable improvement found")),
+            "expected_outcome": normalize_expected_outcome(
+                parsed.get("expected_outcome")
+            ),
+            "evidence": _ensure_list(parsed.get("evidence")),
+            "pattern_fingerprint": "",
+        })
+    if kind not in ("skill", "memory", "prompt"):
+        return {"action": "no_op", "reason": f"Invalid kind: {kind}"}
+    if not name and kind != "prompt":
+        return {"action": "no_op", "reason": "Name is required for skill and memory create/patch"}
+    if not content and not (action == "patch" and kind == "skill"):
+        return {"action": "no_op", "reason": f"{action.title()} requires non-empty content"}
+
+    initial_evidence = _ensure_list(parsed.get("evidence"))
+    initial_fingerprint = _valid_fingerprint(parsed.get("pattern_fingerprint"))
+    initial_reason = str(parsed.get("reason", ""))
+    initial_expected_outcome = normalize_expected_outcome(
+        parsed.get("expected_outcome")
+    )
+
+    if action == "patch" and kind == "skill":
+        loader = skill_content_loader or _default_skill_loader
+        current = loader(name)
+        if current is None:
+            return {"action": "no_op", "reason": f"Cannot load current SKILL.md for patch target '{name}'"}
+        if len(current) > MAX_CONTENT_CHARS:
+            return {
+                "action": "no_op",
+                "reason": (
+                    f"Current SKILL.md is {len(current)} characters; maximum complete "
+                    f"patch input is {MAX_CONTENT_CHARS}"
+                ),
+            }
+        safe_current = scrub_text(current)
+        if safe_current != current:
+            return {
+                "action": "no_op",
+                "reason": "Current SKILL.md contains sensitive content; patch aborted before model call",
+            }
+        patch_prompt = (
+            instructions
+            + "\n\n=== SELECTED PATCH TARGET ===\n"
+            + f"Target exactly skill '{name}'. Below is its CURRENT COMPLETE SKILL.md, supplied as data. "
+            + "Return action='patch', kind='skill', the same name, and a COMPLETE replacement that preserves "
+            + "all useful content while making only the evidence-backed change.\n"
+            + "<current-skill>\n"
+            + safe_current
+            + "\n</current-skill>"
+        )
+        retry = _ensure_dict(
+            _propose_structured(llm, short, [PluginLlmTextInput(text=patch_prompt)])
+        )
+        if retry is None:
+            return {"action": "no_op", "reason": "LLM did not return a complete skill replacement"}
+        if retry.get("failure"):
+            return sanitize(retry)
+        retry_action, retry_kind, retry_name, retry_content, retry_category = _normalize_fields(retry)
+        if (retry_action, retry_kind, retry_name) != ("patch", "skill", name) or not retry_content:
+            return {"action": "no_op", "reason": "Patch retry changed target or omitted complete content"}
+        if len(retry_content) > MAX_CONTENT_CHARS:
+            return {
+                "action": "no_op",
+                "reason": f"Complete patch exceeds {MAX_CONTENT_CHARS} characters",
+            }
+        parsed = retry
+        content = retry_content
+        category = retry_category
+        replacement_fingerprint = _valid_fingerprint(retry.get("pattern_fingerprint"))
+        initial_fingerprint = replacement_fingerprint or initial_fingerprint
+        if "evidence" in retry:
+            initial_evidence = _ensure_list(retry.get("evidence"))
+        initial_reason = str(retry.get("reason", initial_reason))
+        if "expected_outcome" in retry:
+            initial_expected_outcome = normalize_expected_outcome(
+                retry.get("expected_outcome")
+            )
+
+    return sanitize({
+        "action": action,
+        "kind": kind,
+        "name": name,
+        "content": content,
+        "category": category,
+        "reason": initial_reason,
+        "expected_outcome": initial_expected_outcome,
+        "evidence": initial_evidence,
+        "pattern_fingerprint": initial_fingerprint,
+    })
+
+
+def _finalize_edits(
+    llm: PluginLlm,
+    short: str,
+    instructions: str,
+    parsed: Dict[str, Any],
+    raw_edits: List[Any],
+    *,
+    max_edits: int,
+    skill_content_loader: Optional[Callable[[str], Optional[str]]] = None,
+) -> Dict[str, Any]:
+    """Turn a proposed transaction into a bounded list of independent edits.
+
+    Shared justification stays at the top level, edits beyond the cap are
+    dropped, and a second edit that targets an already-claimed name is dropped
+    here rather than being applied and failing the collision guardrail later.
+    """
+    shared_reason = str(parsed.get("reason", ""))
+    shared_expected = normalize_expected_outcome(parsed.get("expected_outcome"))
+    shared_evidence = _ensure_list(parsed.get("evidence"))
+    shared_fingerprint = _valid_fingerprint(parsed.get("pattern_fingerprint"))
+    summary = scrub_text(str(parsed.get("summary", ""))).strip()[:MAX_SUMMARY_CHARS]
+
+    edits: List[Dict[str, Any]] = []
+    claimed: set = set()
+    dropped = max(0, len(raw_edits) - max_edits)
+    for raw_edit in raw_edits[:max_edits]:
+        if not isinstance(raw_edit, dict):
+            dropped += 1
+            continue
+        candidate = dict(raw_edit)
+        if not str(candidate.get("reason", "")).strip():
+            candidate["reason"] = shared_reason
+        if not str(candidate.get("expected_outcome", "") or "").strip():
+            candidate["expected_outcome"] = shared_expected
+        if not candidate.get("evidence"):
+            candidate["evidence"] = shared_evidence
+        if not _valid_fingerprint(candidate.get("pattern_fingerprint")):
+            candidate["pattern_fingerprint"] = shared_fingerprint
+        edit = _finalize_edit(
+            llm,
+            short,
+            instructions,
+            candidate,
+            skill_content_loader=skill_content_loader,
+            # A create without content is dropped from a transaction instead of
+            # spending an extra model call per edit on a retry.
+            allow_content_retry=False,
+        )
+        if edit.get("failure"):
+            return sanitize(edit)
+        if edit.get("action") == "no_op":
+            dropped += 1
+            logger.warning(
+                "Dropping unusable edit from a refine transaction: %s",
+                scrub_text(str(edit.get("reason", "")))[:200],
+            )
+            continue
+        target = (edit["kind"], edit["name"])
+        if edit["kind"] != "prompt":
+            if target in claimed:
+                dropped += 1
+                logger.warning(
+                    "Dropping a refine transaction edit that repeats target %s",
+                    scrub_text(f"{edit['kind']}:{edit['name']}"),
+                )
+                continue
+            claimed.add(target)
+        edits.append(edit)
+
+    if dropped:
+        logger.warning(
+            "Refine transaction kept %d of %d proposed edit(s)", len(edits), len(raw_edits)
+        )
+    if not edits:
+        return {
+            "action": "no_op",
+            "reason": (
+                f"Proposed transaction contained no usable edit ({dropped} discarded)"
+            ),
+        }
+    if len(edits) == 1:
+        return sanitize(edits[0])
+    return sanitize({
+        "action": "multi",
+        "kind": "",
+        "name": "",
+        "content": "",
+        "category": "",
+        "summary": summary,
+        "reason": shared_reason,
+        "expected_outcome": shared_expected,
+        "evidence": shared_evidence,
+        "pattern_fingerprint": shared_fingerprint,
+        "edits": edits,
+        # Reported so a transaction the model called inseparable cannot be
+        # journaled as complete after part of it was discarded.
+        "dropped_edits": dropped,
+    })
+
+
 def propose(
     llm: PluginLlm,
     evidence_text: str,
@@ -488,6 +760,7 @@ def propose(
     overview_max_entries = config.overview_max_entries()
     overview_max_chars = config.overview_max_chars()
     history_max_entries = config.history_max_entries()
+    max_edits = config.max_edits_per_proposal()
     del purpose  # The host purpose is fixed to the plugin's trusted purpose.
 
     skills_list = _render_overview(
@@ -539,130 +812,45 @@ def propose(
         f"{history_block}\n"
         "=== RECENT TRAJECTORY ===\n"
         f"{evidence_text[-8000:]}\n\n"
-        "Return one JSON object. Copy the full 12-character fp exactly when applicable."
+        "Return one JSON object. Copy the full 12-character fp exactly when applicable.\n"
+        f"Prefer a single edit. Use edits only for inseparable changes, at most {max_edits}; "
+        "anything past that is discarded."
     )
     short = "Propose one minimal skill, memory, or prompt-note edit."
 
     try:
         parsed = _ensure_dict(
-            _propose_structured(llm, short, [PluginLlmTextInput(text=instructions)])
+            _propose_structured(
+                llm,
+                short,
+                [PluginLlmTextInput(text=instructions)],
+                # The first reply may legitimately carry one permitted body per edit.
+                max_tokens=proposal_max_tokens(max_edits),
+            )
         )
         if parsed is None:
             return {"action": "no_op", "reason": "LLM returned non-object output"}
         if parsed.get("failure"):
             return sanitize(parsed)
 
-        action, kind, name, content, category = _normalize_fields(parsed)
-        if action == "create" and not content:
-            retry_text = instructions + "\n\nA create requires non-empty complete content. Return it now."
-            retry = _ensure_dict(
-                _propose_structured(llm, short, [PluginLlmTextInput(text=retry_text)])
+        raw_edits = parsed.get("edits")
+        if isinstance(raw_edits, list) and raw_edits:
+            return _finalize_edits(
+                llm,
+                short,
+                instructions,
+                parsed,
+                raw_edits,
+                max_edits=max_edits,
+                skill_content_loader=skill_content_loader,
             )
-            if retry is not None:
-                if retry.get("failure"):
-                    return sanitize(retry)
-                parsed = retry
-                action, kind, name, content, category = _normalize_fields(parsed)
-
-        if action not in ("create", "patch", "no_op"):
-            return {"action": "no_op", "reason": f"Invalid action: {action}"}
-        if action == "no_op":
-            return sanitize({
-                "action": "no_op",
-                "kind": "",
-                "name": "",
-                "content": "",
-                "category": "",
-                "reason": str(parsed.get("reason", "No actionable improvement found")),
-                "expected_outcome": normalize_expected_outcome(
-                    parsed.get("expected_outcome")
-                ),
-                "evidence": _ensure_list(parsed.get("evidence")),
-                "pattern_fingerprint": "",
-            })
-        if kind not in ("skill", "memory", "prompt"):
-            return {"action": "no_op", "reason": f"Invalid kind: {kind}"}
-        if not name and kind != "prompt":
-            return {"action": "no_op", "reason": "Name is required for skill and memory create/patch"}
-        if not content and not (action == "patch" and kind == "skill"):
-            return {"action": "no_op", "reason": f"{action.title()} requires non-empty content"}
-
-        initial_evidence = _ensure_list(parsed.get("evidence"))
-        initial_fingerprint = _valid_fingerprint(parsed.get("pattern_fingerprint"))
-        initial_reason = str(parsed.get("reason", ""))
-        initial_expected_outcome = normalize_expected_outcome(
-            parsed.get("expected_outcome")
+        return _finalize_edit(
+            llm,
+            short,
+            instructions,
+            parsed,
+            skill_content_loader=skill_content_loader,
         )
-
-        if action == "patch" and kind == "skill":
-            loader = skill_content_loader or _default_skill_loader
-            current = loader(name)
-            if current is None:
-                return {"action": "no_op", "reason": f"Cannot load current SKILL.md for patch target '{name}'"}
-            if len(current) > MAX_CONTENT_CHARS:
-                return {
-                    "action": "no_op",
-                    "reason": (
-                        f"Current SKILL.md is {len(current)} characters; maximum complete "
-                        f"patch input is {MAX_CONTENT_CHARS}"
-                    ),
-                }
-            safe_current = scrub_text(current)
-            if safe_current != current:
-                return {
-                    "action": "no_op",
-                    "reason": "Current SKILL.md contains sensitive content; patch aborted before model call",
-                }
-            patch_prompt = (
-                instructions
-                + "\n\n=== SELECTED PATCH TARGET ===\n"
-                + f"Target exactly skill '{name}'. Below is its CURRENT COMPLETE SKILL.md, supplied as data. "
-                + "Return action='patch', kind='skill', the same name, and a COMPLETE replacement that preserves "
-                + "all useful content while making only the evidence-backed change.\n"
-                + "<current-skill>\n"
-                + safe_current
-                + "\n</current-skill>"
-            )
-            retry = _ensure_dict(
-                _propose_structured(llm, short, [PluginLlmTextInput(text=patch_prompt)])
-            )
-            if retry is None:
-                return {"action": "no_op", "reason": "LLM did not return a complete skill replacement"}
-            if retry.get("failure"):
-                return sanitize(retry)
-            retry_action, retry_kind, retry_name, retry_content, retry_category = _normalize_fields(retry)
-            if (retry_action, retry_kind, retry_name) != ("patch", "skill", name) or not retry_content:
-                return {"action": "no_op", "reason": "Patch retry changed target or omitted complete content"}
-            if len(retry_content) > MAX_CONTENT_CHARS:
-                return {
-                    "action": "no_op",
-                    "reason": f"Complete patch exceeds {MAX_CONTENT_CHARS} characters",
-                }
-            parsed = retry
-            content = retry_content
-            category = retry_category
-            replacement_fingerprint = _valid_fingerprint(retry.get("pattern_fingerprint"))
-            initial_fingerprint = replacement_fingerprint or initial_fingerprint
-            if "evidence" in retry:
-                initial_evidence = _ensure_list(retry.get("evidence"))
-            initial_reason = str(retry.get("reason", initial_reason))
-            if "expected_outcome" in retry:
-                initial_expected_outcome = normalize_expected_outcome(
-                    retry.get("expected_outcome")
-                )
-
-        result = {
-            "action": action,
-            "kind": kind,
-            "name": name,
-            "content": content,
-            "category": category,
-            "reason": initial_reason,
-            "expected_outcome": initial_expected_outcome,
-            "evidence": initial_evidence,
-            "pattern_fingerprint": initial_fingerprint,
-        }
-        return sanitize(result)
     except PluginLlmTrustError as exc:
         safe_error = scrub_text(str(exc))
         logger.warning("PluginLlm trust denied: %s", safe_error)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1056,7 +1056,7 @@ class RefineTests(unittest.TestCase):
             "content": skill_content(name, "# Changed"), "reason": "why", "evidence": [],
         }
         with patch.object(core._llm, "propose", return_value=patch_proposal), patch.object(
-            journal, "backup_skill", return_value=None
+            journal, "prepare_skill_recovery", return_value=None
         ):
             result = core.refine_run(MockLlm())
         self.assertFalse(result["success"])
@@ -1164,6 +1164,82 @@ class RefineTests(unittest.TestCase):
         conflict = core.refine_rollback(changed["journal_id"])
         self.assertFalse(conflict["success"])
         self.assertEqual(FakeHost.skills[name], later)
+
+    def test_patch_rollback_prefers_the_journal_snapshot_over_the_backup_file(self):
+        name = "snapshot-rollback"
+        old = skill_content(name, "# Old\n\nPreserve me.")
+        new = skill_content(name, "# Old\n\nPreserve me.\n\nFixed.")
+        FakeHost.add_skill(name, old)
+        result = self.run_proposal({
+            "action": "patch", "kind": "skill", "name": name,
+            "content": new, "reason": "failure", "evidence": [],
+        })
+        entry = journal.get_entry(result["journal_id"])
+        self.assertEqual(entry["snapshot"]["before"], old)
+        self.assertEqual(FakeHost.skills[name], new)
+
+        # Losing the backup file no longer costs the rollback.
+        Path(result["backup_path"]).unlink()
+        self.assertTrue(journal.is_reversible(journal.get_entry(result["journal_id"])))
+        self.assertTrue(core.refine_rollback(result["journal_id"])["success"])
+        self.assertEqual(FakeHost.skills[name], old)
+
+    def test_legacy_patch_entry_without_a_snapshot_still_rolls_back(self):
+        name = "legacy-rollback"
+        old = skill_content(name, "# Old\n\nLegacy body.")
+        new = skill_content(name, "# Old\n\nLegacy body.\n\nPatched.")
+        FakeHost.add_skill(name, new)
+        backup = journal.backups_dir() / "legacy_skill.bak"
+        backup.write_text(old, encoding="utf-8")
+        entry_id = journal.log(
+            trigger="manual", reason="legacy", session_id="session",
+            proposal={
+                "action": "patch", "kind": "skill", "name": name,
+                "content": new, "reason": "legacy", "evidence": [],
+            },
+            outcome="applied", backup_path=str(backup),
+            recovery={"type": "skill_patch", "name": name},
+        )
+        stored = journal.get_entry(entry_id)
+        self.assertNotIn("snapshot", stored)
+        self.assertTrue(journal.is_reversible(stored))
+        self.assertTrue(core.refine_rollback(entry_id)["success"])
+        self.assertEqual(FakeHost.skills[name], old)
+
+    def test_a_snapshot_that_fails_its_digest_falls_back_to_the_backup_file(self):
+        name = "digest-mismatch"
+        old = skill_content(name, "# Old\n\nTrue body.")
+        backup = journal.backups_dir() / "digest_skill.bak"
+        backup.write_text(old, encoding="utf-8")
+        entry = {
+            "backup_path": str(backup),
+            "snapshot": {
+                "kind": "skill", "name": name,
+                "before": skill_content(name, "# Old\n\n[REDACTED] body."),
+                "before_sha256": journal._content_digest(old),
+            },
+        }
+        # The stored text no longer hashes to the recorded digest, so the raw
+        # backup wins and redacted text is never written over the user's skill.
+        self.assertEqual(journal.snapshot_before_content(entry), old)
+
+    def test_patch_rollback_fails_clearly_when_no_recovery_source_survives(self):
+        name = "no-recovery"
+        old = skill_content(name, "# Old\n\nBody.")
+        new = skill_content(name, "# Old\n\nBody.\n\nPatched.")
+        FakeHost.add_skill(name, old)
+        result = self.run_proposal({
+            "action": "patch", "kind": "skill", "name": name,
+            "content": new, "reason": "failure", "evidence": [],
+        })
+        Path(result["backup_path"]).unlink()
+        stripped = dict(journal.get_entry(result["journal_id"]))
+        stripped.pop("snapshot")
+        with patch.object(journal, "get_entry", return_value=stripped):
+            failed = journal.rollback_skill(result["journal_id"])
+        self.assertFalse(failed["success"])
+        self.assertIn("no verified", failed["error"])
+        self.assertEqual(FakeHost.skills[name], new)
 
     def test_memory_rollback_removes_exact_append_only(self):
         FakeHost.memory_entries[:] = ["before"]

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -345,6 +345,27 @@ def skill_proposal(name, body="# Guidance\n\nNew guidance."):
     }
 
 
+def multi_proposal(*edits, summary="Add the skill and the memory that points at it"):
+    return {
+        "action": "multi", "kind": "", "name": "", "content": "", "category": "",
+        "summary": summary, "reason": "Repeated failure",
+        "expected_outcome": "The repeated failure stops.",
+        "evidence": ["request failed"], "pattern_fingerprint": "deadbeef1234",
+        "edits": list(edits),
+    }
+
+
+def memory_edit(content, name="lesson"):
+    return {
+        "action": "create", "kind": "memory", "name": name, "content": content,
+        "reason": "Repeated failure", "evidence": [],
+    }
+
+
+def grouped_entries():
+    return [entry for entry in journal.entries() if entry.get("group")]
+
+
 def prompt_proposal(content):
     return {
         "action": "create", "kind": "prompt", "name": "",
@@ -452,10 +473,24 @@ class RefineTests(unittest.TestCase):
         )
         self.assertLess(llm.REVIEWER_MAX_TOKENS, llm.PROPOSAL_MAX_TOKENS // 4)
 
+        # A transaction may carry one permitted body per edit, so the budget has
+        # to scale with the edit cap or it truncates the largest proposals.
+        FakeHost.entry_config()["max_edits_per_proposal"] = 3
+        self.assertGreaterEqual(
+            llm.proposal_max_tokens(3) * llm._CHARS_PER_TOKEN,
+            llm.MAX_CONTENT_CHARS * 3,
+        )
         proposal_model = MockLlm({"action": "no_op", "reason": "none"})
         llm.propose(proposal_model, "evidence", [], [])
         self.assertEqual(
-            proposal_model.calls[0]["max_tokens"], llm.PROPOSAL_MAX_TOKENS
+            proposal_model.calls[0]["max_tokens"], llm.proposal_max_tokens(3)
+        )
+
+        FakeHost.entry_config()["max_edits_per_proposal"] = 1
+        single_model = MockLlm({"action": "no_op", "reason": "none"})
+        llm.propose(single_model, "evidence", [], [])
+        self.assertEqual(
+            single_model.calls[0]["max_tokens"], llm.PROPOSAL_MAX_TOKENS
         )
 
         reviewer_model = MockLlm({
@@ -1467,6 +1502,310 @@ class RefineTests(unittest.TestCase):
         self.assertIn("⚠️", output)
         self.assertIn(recovery["journal_id"], output)
         self.assertIn(recovery["rollback_command"], output)
+
+    def test_multi_edit_transaction_applies_each_edit_as_one_recoverable_unit(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        lesson = memory_edit("Reach for the endpoint skill instead of retrying by hand.")
+        result = self.run_proposal(
+            multi_proposal(skill_proposal("endpoint-retry"), lesson)
+        )
+        self.assertTrue(result["success"])
+        self.assertEqual(result["outcome"], "completed")
+        self.assertEqual(result["edits_applied"], 2)
+        self.assertIn("endpoint-retry", FakeHost.skills)
+        self.assertIn(lesson["content"], FakeHost.memory_entries)
+
+        grouped = grouped_entries()
+        self.assertEqual(len({entry["group"]["id"] for entry in grouped}), 1)
+        self.assertEqual(sorted(entry["group"]["index"] for entry in grouped), [0, 1])
+        self.assertEqual({entry["group"]["size"] for entry in grouped}, {2})
+        self.assertEqual([entry["outcome"] for entry in grouped], ["applied", "applied"])
+        # The shared prediction is carried onto every edit that was journaled.
+        for entry in grouped:
+            self.assertEqual(
+                entry["proposal"]["expected_outcome"], "The repeated failure stops."
+            )
+        # The daily budget counts edits, not proposals.
+        self.assertEqual(journal.count_today_applied(), 2)
+
+        self.assertEqual(len(result["recoveries"]), 2)
+        for recovery in result["recoveries"]:
+            self.assertTrue(core.refine_rollback(recovery["journal_id"])["success"])
+        self.assertNotIn("endpoint-retry", FakeHost.skills)
+        self.assertNotIn(lesson["content"], FakeHost.memory_entries)
+
+    def test_multi_edit_partial_application_journals_applied_and_failed_edits(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        broken = {
+            "action": "create", "kind": "skill", "name": "broken-second",
+            "content": "not a skill at all", "reason": "later failure", "evidence": [],
+        }
+        result = self.run_proposal(
+            multi_proposal(skill_proposal("good-first"), broken)
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["outcome"], "partial_success")
+        self.assertEqual(result["edits_applied"], 1)
+        self.assertIn("good-first", FakeHost.skills)
+        self.assertNotIn("broken-second", FakeHost.skills)
+
+        outcomes = {
+            entry["proposal"]["name"]: entry["outcome"] for entry in grouped_entries()
+        }
+        self.assertEqual(outcomes, {"good-first": "applied", "broken-second": "rejected"})
+        self.assertEqual(len(result["recoveries"]), 1)
+        self.assertIn("rollback_command", result["recoveries"][0])
+
+        with patch.object(plugin_init.core, "refine_run", return_value=result):
+            output = plugin_init._handle_refine_command("")
+        self.assertIn("⚠️", output)
+        self.assertIn(result["recoveries"][0]["journal_id"], output)
+        self.assertIn("good-first", output)
+        self.assertIn("broken-second", output)
+
+    def test_transaction_guardrails_see_edits_applied_earlier_in_the_same_run(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        result = self.run_proposal(
+            multi_proposal(
+                skill_proposal("collides"), skill_proposal("collides", "# Second body")
+            )
+        )
+        self.assertEqual(result["outcome"], "partial_success")
+        self.assertEqual(result["edits_applied"], 1)
+        rejected = [
+            entry for entry in grouped_entries() if entry["outcome"] == "rejected"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertIn("already exists", rejected[0]["error"])
+        self.assertEqual(
+            FakeHost.skills["collides"], skill_content("collides", "# Guidance\n\nNew guidance.")
+        )
+
+    def test_multi_edit_stops_when_the_daily_edit_budget_is_exhausted(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 1
+        lesson = memory_edit("second lesson")
+        result = self.run_proposal(
+            multi_proposal(skill_proposal("budget-first"), lesson)
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["outcome"], "partial_success")
+        self.assertEqual(result["edits_applied"], 1)
+        self.assertIn("budget-first", FakeHost.skills)
+        self.assertNotIn("second lesson", FakeHost.memory_entries)
+        self.assertIn("daily edit limit", result["message"])
+        # The unattempted edit is journaled so a partial transaction is readable
+        # from the journal alone, but it consumes no daily budget.
+        self.assertEqual(journal.count_today_applied(), 1)
+        outcomes = {
+            entry["proposal"]["name"]: entry["outcome"] for entry in grouped_entries()
+        }
+        self.assertEqual(outcomes, {"budget-first": "applied", "lesson": "rejected"})
+        skipped = next(
+            entry for entry in grouped_entries() if entry["outcome"] == "rejected"
+        )
+        self.assertIn("Daily edit limit reached", skipped["error"])
+        self.assertEqual(skipped["group"]["index"], 1)
+
+    def test_transaction_edits_are_capped_and_duplicate_targets_collapse(self):
+        reply = {
+            "action": "create", "reason": "Repeated failure",
+            "expected_outcome": "The repeated failure stops.",
+            "pattern_fingerprint": "deadbeef1234",
+            "summary": "Add the skill and its memory pointer",
+            "edits": [
+                {"action": "create", "kind": "skill", "name": "capped-one",
+                 "content": skill_content("capped-one")},
+                {"action": "create", "kind": "skill", "name": "capped-one",
+                 "content": skill_content("capped-one", "# Duplicate")},
+                {"action": "create", "kind": "memory", "name": "note",
+                 "content": "Reach for capped-one first."},
+            ],
+        }
+        FakeHost.entry_config()["max_edits_per_proposal"] = 2
+        capped = llm.propose(MockLlm(reply), "evidence", [], [])
+        # The duplicate target is dropped and the third edit is past the cap, so a
+        # transaction of one collapses back to the ordinary single-edit shape.
+        self.assertNotIn("edits", capped)
+        self.assertEqual((capped["action"], capped["name"]), ("create", "capped-one"))
+        self.assertEqual(capped["expected_outcome"], "The repeated failure stops.")
+
+        FakeHost.entry_config()["max_edits_per_proposal"] = 3
+        model = MockLlm(reply)
+        grouped = llm.propose(model, "evidence", [], [])
+        self.assertEqual(grouped["action"], "multi")
+        self.assertEqual([edit["kind"] for edit in grouped["edits"]], ["skill", "memory"])
+        self.assertEqual(grouped["summary"], "Add the skill and its memory pointer")
+        for edit in grouped["edits"]:
+            self.assertEqual(edit["expected_outcome"], "The repeated failure stops.")
+            self.assertEqual(edit["pattern_fingerprint"], "deadbeef1234")
+        # Creates inside a transaction cost no extra retry call.
+        self.assertEqual(len(model.calls), 1)
+
+    def test_transaction_subcall_truncation_is_reported_not_disguised(self):
+        name = "patched-in-transaction"
+        FakeHost.add_skill(name, skill_content(name, "# Old\n\nKeep."))
+        reply = {
+            "action": "patch", "reason": "Repeated failure",
+            "edits": [
+                {"action": "patch", "kind": "skill", "name": name},
+                memory_edit("lesson", name="note"),
+            ],
+        }
+        truncated = MockResult(
+            text='{"action": "patch", "kind": "skill", "name": "patched',
+            output_tokens=llm.PROPOSAL_MAX_TOKENS,
+        )
+        result = llm.propose(
+            MockLlm(reply, truncated), "evidence", [name], [],
+            skill_content_loader=journal.read_skill_content,
+        )
+        self.assertEqual(result["failure"], "truncated")
+        self.assertEqual(result["action"], "no_op")
+        self.assertNotIn("edits", result)
+
+    def test_transaction_lists_a_recovery_id_for_an_unfinalized_mutation(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        original_finalize = journal.finalize
+        calls = []
+
+        def fail_second(entry_id, outcome, **kwargs):
+            calls.append(entry_id)
+            if len(calls) == 2:
+                raise OSError("finalize disk error")
+            return original_finalize(entry_id, outcome, **kwargs)
+
+        lesson = memory_edit("second body")
+        with patch.object(
+            core._llm, "propose",
+            return_value=multi_proposal(skill_proposal("finalized-first"), lesson),
+        ), patch.object(journal, "finalize", side_effect=fail_second):
+            result = core.refine_run(MockLlm())
+
+        self.assertEqual(result["outcome"], "partial_success")
+        # The second edit really mutated the host and really consumed budget, so
+        # its recovery id has to be listed, not merely mentioned in free text.
+        self.assertIn(lesson["content"], FakeHost.memory_entries)
+        self.assertEqual(journal.count_today_applied(), 2)
+        self.assertEqual(result["edits_applied"], 2)
+        self.assertEqual(len(result["journal_ids"]), 2)
+        unfinalized = [
+            entry for entry in grouped_entries() if entry["outcome"] == "prepared"
+        ]
+        self.assertEqual(len(unfinalized), 1)
+        self.assertIn(unfinalized[0]["id"], result["journal_ids"])
+
+    def test_transaction_recovery_ids_are_listed_in_a_safe_rollback_order(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        result = self.run_proposal(multi_proposal(
+            memory_edit("first lesson", name="first"),
+            memory_edit("second lesson", name="second"),
+        ))
+        self.assertTrue(result["success"])
+        self.assertEqual(FakeHost.memory_entries, ["first lesson", "second lesson"])
+        # Memory recovery is positional, so rolling back in the printed order has
+        # to work; the reverse order fails closed and strands half the change.
+        for recovery in result["recoveries"]:
+            self.assertTrue(core.refine_rollback(recovery["journal_id"])["success"])
+        self.assertEqual(FakeHost.memory_entries, [])
+
+    def test_transaction_summary_and_edits_are_scrubbed_everywhere(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        secret = "ghp_" + "S" * 36
+        result = self.run_proposal(multi_proposal(
+            skill_proposal("scrubbed-skill"),
+            memory_edit(f"remember token={secret} for later"),
+            summary=f"summary carrying {secret}",
+        ))
+        self.assertTrue(result["success"])
+        self.assertNotIn(secret, journal.journal_path().read_text(encoding="utf-8"))
+        self.assertNotIn(secret, json.dumps(result))
+        self.assertNotIn(secret, "\n".join(FakeHost.memory_entries))
+        group = grouped_entries()[0]["group"]
+        self.assertNotIn(secret, group["summary"])
+        self.assertIn("[REDACTED]", group["summary"])
+
+    def test_prompt_note_edit_inside_a_transaction_persists_and_reverts(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        note = prompt_proposal(
+            "When the request returns 500, retry with the other endpoint."
+        )
+        result = self.run_proposal(multi_proposal(skill_proposal("with-note"), note))
+        self.assertTrue(result["success"])
+        self.assertEqual(result["edits_applied"], 2)
+        self.assertEqual(len(journal.load_prompt_notes()), 1)
+        for recovery in result["recoveries"]:
+            self.assertTrue(core.refine_rollback(recovery["journal_id"])["success"])
+        self.assertEqual(journal.load_prompt_notes(), [])
+        self.assertNotIn("with-note", FakeHost.skills)
+
+    def test_ledger_separates_a_skill_from_a_same_named_memory_edit(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        result = self.run_proposal(multi_proposal(
+            skill_proposal("shared-name"),
+            memory_edit("Reach for shared-name first.", name="shared-name"),
+        ))
+        self.assertTrue(result["success"])
+        stats = ledger.load_stats()
+        self.assertEqual(
+            sorted(stats), ["memory:shared-name", "shared-name"]
+        )
+        self.assertEqual(stats["shared-name"]["version"], 1)
+        self.assertEqual(stats["memory:shared-name"]["version"], 1)
+        rows = ledger.audit([])
+        self.assertEqual([row["name"] for row in rows], ["shared-name", "shared-name"])
+        self.assertEqual(
+            {row["journal_id"] for row in rows}, set(result["journal_ids"])
+        )
+
+    def test_discarded_edits_are_reported_instead_of_a_clean_completion(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        proposal = multi_proposal(
+            skill_proposal("kept-a"), memory_edit("kept b", name="kept-b")
+        )
+        proposal["dropped_edits"] = 1
+        result = self.run_proposal(proposal)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["outcome"], "partial_success")
+        self.assertEqual(result["edits_applied"], 2)
+        self.assertIn("discarded before apply", result["message"])
+        self.assertEqual(grouped_entries()[0]["group"]["dropped"], 1)
+
+    def test_transaction_container_never_reaches_guardrails_or_the_ledger(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        seen = []
+        real_validate = core._validate_proposal
+
+        def record(proposal):
+            seen.append(proposal.get("action"))
+            return real_validate(proposal)
+
+        with patch.object(core, "_validate_proposal", side_effect=record):
+            result = self.run_proposal(multi_proposal(
+                skill_proposal("guarded"), memory_edit("guarded lesson")
+            ))
+        self.assertTrue(result["success"])
+        self.assertEqual(seen, ["create", "create"])
+        self.assertNotIn("multi", [meta["kind"] for meta in ledger.load_stats().values()])
+        self.assertEqual(
+            sorted(entry["proposal"]["action"] for entry in grouped_entries()),
+            ["create", "create"],
+        )
+
+    def test_transaction_drops_a_create_edit_that_omits_content(self):
+        FakeHost.entry_config()["max_edits_per_day"] = 5
+        reply = {
+            "action": "create", "reason": "Repeated failure",
+            "edits": [
+                {"action": "create", "kind": "skill", "name": "kept-edit",
+                 "content": skill_content("kept-edit")},
+                {"action": "create", "kind": "memory", "name": "no-content"},
+            ],
+        }
+        model = MockLlm(reply)
+        result = llm.propose(model, "evidence", [], [])
+        self.assertNotIn("edits", result)
+        self.assertEqual(result["name"], "kept-edit")
+        self.assertEqual(len(model.calls), 1)
 
     def test_patch_selection_without_content_reaches_complete_replacement(self):
         name = "contentless-patch"

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1206,40 +1206,109 @@ class RefineTests(unittest.TestCase):
         self.assertTrue(core.refine_rollback(entry_id)["success"])
         self.assertEqual(FakeHost.skills[name], old)
 
-    def test_a_snapshot_that_fails_its_digest_falls_back_to_the_backup_file(self):
-        name = "digest-mismatch"
-        old = skill_content(name, "# Old\n\nTrue body.")
-        backup = journal.backups_dir() / "digest_skill.bak"
-        backup.write_text(old, encoding="utf-8")
-        entry = {
-            "backup_path": str(backup),
-            "snapshot": {
-                "kind": "skill", "name": name,
-                "before": skill_content(name, "# Old\n\n[REDACTED] body."),
-                "before_sha256": journal._content_digest(old),
-            },
-        }
-        # The stored text no longer hashes to the recorded digest, so the raw
-        # backup wins and redacted text is never written over the user's skill.
-        self.assertEqual(journal.snapshot_before_content(entry), old)
+    def test_the_snapshot_digest_is_taken_from_raw_host_content(self):
+        # The journal scrubs credentials out of everything it writes, so the
+        # digest must come from the real skill content. Digesting the scrubbed
+        # text instead would make a rewritten snapshot verify and let rollback
+        # write redacted text over the user's skill.
+        name = "digest-provenance"
+        secret = "ghp_" + "D" * 36
+        raw = skill_content(name, f"# Body\n\ntoken={secret}")
+        FakeHost.add_skill(name, raw)
+        captured = journal.prepare_skill_recovery(name)
+        self.assertEqual(
+            captured["snapshot"]["before_sha256"], journal._content_digest(raw)
+        )
+        self.assertNotEqual(
+            captured["snapshot"]["before_sha256"],
+            journal._content_digest(core.scrub_text(raw)),
+        )
+        # The raw backup file still holds restorable content.
+        self.assertEqual(Path(captured["backup_path"]).read_text(encoding="utf-8"), raw)
 
-    def test_patch_rollback_fails_clearly_when_no_recovery_source_survives(self):
+    def test_a_scrubbed_snapshot_is_refused_in_favour_of_the_backup_file(self):
+        name = "digest-mismatch"
+        secret = "ghp_" + "M" * 36
+        raw = skill_content(name, f"# Old\n\ntoken={secret}")
+        new = skill_content(name, "# Old\n\nPatched.")
+        FakeHost.add_skill(name, raw)
+        captured = journal.prepare_skill_recovery(name)
+        entry_id = journal.log(
+            trigger="manual", reason="scrub-unstable", session_id="session",
+            proposal={
+                "action": "patch", "kind": "skill", "name": name,
+                "content": new, "reason": "why", "evidence": [],
+            },
+            outcome="applied", backup_path=captured["backup_path"],
+            recovery={"type": "skill_patch", "name": name},
+            snapshot=captured["snapshot"],
+        )
+        FakeHost.add_skill(name, new)
+        stored = journal.get_entry(entry_id)
+        # The journal write redacted the snapshot, so it no longer matches its
+        # digest and must not be trusted as a restore source.
+        self.assertNotIn(secret, stored["snapshot"]["before"])
+        # Restoring the snapshot would write redacted text; the raw backup wins.
+        self.assertEqual(journal.snapshot_before_content(stored), raw)
+        self.assertTrue(core.refine_rollback(entry_id)["success"])
+        self.assertEqual(FakeHost.skills[name], raw)
+
+    def test_an_unrestorable_patch_is_not_advertised_as_reversible(self):
         name = "no-recovery"
-        old = skill_content(name, "# Old\n\nBody.")
-        new = skill_content(name, "# Old\n\nBody.\n\nPatched.")
+        secret = "ghp_" + "N" * 36
+        raw = skill_content(name, f"# Old\n\ntoken={secret}")
+        new = skill_content(name, "# Old\n\nPatched.")
+        FakeHost.add_skill(name, raw)
+        captured = journal.prepare_skill_recovery(name)
+        entry_id = journal.log(
+            trigger="manual", reason="scrub-unstable", session_id="session",
+            proposal={
+                "action": "patch", "kind": "skill", "name": name,
+                "content": new, "reason": "why", "evidence": [],
+            },
+            outcome="applied", backup_path=captured["backup_path"],
+            recovery={"type": "skill_patch", "name": name},
+            snapshot=captured["snapshot"],
+        )
+        FakeHost.add_skill(name, new)
+        Path(captured["backup_path"]).unlink()
+        stored = journal.get_entry(entry_id)
+        # Neither source survives, so reversibility and restorability must agree
+        # instead of promising a rollback that then refuses.
+        self.assertFalse(journal.is_reversible(stored))
+        self.assertIsNone(journal.snapshot_before_content(stored))
+        failed = core.refine_rollback(entry_id)
+        self.assertFalse(failed["success"])
+        self.assertEqual(FakeHost.skills[name], new)
+
+    def test_staged_patch_rollback_reconciles_through_the_snapshot(self):
+        name = "staged-snapshot"
+        old = skill_content(name, "# Old\n\nRestore me.")
+        new = skill_content(name, "# Old\n\nRestore me.\n\nFixed.")
         FakeHost.add_skill(name, old)
         result = self.run_proposal({
             "action": "patch", "kind": "skill", "name": name,
             "content": new, "reason": "failure", "evidence": [],
         })
-        Path(result["backup_path"]).unlink()
-        stripped = dict(journal.get_entry(result["journal_id"]))
-        stripped.pop("snapshot")
-        with patch.object(journal, "get_entry", return_value=stripped):
-            failed = journal.rollback_skill(result["journal_id"])
-        self.assertFalse(failed["success"])
-        self.assertIn("no verified", failed["error"])
         self.assertEqual(FakeHost.skills[name], new)
+
+        # Losing the backup file must not stop a staged rollback from being
+        # proven once the host approves it.
+        Path(result["backup_path"]).unlink()
+        FakeHost.stage_writes = True
+        staged = core.refine_rollback(result["journal_id"])
+        self.assertTrue(staged["staged"])
+        entry = journal.get_entry(result["journal_id"])
+        self.assertEqual(entry["outcome"], "pending_rollback")
+        self.assertEqual(FakeHost.skills[name], new)
+
+        FakeHost.approve_pending("skills", entry["pending_id"])
+        FakeHost.stage_writes = False
+        core.refine_audit()
+        self.assertEqual(FakeHost.skills[name], old)
+        self.assertEqual(
+            journal.get_entry(result["journal_id"])["outcome"], "rolled_back"
+        )
 
     def test_memory_rollback_removes_exact_append_only(self):
         FakeHost.memory_entries[:] = ["before"]


### PR DESCRIPTION
Closes the two Opus-scope items of the round-2 brief.

## B4 — multi-edit transactions
A proposal may carry an `edits` array of inseparable edits under one shared reason, expected outcome, and summary. Each edit keeps its own journal record, recovery metadata, and rollback id, grouped by an additive `group` field, so rollback, approval reconciliation, dedup, and the ledger work unchanged and the daily budget counts edits. Edits apply sequentially, so per-edit guardrails see the edits applied before them. Partial application is journaled per edit and never reported as complete.

## C1 — snapshot rollback
A skill patch records its pre-edit content in the journal alongside the readable `.bak` file, both from one host read. Rollback prefers the snapshot, so losing the backup file no longer costs the rollback. A digest of the raw content detects a snapshot the journal scrubber rewrote and falls back to the `.bak`. `is_reversible` asks the restore path itself, so it cannot promise more than rollback delivers. Pre-change records keep restoring from `backup_path`.

Rollback is deliberately not modeled as an ordinary proposal: it would need a privileged bypass of the no-delete guardrail. Documented as a gap.

## Validation
- `python -B -m tests.run_tests` — 98 tests (was 78)
- compiled 9 Python files
- `git diff HEAD --check`
- Both highest-risk new tests verified to fail when the defect is reintroduced.
- Two independent reviews; every High and the material Medium findings fixed before merge.

## Not verified
No live Hermes and no real model calls. Hermetic fake host only.