### PR TITLE
Stale-plan guard, review fixes, autostart & /refine status

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ trajectory (state.db) → scrub → fingerprint + aggregate → signal gate
 | **4. LLM proposal** | Requests one structured `create`, `patch`, or `no_op` proposal with an optional one-sentence, falsifiable `expected_outcome`. Kinds are `skill`, `memory`, and `prompt`. A proposal may instead carry an `edits` array of inseparable edits under one shared reason, `expected_outcome`, and `summary`. Every model-bound field is sanitized. The proposal output budget is derived locally from the shared 15,000-character content limit and scales with `max_edits_per_proposal`; the reviewer remains separately capped at 300 tokens. A cut-off, malformed, or reasoning-only reply is journaled as `llm_incomplete` rather than presented as a normal `no_op`. Skill patches receive the current complete `SKILL.md` only when it is unchanged by scrubbing and no larger than 15,000 characters. |
 | **5. Guardrails** | Enforces agent-created patch targets, fresh create names, content/frontmatter, prompt-note policy shape, size limits, daily budget, and recent-duplicate rejection. Every check runs per edit, so a later edit of a transaction is measured against the edits already applied before it. |
 | **6. Prepare** | Captures a skill's pre-edit content as both a journal snapshot and a readable `.bak` file, or memory/prompt-note recovery metadata, then appends and `fsync`s a `prepared` journal record before mutation. |
-| **7. Apply and reconcile** | Runs the standard host API for skills/memory (`patch` maps to host `edit`) or atomically writes the plugin-owned prompt-note store. It proves target state and records `applied`, `pending_approval`, or `error`. Host pending approvals reconcile lazily before later runs, audit, or rollback. |
+| **7. Apply and reconcile** | Runs the standard host API for skills/memory (`patch` maps to host `edit`) or atomically writes the plugin-owned prompt-note store. It proves target state and records `applied`, `pending_approval`, `conflict`, or `error`. A `conflict` occurs when a skill patch was planned against content that changed before apply; the budget is not consumed and the edit is not advertised as reversible. Host pending approvals reconcile lazily before later runs, audit, or rollback. |
 | **8. Rollback** | Journals `rollback_prepared` before a rollback side effect. A rollback is finalized only after target-state proof; staged host rollbacks remain `pending_rollback` until approval reconciliation. |
 
 ### Why fingerprinting
@@ -258,11 +258,13 @@ Candidates for removal:
 ```
 
 The audit deletes nothing. It prints a rollback command only for recorded
-candidates. Every row shows the model's sanitized expected outcome (`—` when
-omitted) alongside its observed result. Later edits of the same entry advance a
-version; version 3 or later is labelled `churning` only when the normal verdict
-would otherwise be `unclear`. Skills that remain unused are fed into later
-proposals as negative examples.
+candidates. Skill rows keep their plain names; memory and prompt-note rows use
+`memory:` / `prompt:` prefixes so same-named entries remain distinguishable.
+Every row shows the model's sanitized expected outcome (`—` when omitted)
+alongside its observed result. Later edits of the same entry advance a version;
+version 3 or later is labelled `churning` only when the normal verdict would
+otherwise be `unclear`. Skills that remain unused are fed into later proposals
+as negative examples.
 
 ### Agent-invocable tool
 
@@ -478,6 +480,12 @@ must be manually initiated.
 
 - **Credential scrubbing** covers evidence, reasons, proposals, reviewer
   verdicts, host errors, prompt notes, and recursively nested journal fields.
+- **Stale-plan guard** — a skill patch proposal carries a SHA-256 baseline
+  digest captured at planning time. Before backup and before apply, the plugin
+  re-reads the live host state and refuses the edit with a non-budget-consuming
+  `conflict` journal outcome when the content has changed or disappeared.
+  Transactions with any stale target apply zero edits. Proposals without a
+  baseline (manually assembled or legacy) bypass this check unchanged.
 - **Signal gate and reviewer** reject one-off noise; reviewer failures and
   malformed output decline safely without a proposal call.
 - **Incomplete model replies are visible:** a malformed, token-limited, or

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ trajectory (state.db) → scrub → fingerprint + aggregate → signal gate
 | **4. LLM proposal** | Requests one structured `create`, `patch`, or `no_op` proposal with an optional one-sentence, falsifiable `expected_outcome`. Kinds are `skill`, `memory`, and `prompt`. A proposal may instead carry an `edits` array of inseparable edits under one shared reason, `expected_outcome`, and `summary`. Every model-bound field is sanitized. The proposal output budget is derived locally from the shared 15,000-character content limit and scales with `max_edits_per_proposal`; the reviewer remains separately capped at 300 tokens. A cut-off, malformed, or reasoning-only reply is journaled as `llm_incomplete` rather than presented as a normal `no_op`. Skill patches receive the current complete `SKILL.md` only when it is unchanged by scrubbing and no larger than 15,000 characters. |
 | **5. Guardrails** | Enforces agent-created patch targets, fresh create names, content/frontmatter, prompt-note policy shape, size limits, daily budget, and recent-duplicate rejection. Every check runs per edit, so a later edit of a transaction is measured against the edits already applied before it. |
 | **6. Prepare** | Captures a skill's pre-edit content as both a journal snapshot and a readable `.bak` file, or memory/prompt-note recovery metadata, then appends and `fsync`s a `prepared` journal record before mutation. |
-| **7. Apply and reconcile** | Runs the standard host API for skills/memory (`patch` maps to host `edit`) or atomically writes the plugin-owned prompt-note store. It proves target state and records `applied`, `pending_approval`, `conflict`, or `error`. A `conflict` occurs when a skill patch was planned against content that changed before apply; the budget is not consumed and the edit is not advertised as reversible. Host pending approvals reconcile lazily before later runs, audit, or rollback. |
+| **7. Apply and reconcile** | Runs the standard host API for skills/memory (`patch` maps to host `edit`) or atomically writes the plugin-owned prompt-note store. It proves target state and records `applied`, `pending_approval`, `conflict`, or `error`. A `conflict` occurs when a skill patch was planned against content that changed before apply, disappeared, or can no longer be read reliably; the budget is not consumed and the edit is not advertised as reversible. Host pending approvals reconcile lazily before later runs, audit, or rollback. |
 | **8. Rollback** | Journals `rollback_prepared` before a rollback side effect. A rollback is finalized only after target-state proof; staged host rollbacks remain `pending_rollback` until approval reconciliation. |
 
 ### Why fingerprinting
@@ -84,6 +84,13 @@ on Linux and macOS, and `%LOCALAPPDATA%\hermes\plugins\refine\` on Windows.
 Under a Hermes profile it follows that profile; the plugin resolves the location
 through `hermes_constants.get_hermes_home()`.
 
+> **Data safety:** the default `journal_dir` resolves to the plugin install
+> directory itself. If you already have runtime data (`refine_journal.jsonl`,
+> `backups/`, `skill_stats.json`, `prompt_notes.json`) there, move them to a
+> separate path **before** running `hermes plugins install --force`, which
+> deletes the target directory. Set `plugins.entries.refine.journal_dir` to
+> point at the new location. `/refine status` warns when this collision exists.
+
 1. Add to Hermes `config.yaml`:
 
 ```yaml
@@ -92,6 +99,7 @@ plugins:
     - refine
   entries:
     refine:
+      journal_dir: "<HERMES_HOME>/refine-data"   # keep data separate from plugin source
       llm:
         allow_model_override: false
         allow_provider_override: false
@@ -108,6 +116,8 @@ hermes gateway restart
 ```
 hermes plugins list
 # refine  0.1.0  Self-improvement loop ...  user  enabled
+/refine status
+# auto: on, blockers: none — auto-refine is active
 ```
 
 ---
@@ -120,14 +130,21 @@ hermes plugins list
 /refine
 /refine focus on Gmail API failures
 /refine audit
+/refine status
 /refine rollback 1f2a3b4c5d6e
 ```
 
-`audit` and `rollback <12-character-id>` are exact subcommands. Other text,
-including reasons beginning with those words, is passed to the proposal model as
-the manual reason.
+`audit` and `rollback <12-character-id>` are exact subcommands. `status`
+reports whether automatic refinement is active, what blocks it, and whether
+the journal directory is safe. Other text, including reasons beginning with
+those words, is passed to the proposal model as the manual reason.
 
 ### Automatic refinement
+
+Automatic refinement is **enabled by default** (`auto_enabled: true`). After
+installation, the plugin begins analyzing sessions and proposing improvements
+without additional configuration. To disable it, set `auto_enabled: false` in
+`plugins.entries.refine`.
 
 `post_llm_call` counts the assistant messages in the history Hermes supplies and
 starts at most one background refinement attempt once that count has grown by
@@ -481,11 +498,18 @@ must be manually initiated.
 - **Credential scrubbing** covers evidence, reasons, proposals, reviewer
   verdicts, host errors, prompt notes, and recursively nested journal fields.
 - **Stale-plan guard** — a skill patch proposal carries a SHA-256 baseline
-  digest captured at planning time. Before backup and before apply, the plugin
-  re-reads the live host state and refuses the edit with a non-budget-consuming
-  `conflict` journal outcome when the content has changed or disappeared.
-  Transactions with any stale target apply zero edits. Proposals without a
-  baseline (manually assembled or legacy) bypass this check unchanged.
+  digest captured at planning time. Before backup, and again against the
+  recovery snapshot captured for rollback, the plugin re-reads the live host
+  state and refuses the edit with a non-budget-consuming `conflict` journal
+  outcome when the literal content has already changed, disappeared, or cannot
+  be read reliably. Host preprocessing is disabled for these reads so inline
+  shell directives are not executed and cannot alter the baseline. Transaction
+  preflight applies zero edits when any target is stale at that point.
+  Proposals without a baseline (manually assembled or legacy) bypass this check
+  unchanged. Hermes does not expose an atomic compare-and-write operation:
+  another process can still race the final check and host write, and an approved
+  staged write can race changes made while approval is pending. A transaction
+  can therefore become partial if a target changes after preflight.
 - **Signal gate and reviewer** reject one-off noise; reviewer failures and
   malformed output decline safely without a proposal call.
 - **Incomplete model replies are visible:** a malformed, token-limited, or

--- a/__init__.py
+++ b/__init__.py
@@ -231,6 +231,38 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
             logger.exception("refine audit failed")
             return f"❌ Audit failed: {exc}"
 
+    if args == "status":
+        try:
+            from .sanitization import scrub_text as _scrub
+        except ImportError:
+            from sanitization import scrub_text as _scrub
+        try:
+            status = core.refine_status()
+        except Exception as exc:
+            logger.exception("refine status failed")
+            return f"❌ Status failed: {exc}"
+        lines = [
+            f"auto: {'on' if status['auto_enabled'] else 'off'}",
+            f"turn interval: {status['auto_turn_interval']}",
+            f"min messages: {status['auto_min_messages']}",
+            f"cooldown: {status['auto_cooldown_minutes']} min",
+            f"edits today: {status['edits_today']}/{status['max_edits_per_day']}",
+            f"journal: {status['journal_dir']}",
+        ]
+        if status.get("cooldown_remaining_minutes"):
+            lines.append(f"cooldown remaining: {status['cooldown_remaining_minutes']} min")
+        if status["blockers"]:
+            lines.append("blockers:")
+            for b in status["blockers"]:
+                lines.append(f"  • {b}")
+        else:
+            lines.append("blockers: none — auto-refine is active")
+        if status["warnings"]:
+            lines.append("warnings:")
+            for w in status["warnings"]:
+                lines.append(f"  ⚠ {w}")
+        return _scrub("\n".join(lines))
+
     if args == "rollback":
         return (
             "Usage: /refine rollback <12-character journal_id>\n"
@@ -372,8 +404,8 @@ def register(ctx) -> None:
     ctx.register_command(
         "refine",
         _handle_refine_command,
-        description="Self-improve skills/memory. Usage: /refine [reason|audit|rollback <id>]",
-        args_hint="[reason | audit | rollback <id>]",
+        description="Self-improve skills/memory. Usage: /refine [reason|audit|status|rollback <id>]",
+        args_hint="[reason | audit | status | rollback <id>]",
     )
     ctx.register_tool(
         "refine_run",
@@ -387,3 +419,26 @@ def register(ctx) -> None:
     ctx.register_hook("post_llm_call", _on_post_llm_call)
     ctx.register_hook("on_session_end", _on_session_end)
     ctx.register_hook("on_session_reset", _on_session_reset)
+    _warn_on_register()
+
+
+_REGISTER_WARNED = False
+
+
+def _warn_on_register() -> None:
+    """Log once-per-process warnings about configuration issues."""
+    global _REGISTER_WARNED
+    if _REGISTER_WARNED:
+        return
+    _REGISTER_WARNED = True
+    jdir = config.journal_dir()
+    try:
+        if (jdir / "plugin.yaml").is_file():
+            logger.warning(
+                "Refine journal_dir (%s) contains plugin source code. "
+                "A forced reinstall may delete runtime data (journal, backups, ledger). "
+                "Set plugins.entries.refine.journal_dir to a separate path.",
+                jdir,
+            )
+    except Exception:
+        pass

--- a/config.py
+++ b/config.py
@@ -86,7 +86,7 @@ def get_str(key: str, default: str = "") -> str:
 
 # Convenience accessors
 def auto_enabled() -> bool:
-    return get_bool("auto_enabled", False)
+    return get_bool("auto_enabled", True)
 
 
 def auto_min_messages() -> int:

--- a/core.py
+++ b/core.py
@@ -509,6 +509,60 @@ def _apply_prompt_note(note: Dict[str, str]) -> Dict[str, Any]:
     return journal.add_prompt_note(note)
 
 
+def _skill_baseline_conflict(
+    proposal: Dict[str, Any], observed_sha: str = ""
+) -> Optional[str]:
+    """Return a conflict message when the patch target no longer matches planning.
+
+    Returns None (no conflict) when:
+      - baseline is absent or not a dict (legacy proposal without baseline);
+      - baseline has invalid structure (logged but not treated as conflict).
+
+    Returns an error string when the current state diverges from the planning
+    baseline, meaning the model's replacement was built from stale content.
+    """
+    import re as _re
+
+    baseline = proposal.get("refine_baseline")
+    if not isinstance(baseline, dict):
+        return None  # Legacy proposal without baseline — today's behaviour unchanged.
+    exists = baseline.get("exists")
+    sha = str(baseline.get("sha256", ""))
+    if exists is not True or not _re.fullmatch(r"[0-9a-f]{64}", sha):
+        logger.warning(
+            "Ignoring malformed refine_baseline in proposal for '%s'",
+            proposal.get("name", ""),
+        )
+        return None
+    name = str(proposal.get("name", ""))
+    if observed_sha:
+        # Check B: compare against the sha from prepare_skill_recovery snapshot.
+        if observed_sha != sha:
+            return (
+                f"Skill '{name}': entry changed during refinement planning "
+                f"(baseline {sha[:12]}… vs current {observed_sha[:12]}…)"
+            )
+        return None
+    # Check A: read current state from host before backup.
+    current = journal.skill_baseline(name)
+    if current is None:
+        return (
+            f"Skill '{name}': entry changed during refinement planning "
+            "(cannot confirm target state)"
+        )
+    if not current.get("exists"):
+        return (
+            f"Skill '{name}': entry changed during refinement planning "
+            "(target was deleted after planning)"
+        )
+    if current["sha256"] != sha:
+        return (
+            f"Skill '{name}': entry changed during refinement planning "
+            f"(baseline {sha[:12]}… vs current {current['sha256'][:12]}…)"
+        )
+    return None
+
+
 def _journal_nonmutation(**kwargs: Any) -> Optional[str]:
     try:
         return journal.log(**kwargs)
@@ -798,6 +852,28 @@ def _apply_edit(
     recovery: Dict[str, Any] = {}
     prompt_note: Optional[Dict[str, str]] = None
     if kind == "skill" and action == "patch":
+        # Check A: refuse before backup if planning baseline is stale.
+        conflict_a = _skill_baseline_conflict(proposal)
+        if conflict_a:
+            entry_id = _journal_nonmutation(
+                trigger=trigger,
+                reason=safe_reason,
+                session_id=session,
+                proposal=proposal,
+                outcome="conflict",
+                error=conflict_a,
+                group=group,
+            )
+            result = {
+                "success": False,
+                "message": conflict_a,
+                "proposal": proposal,
+                "reversible": False,
+                "edits_applied": 0,
+            }
+            if entry_id:
+                result["record_id"] = entry_id
+            return result
         captured = journal.prepare_skill_recovery(name)
         if captured is None:
             error = f"Cannot create durable backup for skill '{name}'; mutation aborted"
@@ -817,6 +893,30 @@ def _apply_edit(
                 "reversible": False,
                 "edits_applied": 0,
             }
+        # Check B: verify the snapshot digest matches baseline (zero-window).
+        conflict_b = _skill_baseline_conflict(
+            proposal, observed_sha=captured["snapshot"]["before_sha256"]
+        )
+        if conflict_b:
+            entry_id = _journal_nonmutation(
+                trigger=trigger,
+                reason=safe_reason,
+                session_id=session,
+                proposal=proposal,
+                outcome="conflict",
+                error=conflict_b,
+                group=group,
+            )
+            result = {
+                "success": False,
+                "message": conflict_b,
+                "proposal": proposal,
+                "reversible": False,
+                "edits_applied": 0,
+            }
+            if entry_id:
+                result["record_id"] = entry_id
+            return result
         backup_path = str(captured["backup_path"])
         snapshot = captured["snapshot"]
         recovery = {"type": "skill_patch", "name": name}
@@ -1094,6 +1194,60 @@ def _apply_transaction(
 
     results: List[Dict[str, Any]] = []
     stop_reason = ""
+
+    # ── Stale-plan preflight: reject the entire transaction if any skill patch
+    # was built from content that no longer matches the live host state. This
+    # prevents a partial apply where edit #1 succeeds but edit #2 would conflict.
+    stale_edits: List[int] = []
+    for index, edit in enumerate(edits):
+        normalized = edit_proposal(edit)
+        if (
+            normalized.get("kind") == "skill"
+            and normalized.get("action") == "patch"
+            and isinstance(normalized.get("refine_baseline"), dict)
+        ):
+            conflict = _skill_baseline_conflict(normalized)
+            if conflict:
+                stale_edits.append(index)
+    if stale_edits:
+        conflict_msg = (
+            f"Transaction rejected: entry changed during refinement planning "
+            f"(stale edit(s) at index {stale_edits})"
+        )
+        for index, edit in enumerate(edits):
+            normalized = edit_proposal(edit)
+            if index in stale_edits:
+                _journal_nonmutation(
+                    trigger=trigger,
+                    reason=safe_reason,
+                    session_id=session,
+                    proposal=normalized,
+                    outcome="conflict",
+                    error=conflict_msg,
+                    group=edit_group(index),
+                )
+            else:
+                _journal_nonmutation(
+                    trigger=trigger,
+                    reason=safe_reason,
+                    session_id=session,
+                    proposal=normalized,
+                    outcome="rejected",
+                    error=conflict_msg,
+                    group=edit_group(index),
+                )
+        return {
+            "success": False,
+            "outcome": "failed",
+            "message": conflict_msg,
+            "proposal": proposal,
+            "results": [],
+            "recoveries": [],
+            "journal_ids": [],
+            "reversible": False,
+            "edits_applied": 0,
+        }
+
     for index, edit in enumerate(edits):
         # Re-read the durable budget between edits: it counts edits, so a long
         # transaction can legitimately exhaust it part way through.

--- a/core.py
+++ b/core.py
@@ -2,10 +2,12 @@
 
 import json
 import logging
+import os
 import re
 import sqlite3
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.plugin_llm import PluginLlm
@@ -339,6 +341,74 @@ def _reconcile_pending() -> List[Dict[str, Any]]:
         except Exception as exc:
             logger.warning("Cannot mirror reconciled state in ledger: %s", scrub_text(str(exc)))
     return changed
+
+
+def refine_status() -> Dict[str, Any]:
+    """Report why automatic refinement will or will not run. Read-only."""
+    auto = config.auto_enabled()
+    interval = config.auto_turn_interval()
+    min_msgs = config.auto_min_messages()
+    cooldown_minutes = config.auto_cooldown_minutes()
+    max_edits = config.max_edits_per_day()
+    edits_today = journal.count_today_applied()
+    last_ts = journal.last_attempt_ts()
+    jdir = config.journal_dir()
+
+    cooldown_remaining = 0.0
+    if last_ts is not None:
+        elapsed = time.time() - last_ts
+        remaining = cooldown_minutes * 60 - elapsed
+        if remaining > 0:
+            cooldown_remaining = remaining / 60
+
+    jdir_writable = False
+    try:
+        jdir.mkdir(parents=True, exist_ok=True)
+        jdir_writable = os.access(str(jdir), os.W_OK)
+    except Exception:
+        pass
+
+    jdir_is_plugin_source = False
+    try:
+        plugin_yaml = jdir / "plugin.yaml"
+        jdir_is_plugin_source = plugin_yaml.is_file()
+    except Exception:
+        pass
+
+    blockers: List[str] = []
+    if not auto:
+        blockers.append("Автоматичний режим вимкнений у налаштуваннях")
+    if interval <= 0:
+        blockers.append("Тригер за ходами вимкнений (interval=0)")
+    if edits_today >= max_edits:
+        blockers.append("Денний ліміт правок уже використаний")
+    if cooldown_remaining > 0:
+        blockers.append(f"Ще діє пауза між спробами ({cooldown_remaining:.0f} хв)")
+    if not jdir_writable:
+        blockers.append("Немає доступу до папки журналу")
+
+    warnings: List[str] = []
+    if jdir_is_plugin_source:
+        warnings.append(
+            "Папка журналу збігається з папкою коду плагіна — "
+            "hermes plugins install --force може видалити журнал"
+        )
+
+    return {
+        "auto_enabled": auto,
+        "auto_turn_interval": interval,
+        "auto_min_messages": min_msgs,
+        "auto_cooldown_minutes": cooldown_minutes,
+        "last_attempt_ts": last_ts,
+        "cooldown_remaining_minutes": round(cooldown_remaining, 1),
+        "edits_today": edits_today,
+        "max_edits_per_day": max_edits,
+        "journal_dir": str(jdir),
+        "journal_dir_writable": jdir_writable,
+        "journal_dir_is_plugin_source": jdir_is_plugin_source,
+        "blockers": blockers,
+        "warnings": warnings,
+    }
 
 
 def refine_audit() -> Dict[str, Any]:
@@ -893,17 +963,32 @@ def _apply_edit(
                 "reversible": False,
                 "edits_applied": 0,
             }
-        # Check B: verify the snapshot digest matches baseline (zero-window).
+        # Check B: verify the backup snapshot came from the planning baseline.
         conflict_b = _skill_baseline_conflict(
             proposal, observed_sha=captured["snapshot"]["before_sha256"]
         )
         if conflict_b:
+            # The recovery capture wrote a raw backup before discovering the
+            # conflict. A conflict is never reversible, so remove that copy;
+            # if cleanup fails, retain its path in the journal for auditability.
+            conflict_backup = Path(str(captured["backup_path"]))
+            retained_backup_path = ""
+            try:
+                conflict_backup.unlink(missing_ok=True)
+            except OSError as exc:
+                retained_backup_path = str(conflict_backup)
+                logger.warning(
+                    "Cannot remove unused conflict backup for skill '%s': %s",
+                    name,
+                    scrub_text(str(exc)),
+                )
             entry_id = _journal_nonmutation(
                 trigger=trigger,
                 reason=safe_reason,
                 session_id=session,
                 proposal=proposal,
                 outcome="conflict",
+                backup_path=retained_backup_path,
                 error=conflict_b,
                 group=group,
             )

--- a/journal.py
+++ b/journal.py
@@ -673,7 +673,10 @@ def _read_skill_state(name: str) -> tuple:
     from tools.skills_tool import skill_view
 
     try:
-        raw = skill_view(name)
+        # Baselines and backups must use literal SKILL.md bytes. The host's
+        # default preprocessing can render inline shell directives, producing
+        # changing content and executing commands on every guard read.
+        raw = skill_view(name, preprocess=False)
         result = raw if isinstance(raw, dict) else json.loads(raw)
     except Exception as exc:
         logger.warning("Cannot view skill '%s': %s", name, scrub_text(str(exc)))

--- a/journal.py
+++ b/journal.py
@@ -715,6 +715,27 @@ def _content_digest(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8", "replace")).hexdigest()
 
 
+def content_digest(content: str) -> str:
+    """Public wrapper over the internal digest used by planning baseline capture."""
+    return _content_digest(content)
+
+
+def skill_baseline(name: str) -> Optional[Dict[str, Any]]:
+    """Return the current skill identity for planning-baseline comparison.
+
+    Returns:
+        None — host state is unknown (read error); cannot confirm or deny.
+        {"exists": False, "sha256": ""} — skill definitively does not exist.
+        {"exists": True, "sha256": "<hex>"} — skill exists with this content digest.
+    """
+    known, content = _read_skill_state(name)
+    if not known:
+        return None
+    if content is None:
+        return {"exists": False, "sha256": ""}
+    return {"exists": True, "sha256": _content_digest(content)}
+
+
 def prepare_skill_recovery(name: str) -> Optional[Dict[str, Any]]:
     """Capture a skill's pre-edit state as a journal snapshot and a backup file.
 

--- a/ledger.py
+++ b/ledger.py
@@ -75,6 +75,17 @@ def record_edit(
     key = name if kind == "skill" else f"{kind}:{name}"
     with journal.mutation_lock():
         stats = load_stats()
+        # Before kind-qualified keys existed, every entry used its bare name.
+        # Move a legacy non-skill row out of the skill namespace before any
+        # write, including a same-named skill write, so history and versions
+        # survive the upgrade instead of becoming a duplicate audit row.
+        legacy = stats.get(name)
+        if isinstance(legacy, dict):
+            legacy_kind = str(legacy.get("kind", "skill") or "skill")
+            if legacy_kind != "skill":
+                legacy_key = f"{legacy_kind}:{name}"
+                stats.setdefault(legacy_key, legacy)
+                del stats[name]
         previous = stats.get(key, {})
         now = time.time()
         same_edit = previous.get("journal_id") == journal_id
@@ -287,8 +298,11 @@ def format_audit(rows: List[Dict[str, Any]]) -> str:
         else:
             uses = str(row["uses"])
         recurred = {True: "yes", False: "no", None: "—"}[row["pattern_recurred"]]
+        kind = str(row.get("kind", "skill") or "skill")
+        name = str(row.get("name", ""))
+        display_name = name if kind == "skill" else f"{kind}:{name}"
         lines.append(
-            f"  {row['name'][:28]:<28} {str(row['age_days']) + 'd':>5}  "
+            f"  {display_name[:28]:<28} {str(row['age_days']) + 'd':>5}  "
             f"{'v' + str(row.get('version', 1)):>3}  {uses:>7}  "
             f"{recurred:>8}  {row['verdict']}"
         )
@@ -299,7 +313,12 @@ def format_audit(rows: List[Dict[str, Any]]) -> str:
     if candidates:
         lines.extend(["", "Candidates for removal:"])
         for row in candidates:
-            lines.append(f"  {row['name']} — /refine rollback {row['journal_id']}")
+            kind = str(row.get("kind", "skill") or "skill")
+            name = str(row.get("name", ""))
+            display_name = name if kind == "skill" else f"{kind}:{name}"
+            lines.append(
+                f"  {display_name} — /refine rollback {row['journal_id']}"
+            )
         lines.extend(["", "Nothing was deleted. Run the command yourself if you agree."])
     lines.extend([
         "",

--- a/llm.py
+++ b/llm.py
@@ -556,6 +556,7 @@ def _finalize_edit(
     initial_expected_outcome = normalize_expected_outcome(
         parsed.get("expected_outcome")
     )
+    _planning_baseline = None  # Set only for skill patch from loader content
 
     if action == "patch" and kind == "skill":
         loader = skill_content_loader or _default_skill_loader
@@ -576,6 +577,13 @@ def _finalize_edit(
                 "action": "no_op",
                 "reason": "Current SKILL.md contains sensitive content; patch aborted before model call",
             }
+        # Capture planning baseline digest from the content the model will see.
+        # This value is NEVER read from model output — only from this loader read.
+        try:
+            from .journal import content_digest as _baseline_digest
+        except ImportError:
+            from journal import content_digest as _baseline_digest  # type: ignore
+        _planning_baseline = {"exists": True, "sha256": _baseline_digest(current)}
         patch_prompt = (
             instructions
             + "\n\n=== SELECTED PATCH TARGET ===\n"
@@ -614,7 +622,7 @@ def _finalize_edit(
                 retry.get("expected_outcome")
             )
 
-    return sanitize({
+    result = sanitize({
         "action": action,
         "kind": kind,
         "name": name,
@@ -625,6 +633,9 @@ def _finalize_edit(
         "evidence": initial_evidence,
         "pattern_fingerprint": initial_fingerprint,
     })
+    if _planning_baseline is not None:
+        result["refine_baseline"] = _planning_baseline
+    return result
 
 
 def _finalize_edits(
@@ -707,7 +718,7 @@ def _finalize_edits(
                 f"Proposed transaction contained no usable edit ({dropped} discarded)"
             ),
         }
-    if len(edits) == 1:
+    if len(edits) == 1 and not dropped:
         return sanitize(edits[0])
     return sanitize({
         "action": "multi",

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -205,7 +205,7 @@ def install_fake_host():
         "skills": [{"name": name} for name in sorted(FakeHost.skills)]
     })
 
-    def skill_view(name):
+    def skill_view(name, preprocess=True):
         if name not in FakeHost.skills:
             return json.dumps({"success": False, "error": "not found"})
         return json.dumps({
@@ -2776,7 +2776,7 @@ def skills_list():
     if skills_root.is_dir():
         values = [{"name": child.name} for child in skills_root.iterdir() if child.is_dir()]
     return json.dumps({"skills": values})
-def skill_view(skill_name):
+def skill_view(skill_name, preprocess=True):
     path = skill_path(skill_name)
     if not path.is_file():
         return json.dumps({"success": False, "error": "not found"})
@@ -2894,6 +2894,32 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         import hashlib
         expected_sha = hashlib.sha256(body.encode("utf-8", "replace")).hexdigest()
         self.assertEqual(result["sha256"], expected_sha)
+
+    def test_skill_state_reads_disable_host_preprocessing(self):
+        name = "baseline-raw"
+        raw_content = skill_content(name, "# Literal !`dynamic command`")
+        rendered_content = raw_content + "\n\nrendered-at-a-different-time"
+        preprocess_values = []
+
+        def dynamic_skill_view(skill_name, preprocess=True):
+            self.assertEqual(skill_name, name)
+            preprocess_values.append(preprocess)
+            return json.dumps({
+                "success": True,
+                "content": rendered_content if preprocess else raw_content,
+            })
+
+        skills_module = sys.modules["tools.skills_tool"]
+        with patch.object(skills_module, "skill_view", side_effect=dynamic_skill_view):
+            self.assertEqual(journal.read_skill_content(name), raw_content)
+            baseline = journal.skill_baseline(name)
+
+        import hashlib
+        expected_sha = hashlib.sha256(
+            raw_content.encode("utf-8", "replace")
+        ).hexdigest()
+        self.assertEqual(baseline, {"exists": True, "sha256": expected_sha})
+        self.assertEqual(preprocess_values, [False, False])
 
     def test_skill_baseline_absent_skill_returns_exists_false(self):
         result = journal.skill_baseline("nonexistent-skill")
@@ -3038,6 +3064,48 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         # Budget NOT consumed
         self.assertEqual(journal.count_today_applied(), 0)
 
+    def test_conflict_after_backup_removes_backup(self):
+        name = "conflict-after-backup"
+        original = skill_content(name, "# Original guidance")
+        replacement = skill_content(name, "# Original guidance\n\nFix.")
+        external_content = skill_content(name, "# Externally modified")
+        FakeHost.add_skill(name, original)
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": "stub", "reason": "failure", "evidence": [],
+            "pattern_fingerprint": "deadbeef1234",
+        }
+        proposal = llm.propose(
+            MockLlm(initial, dict(initial, content=replacement)),
+            "evidence", [name], [],
+            skill_content_loader=journal.read_skill_content,
+        )
+        real_prepare = journal.prepare_skill_recovery
+
+        def prepare_after_external_change(skill_name):
+            FakeHost.add_skill(skill_name, external_content)
+            return real_prepare(skill_name)
+
+        with patch.object(
+            journal,
+            "prepare_skill_recovery",
+            side_effect=prepare_after_external_change,
+        ):
+            result = core._apply_edit(
+                proposal, trigger="manual", safe_reason="test",
+                session="session", started=time.time()
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(FakeHost.skills[name], external_content)
+        conflict = next(
+            entry for entry in journal.entries()
+            if entry.get("outcome") == "conflict"
+        )
+        retained_path = conflict.get("backup_path", "")
+        self.assertFalse(retained_path and Path(retained_path).exists())
+        self.assertEqual(list(journal.backups_dir().glob("*.bak")), [])
+
     def test_external_deletion_is_conflict_not_backup_failure(self):
         name = "conflict-del"
         original = skill_content(name, "# Will be deleted")
@@ -3176,6 +3244,86 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         result = core.refine_run(model)
         self.assertFalse(result["success"])
         self.assertIn("entry changed during refinement planning", result["message"])
+
+    # ── Autostart / status tests ──────────────────────────────────────────────
+
+    def test_status_reports_blockers_when_auto_disabled(self):
+        with patch.object(config, "auto_enabled", return_value=False):
+            status = core.refine_status()
+        self.assertFalse(status["auto_enabled"])
+        self.assertTrue(any("вимкнений" in b for b in status["blockers"]))
+
+    def test_status_reports_no_blockers_when_ready(self):
+        status = core.refine_status()
+        self.assertTrue(status["auto_enabled"])
+        # Fresh journal, no cooldown, budget free → no blockers
+        self.assertEqual(status["blockers"], [])
+
+    def test_status_reports_budget_exhausted(self):
+        # Temporarily lower budget to 1 and exhaust it
+        FakeHost.entry_config()["max_edits_per_day"] = 1
+        result = self.run_proposal(skill_proposal("status-budget-test"))
+        self.assertTrue(result["success"])
+        status = core.refine_status()
+        self.assertEqual(status["edits_today"], 1)
+        self.assertGreater(len(status["blockers"]), 0)
+
+    def test_status_does_not_create_journal_entries(self):
+        before = len(journal.entries())
+        core.refine_status()
+        self.assertEqual(len(journal.entries()), before)
+
+    def test_status_does_not_call_model(self):
+        with patch.object(core, "refine_run", side_effect=AssertionError("model called")):
+            core.refine_status()  # should not raise
+
+    def test_status_command_returns_text_not_dict(self):
+        result = plugin_init._handle_refine_command("status")
+        self.assertIsInstance(result, str)
+        self.assertIn("auto:", result)
+
+    def test_status_as_reason_word_goes_to_proposal(self):
+        with patch.object(plugin_init.core, "refine_run", return_value={
+            "success": True, "message": "done", "outcome": "no_op",
+        }) as run:
+            plugin_init._handle_refine_command("status of gmail failures")
+        run.assert_called_once()
+        self.assertEqual(run.call_args.kwargs["reason"], "status of gmail failures")
+
+    def test_journal_dir_collision_warning(self):
+        # Place a plugin.yaml in journal_dir to simulate collision
+        jdir = Path(config.journal_dir())
+        jdir.mkdir(parents=True, exist_ok=True)
+        (jdir / "plugin.yaml").write_text("name: refine\n", encoding="utf-8")
+        status = core.refine_status()
+        self.assertTrue(status["journal_dir_is_plugin_source"])
+        self.assertTrue(len(status["warnings"]) > 0)
+
+    def test_register_warns_on_collision(self):
+        jdir = Path(config.journal_dir())
+        jdir.mkdir(parents=True, exist_ok=True)
+        (jdir / "plugin.yaml").write_text("name: refine\n", encoding="utf-8")
+        plugin_init._REGISTER_WARNED = False
+        # The logger name when imported directly is __init__
+        with self.assertLogs(level="WARNING") as cm:
+            plugin_init._warn_on_register()
+        self.assertTrue(any("journal_dir" in msg for msg in cm.output))
+        # Second call does not warn again due to the flag
+        self.assertTrue(plugin_init._REGISTER_WARNED)
+
+    def test_register_does_not_warn_without_collision(self):
+        plugin_init._REGISTER_WARNED = False
+        # No plugin.yaml in journal_dir — should not log a warning at our level
+        try:
+            with self.assertLogs(level="WARNING"):
+                plugin_init._warn_on_register()
+            self.fail("Should not have logged a warning without collision")
+        except AssertionError as exc:
+            if "no logs" not in str(exc).lower():
+                raise
+
+    def test_auto_enabled_defaults_to_true(self):
+        self.assertTrue(config.auto_enabled())
 
 
 if __name__ == "__main__":

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1751,7 +1751,7 @@ class RefineTests(unittest.TestCase):
         self.assertIn("Daily edit limit reached", skipped["error"])
         self.assertEqual(skipped["group"]["index"], 1)
 
-    def test_transaction_edits_are_capped_and_duplicate_targets_collapse(self):
+    def test_transaction_edits_are_capped_and_duplicate_targets_are_reported(self):
         reply = {
             "action": "create", "reason": "Repeated failure",
             "expected_outcome": "The repeated failure stops.",
@@ -1768,10 +1768,13 @@ class RefineTests(unittest.TestCase):
         }
         FakeHost.entry_config()["max_edits_per_proposal"] = 2
         capped = llm.propose(MockLlm(reply), "evidence", [], [])
-        # The duplicate target is dropped and the third edit is past the cap, so a
-        # transaction of one collapses back to the ordinary single-edit shape.
-        self.assertNotIn("edits", capped)
-        self.assertEqual((capped["action"], capped["name"]), ("create", "capped-one"))
+        # The duplicate target is dropped and the third edit is past the cap.
+        # Preserve that loss so applying the remaining edit reports a partial
+        # transaction instead of silently claiming the inseparable set landed.
+        self.assertEqual(capped["action"], "multi")
+        self.assertEqual(len(capped["edits"]), 1)
+        self.assertEqual(capped["edits"][0]["name"], "capped-one")
+        self.assertEqual(capped["dropped_edits"], 2)
         self.assertEqual(capped["expected_outcome"], "The repeated failure stops.")
 
         FakeHost.entry_config()["max_edits_per_proposal"] = 3
@@ -1936,7 +1939,7 @@ class RefineTests(unittest.TestCase):
             ["create", "create"],
         )
 
-    def test_transaction_drops_a_create_edit_that_omits_content(self):
+    def test_transaction_reports_a_create_edit_dropped_for_missing_content(self):
         FakeHost.entry_config()["max_edits_per_day"] = 5
         reply = {
             "action": "create", "reason": "Repeated failure",
@@ -1947,10 +1950,19 @@ class RefineTests(unittest.TestCase):
             ],
         }
         model = MockLlm(reply)
-        result = llm.propose(model, "evidence", [], [])
-        self.assertNotIn("edits", result)
-        self.assertEqual(result["name"], "kept-edit")
+        proposal = llm.propose(model, "evidence", [], [])
+        self.assertEqual(proposal["action"], "multi")
+        self.assertEqual(len(proposal["edits"]), 1)
+        self.assertEqual(proposal["edits"][0]["name"], "kept-edit")
+        self.assertEqual(proposal["dropped_edits"], 1)
         self.assertEqual(len(model.calls), 1)
+
+        result = self.run_proposal(proposal)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["outcome"], "partial_success")
+        self.assertEqual(result["edits_applied"], 1)
+        self.assertIn("discarded before apply", result["message"])
+        self.assertEqual(grouped_entries()[0]["group"]["dropped"], 1)
 
     def test_patch_selection_without_content_reaches_complete_replacement(self):
         name = "contentless-patch"
@@ -2868,6 +2880,32 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         self.assertEqual(
             len(list((self.root / "driver-skills").glob("*/SKILL.md"))), 1
         )
+
+
+    # ── Phase 1: skill_baseline tests ─────────────────────────────────────────
+
+    def test_skill_baseline_existing_skill_returns_digest(self):
+        name = "baseline-existing"
+        body = skill_content(name, "# Current guidance\n\nSome text.")
+        FakeHost.add_skill(name, body)
+        result = journal.skill_baseline(name)
+        self.assertIsNotNone(result)
+        self.assertTrue(result["exists"])
+        import hashlib
+        expected_sha = hashlib.sha256(body.encode("utf-8", "replace")).hexdigest()
+        self.assertEqual(result["sha256"], expected_sha)
+
+    def test_skill_baseline_absent_skill_returns_exists_false(self):
+        result = journal.skill_baseline("nonexistent-skill")
+        self.assertIsNotNone(result)
+        self.assertFalse(result["exists"])
+        self.assertEqual(result["sha256"], "")
+
+    def test_skill_baseline_host_failure_returns_none(self):
+        skills_module = sys.modules["tools.skills_tool"]
+        with patch.object(skills_module, "skill_view", side_effect=OSError("host down")):
+            result = journal.skill_baseline("any-skill")
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -2907,6 +2907,97 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
             result = journal.skill_baseline("any-skill")
         self.assertIsNone(result)
 
+    # ── Phase 2: planning baseline capture tests ───────────────────────────────
+
+    def test_skill_patch_proposal_carries_planning_baseline(self):
+        name = "baseline-patch"
+        current = skill_content(name, "# Existing\n\nKeep this.")
+        replacement = skill_content(name, "# Existing\n\nKeep this.\n\nNew fix.")
+        FakeHost.add_skill(name, current)
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": "stub", "reason": "failure", "evidence": [],
+        }
+        model = MockLlm(initial, dict(initial, content=replacement))
+        result = llm.propose(
+            model, "evidence", [name], [], skill_content_loader=journal.read_skill_content
+        )
+        self.assertIn("refine_baseline", result)
+        import hashlib
+        expected_sha = hashlib.sha256(current.encode("utf-8", "replace")).hexdigest()
+        self.assertEqual(result["refine_baseline"]["sha256"], expected_sha)
+        self.assertTrue(result["refine_baseline"]["exists"])
+
+    def test_model_cannot_inject_fake_baseline(self):
+        name = "tamper-baseline"
+        current = skill_content(name, "# Real content")
+        replacement = skill_content(name, "# Real content\n\nFixed.")
+        FakeHost.add_skill(name, current)
+        fake_baseline = {"exists": True, "sha256": "0" * 64}
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": "stub", "reason": "failure", "evidence": [],
+            "refine_baseline": fake_baseline,
+        }
+        retry_with_fake = dict(initial, content=replacement, refine_baseline=fake_baseline)
+        model = MockLlm(initial, retry_with_fake)
+        result = llm.propose(
+            model, "evidence", [name], [], skill_content_loader=journal.read_skill_content
+        )
+        import hashlib
+        expected_sha = hashlib.sha256(current.encode("utf-8", "replace")).hexdigest()
+        self.assertEqual(result["refine_baseline"]["sha256"], expected_sha)
+        self.assertNotEqual(result["refine_baseline"]["sha256"], "0" * 64)
+
+    def test_create_and_memory_have_no_baseline(self):
+        result_create = llm._finalize_edit(
+            MockLlm(), "short", "instructions",
+            {"action": "create", "kind": "skill", "name": "new-skill",
+             "content": skill_content("new-skill"), "reason": "r", "evidence": []},
+            skill_content_loader=journal.read_skill_content,
+        )
+        self.assertNotIn("refine_baseline", result_create)
+        result_memory = llm._finalize_edit(
+            MockLlm(), "short", "instructions",
+            {"action": "create", "kind": "memory", "name": "lesson",
+             "content": "Remember this", "reason": "r", "evidence": []},
+            skill_content_loader=journal.read_skill_content,
+        )
+        self.assertNotIn("refine_baseline", result_memory)
+
+    def test_multi_proposal_each_patch_has_own_baseline(self):
+        name_a = "multi-base-a"
+        name_b = "multi-base-b"
+        body_a = skill_content(name_a, "# A content")
+        body_b = skill_content(name_b, "# B content")
+        FakeHost.add_skill(name_a, body_a)
+        FakeHost.add_skill(name_b, body_b)
+        replacement_a = skill_content(name_a, "# A content\n\nFix A.")
+        replacement_b = skill_content(name_b, "# B content\n\nFix B.")
+        edits = [
+            {"action": "patch", "kind": "skill", "name": name_a, "content": replacement_a},
+            {"action": "patch", "kind": "skill", "name": name_b, "content": replacement_b},
+        ]
+        multi = {
+            "action": "multi", "kind": "", "name": "", "content": "",
+            "summary": "Fix both", "reason": "failure", "evidence": [],
+            "edits": edits,
+        }
+        # _finalize_edit for each patch sub-calls the model to get the full replacement
+        patch_reply_a = {"action": "patch", "kind": "skill", "name": name_a, "content": replacement_a, "reason": "failure", "evidence": []}
+        patch_reply_b = {"action": "patch", "kind": "skill", "name": name_b, "content": replacement_b, "reason": "failure", "evidence": []}
+        model = MockLlm(multi, patch_reply_a, patch_reply_b)
+        result = llm.propose(
+            model, "evidence", [name_a, name_b], [],
+            skill_content_loader=journal.read_skill_content
+        )
+        self.assertEqual(result["action"], "multi")
+        import hashlib
+        sha_a = hashlib.sha256(body_a.encode("utf-8", "replace")).hexdigest()
+        sha_b = hashlib.sha256(body_b.encode("utf-8", "replace")).hexdigest()
+        self.assertEqual(result["edits"][0]["refine_baseline"]["sha256"], sha_a)
+        self.assertEqual(result["edits"][1]["refine_baseline"]["sha256"], sha_b)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -2998,6 +2998,185 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         self.assertEqual(result["edits"][0]["refine_baseline"]["sha256"], sha_a)
         self.assertEqual(result["edits"][1]["refine_baseline"]["sha256"], sha_b)
 
+    # ── Phase 3: stale-plan conflict detection tests ───────────────────────────
+
+    def test_external_change_between_planning_and_apply_is_conflict(self):
+        name = "conflict-ext"
+        original = skill_content(name, "# Original guidance")
+        replacement = skill_content(name, "# Original guidance\n\nFix.")
+        FakeHost.add_skill(name, original)
+        # Build a proposal with baseline via llm.propose
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": "stub", "reason": "failure", "evidence": [],
+            "pattern_fingerprint": "deadbeef1234",
+        }
+        model = MockLlm(initial, dict(initial, content=replacement))
+        proposal = llm.propose(
+            model, "evidence", [name], [],
+            skill_content_loader=journal.read_skill_content
+        )
+        self.assertIn("refine_baseline", proposal)
+        # Simulate external edit between planning and apply
+        external_content = skill_content(name, "# Externally modified")
+        FakeHost.add_skill(name, external_content)
+        result = core._apply_edit(
+            proposal, trigger="manual", safe_reason="test",
+            session="session", started=time.time()
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("entry changed during refinement planning", result["message"])
+        # Host skill was NOT overwritten
+        self.assertEqual(FakeHost.skills[name], external_content)
+        # No edit action reached the host
+        edit_actions = [a for a in FakeHost.actions if a["action"] == "edit"]
+        self.assertEqual(len(edit_actions), 0)
+        # Journal has a conflict record
+        entries = journal.entries()
+        conflict_entries = [e for e in entries if e.get("outcome") == "conflict"]
+        self.assertEqual(len(conflict_entries), 1)
+        # Budget NOT consumed
+        self.assertEqual(journal.count_today_applied(), 0)
+
+    def test_external_deletion_is_conflict_not_backup_failure(self):
+        name = "conflict-del"
+        original = skill_content(name, "# Will be deleted")
+        replacement = skill_content(name, "# Will be deleted\n\nFix.")
+        FakeHost.add_skill(name, original)
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": "stub", "reason": "failure", "evidence": [],
+            "pattern_fingerprint": "deadbeef1234",
+        }
+        model = MockLlm(initial, dict(initial, content=replacement))
+        proposal = llm.propose(
+            model, "evidence", [name], [],
+            skill_content_loader=journal.read_skill_content
+        )
+        # Delete the skill externally
+        del FakeHost.skills[name]
+        import shutil
+        shutil.rmtree(self.root / "skills" / name, ignore_errors=True)
+        result = core._apply_edit(
+            proposal, trigger="manual", safe_reason="test",
+            session="session", started=time.time()
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("entry changed during refinement planning", result["message"])
+        # Must say deletion, not "Cannot create durable backup"
+        self.assertNotIn("Cannot create durable backup", result["message"])
+
+    def test_unchanged_target_applies_normally(self):
+        name = "conflict-ok"
+        original = skill_content(name, "# Unchanged guidance")
+        replacement = skill_content(name, "# Unchanged guidance\n\nFix.")
+        FakeHost.add_skill(name, original)
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": "stub", "reason": "failure", "evidence": [],
+            "pattern_fingerprint": "deadbeef1234",
+        }
+        model = MockLlm(initial, dict(initial, content=replacement))
+        proposal = llm.propose(
+            model, "evidence", [name], [],
+            skill_content_loader=journal.read_skill_content
+        )
+        result = core._apply_edit(
+            proposal, trigger="manual", safe_reason="test",
+            session="session", started=time.time()
+        )
+        self.assertTrue(result["success"])
+        self.assertEqual(FakeHost.actions[-1]["action"], "edit")
+        self.assertEqual(FakeHost.skills[name], replacement)
+
+    def test_transaction_with_one_stale_edit_applies_zero(self):
+        name_a = "txn-ok"
+        name_b = "txn-stale"
+        body_a = skill_content(name_a, "# A ok")
+        body_b = skill_content(name_b, "# B ok")
+        FakeHost.add_skill(name_a, body_a)
+        FakeHost.add_skill(name_b, body_b)
+        replacement_a = skill_content(name_a, "# A ok\n\nFix A.")
+        replacement_b = skill_content(name_b, "# B ok\n\nFix B.")
+        edits = [
+            {"action": "patch", "kind": "skill", "name": name_a, "content": replacement_a},
+            {"action": "patch", "kind": "skill", "name": name_b, "content": replacement_b},
+        ]
+        multi = {
+            "action": "multi", "kind": "", "name": "", "content": "",
+            "summary": "Fix both", "reason": "failure", "evidence": [],
+            "edits": edits,
+        }
+        patch_reply_a = {"action": "patch", "kind": "skill", "name": name_a, "content": replacement_a, "reason": "failure", "evidence": []}
+        patch_reply_b = {"action": "patch", "kind": "skill", "name": name_b, "content": replacement_b, "reason": "failure", "evidence": []}
+        model = MockLlm(multi, patch_reply_a, patch_reply_b)
+        proposal = llm.propose(
+            model, "evidence", [name_a, name_b], [],
+            skill_content_loader=journal.read_skill_content
+        )
+        # Externally modify B only
+        FakeHost.add_skill(name_b, skill_content(name_b, "# B externally changed"))
+        result = core._apply_transaction(
+            proposal, trigger="manual", safe_reason="test",
+            session="session", started=time.time()
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["edits_applied"], 0)
+        # A was not touched
+        self.assertEqual(FakeHost.skills[name_a], body_a)
+        # Journal has conflict and rejected entries with groups
+        entries = journal.entries()
+        conflict_entries = [e for e in entries if e.get("outcome") == "conflict"]
+        rejected_entries = [e for e in entries if e.get("outcome") == "rejected"]
+        self.assertGreaterEqual(len(conflict_entries), 1)
+        self.assertGreaterEqual(len(rejected_entries), 1)
+
+    def test_legacy_proposal_without_baseline_applies_normally(self):
+        name = "legacy-no-base"
+        original = skill_content(name, "# Legacy content")
+        replacement = skill_content(name, "# Legacy content\n\nFix.")
+        FakeHost.add_skill(name, original)
+        # Manually assembled proposal without refine_baseline (as existing tests do)
+        proposal = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": replacement, "reason": "Repeated failure",
+            "evidence": ["request failed"], "pattern_fingerprint": "deadbeef1234",
+            "expected_outcome": "The failure stops.",
+        }
+        result = core._apply_edit(
+            proposal, trigger="manual", safe_reason="test",
+            session="session", started=time.time()
+        )
+        self.assertTrue(result["success"])
+        self.assertEqual(FakeHost.skills[name], replacement)
+
+    def test_full_path_conflict_through_refine_run(self):
+        name = "full-path"
+        original = skill_content(name, "# Original for full path")
+        replacement = skill_content(name, "# Original for full path\n\nFix.")
+        FakeHost.add_skill(name, original)
+        initial = {
+            "action": "patch", "kind": "skill", "name": name,
+            "content": "stub", "reason": "Repeated failure",
+            "evidence": ["request failed"],
+            "pattern_fingerprint": "deadbeef1234",
+        }
+        retry = dict(initial, content=replacement)
+
+        class ConflictInjectingLlm(MockLlm):
+            """After the second call (patch content), mutate FakeHost to simulate conflict."""
+            def complete_structured(self, **kwargs):
+                result = super().complete_structured(**kwargs)
+                if len(self.calls) == 2:
+                    # Simulate external change after model saw the content
+                    FakeHost.add_skill(name, skill_content(name, "# Externally changed"))
+                return result
+
+        model = ConflictInjectingLlm(initial, retry)
+        result = core.refine_run(model)
+        self.assertFalse(result["success"])
+        self.assertIn("entry changed during refinement planning", result["message"])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Changes

1. **Stale-plan guard** (Phase 1-4): baseline capture, pre-apply conflict checks, transaction preflight, docs.
2. **Review corrections**: raw skill reads (preprocess=False), orphan backup cleanup, honest non-atomic docs.
3. **Autostart**: auto_enabled defaults to True, /refine status command, journal_dir collision warning.
4. **Ledger**: kind-qualified names, legacy row migration.

## Validation

- 124 tests OK
- compiled 9 files
- git diff --check clean

## Known limitations

- Hermes skill_manage has no atomic compare-and-write; documented in README.