### PR TITLE
Harden /refine status, fix non-creating readers, honor pinned model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ it runs and has conflict-aware recovery metadata.
 
 This is a port of the `/refine` concept from
 [Prime Intellect's Prime Agent](https://www.primeintellect.ai/blog/prime-agent)
-(Continual Harness) built on the Hermes plugin system — no core changes and
-pure opt-in plugin behavior.
+(Continual Harness) built on the Hermes plugin system — no core changes, and the
+plugin only loads when it is explicitly enabled.
 
 ---
 
@@ -84,12 +84,18 @@ on Linux and macOS, and `%LOCALAPPDATA%\hermes\plugins\refine\` on Windows.
 Under a Hermes profile it follows that profile; the plugin resolves the location
 through `hermes_constants.get_hermes_home()`.
 
-> **Data safety:** the default `journal_dir` resolves to the plugin install
-> directory itself. If you already have runtime data (`refine_journal.jsonl`,
-> `backups/`, `skill_stats.json`, `prompt_notes.json`) there, move them to a
-> separate path **before** running `hermes plugins install --force`, which
-> deletes the target directory. Set `plugins.entries.refine.journal_dir` to
-> point at the new location. `/refine status` warns when this collision exists.
+> **Data safety — set `journal_dir` before you install.** The default
+> `journal_dir` resolves to the plugin install directory itself, so runtime data
+> (`refine_journal.jsonl`, `backups/`, `skill_stats.json`, `prompt_notes.json`)
+> lands in the directory `hermes plugins install --force` deletes. Point
+> `plugins.entries.refine.journal_dir` at a separate path, and move any existing
+> data there **before** a forced reinstall. `/refine status` and a startup log
+> line both warn while the collision exists.
+>
+> The default is deliberately left alone rather than silently moved: changing it
+> would strand the journal, backups, and ledger of every existing install, and
+> rollback depends on those records. Point the setting at a new path and move the
+> files yourself, once.
 
 1. Add to Hermes `config.yaml`:
 
@@ -116,9 +122,29 @@ hermes gateway restart
 ```
 hermes plugins list
 # refine  0.1.0  Self-improvement loop ...  user  enabled
-/refine status
-# auto: on, blockers: none — auto-refine is active
 ```
+
+Then check that automatic refinement can actually run:
+
+```
+/refine status
+# auto: on
+# turn interval: 25
+# min messages: 15
+# cooldown: 20 min
+# edits today: 0/3
+# journal: /home/you/.hermes/refine-data (does not exist yet, will be created on first write)
+# blockers: none — automatic refinement is active
+```
+
+`blockers` lists every reason a pass would not start; `warnings` lists what does
+not stop it but will cost you later, such as runtime data sitting in the plugin
+directory, or a journal directory that could not be inspected at all.
+
+Status is read-only: it creates no directory — not even the journal directory it
+reports on — writes no journal record, spends no budget, and calls no model. It
+does not reconcile pending approvals, so an unresolved staged edit still counts
+toward the budget it reports.
 
 ---
 
@@ -288,6 +314,33 @@ as negative examples.
 The agent gets a `refine_run` tool (toolset `refine`) and may trigger the same
 serialized flow with an optional reason.
 
+### Which model refine uses
+
+**Refine cannot follow the model you switch to inside a chat session.** Hermes
+resolves provider and model inside its own `call_llm`, and the plugin surface
+(`ctx.llm`, which is itself a `PluginLlm(plugin_id="refine")`) carries no
+session runtime. A mid-session `/model` switch is therefore invisible to this
+plugin, and no arrangement of plugin-side code changes that.
+
+What does work is pinning refine's own target explicitly:
+
+```yaml
+plugins:
+  entries:
+    refine:
+      llm:
+        allow_provider_override: true   # required for `provider` below
+        allow_model_override: true      # required for `model` below
+        provider: opencode-go
+        model: deepseek-v4-flash
+```
+
+Both `allow_*` flags are fail-closed in Hermes: with them off, a pinned value is
+refused rather than applied. Leave `provider`/`model` unset to accept whatever
+the host resolves by default. Every path — the `/refine` command, the
+`refine_run` tool, and both automatic triggers — shares the one host-provided
+client and honors this setting identically.
+
 ---
 
 ## Configuration
@@ -296,7 +349,7 @@ All keys live under `plugins.entries.refine`:
 
 | Key | Type | Default | Description |
 |---|---|---:|---|
-| `auto_enabled` | bool | `false` | Enable automatic turn and session-end attempts. |
+| `auto_enabled` | bool | `true` | Enable automatic turn and session-end attempts. Forced off when the Hermes config cannot be read. |
 | `auto_min_messages` | int | `15` | Minimum messages for session-end auto-analysis. |
 | `auto_turn_interval` | int | `25` | Assistant messages added since this session's last automatic attempt; `0` disables only the turn trigger. |
 | `auto_cooldown_minutes` | int | `20` | Minimum durable journal-derived gap between automatic attempts. |
@@ -349,6 +402,12 @@ llm:
   reasoning and no final text is reported as `llm_incomplete`; pin a
   non-reasoning model for refine with `plugins.entries.refine.llm` (`model` /
   `provider`) under the existing trust policy when that mitigation is needed.
+- **No access to the session's active model:** `ctx.llm` is a
+  `PluginLlm(plugin_id=...)` facade, and Hermes resolves provider and model
+  inside `call_llm` without passing any session runtime to plugins. A model
+  switched mid-session cannot reach refine, so the pinned `llm.model` /
+  `llm.provider` keys above are the only way to steer it. Closing this would
+  need Hermes to expose the resolved session provider/model to the plugin call.
 - **No host approval for the prompt-note store:** it is a plugin-owned atomic
   file, not a host memory or skill write. Host-managed skill and memory changes
   still respect staged approvals and reconciliation.
@@ -430,7 +489,7 @@ cd <HERMES_HOME>/plugins/refine
 python -m tests.run_tests
 ```
 
-The stdlib-only suite (98 tests) installs a fake Hermes host before importing the plugin.
+The stdlib-only suite (138 tests) installs a fake Hermes host before importing the plugin.
 Every database, journal, backup, skill, memory file, ledger, and lock lives
 under a fresh `TemporaryDirectory`; running the suite cannot touch live Hermes
 or profile state. It covers proposal completion, host action mapping,
@@ -488,8 +547,9 @@ skill content becomes `no_op`; it is never redacted, truncated, or used to
 generate a destructive replacement.
 
 Credentials are redacted first, but remaining content is ordinary conversation
-or skill content. Keep `auto_enabled: false` if model-bound session analysis
-must be manually initiated.
+or skill content. Automatic analysis is on by default; set
+`auto_enabled: false` if model-bound session analysis must be manually
+initiated.
 
 ---
 

--- a/__init__.py
+++ b/__init__.py
@@ -60,6 +60,21 @@ def _get_llm(ctx) -> PluginLlm:
     return PluginLlm(plugin_id="refine")
 
 
+def _session_llm() -> PluginLlm:
+    """Return the host-provided client, falling back to a fresh one.
+
+    Reusing the host-provided facade keeps every path on one client instead of
+    building a new one per invocation. It does **not** change which model is
+    used: ``ctx.llm`` is itself a ``PluginLlm(plugin_id=...)``, and Hermes
+    resolves provider and model inside its own ``call_llm``. A model switched
+    during a chat session is not visible to plugins; pin
+    ``plugins.entries.refine.llm.model`` to steer refine's own calls.
+    """
+    return _REGISTERED_LLM if _REGISTERED_LLM is not None else PluginLlm(
+        plugin_id="refine"
+    )
+
+
 def _assistant_turn_count(conversation_history: Any) -> int:
     """Count assistant messages in host callback history without assuming its shape.
 
@@ -77,10 +92,8 @@ def _assistant_turn_count(conversation_history: Any) -> int:
 
 
 def _cooldown_elapsed() -> bool:
-    last_attempt = journal.last_attempt_ts()
-    if last_attempt is None:
-        return True
-    return time.time() - last_attempt >= config.auto_cooldown_minutes() * 60
+    # One owner for the arithmetic, so the gate and /refine status cannot drift.
+    return core.auto_cooldown_remaining_minutes() <= 0
 
 
 def _turn_interval_reached(session_id: str, assistant_turns: int) -> bool:
@@ -123,7 +136,7 @@ def _run_auto_refine(session_id: str, *, cleanup_session_notes: bool = False) ->
         with journal.try_mutation_lock() as acquired:
             if acquired and _cooldown_elapsed():
                 core.refine_run(
-                    llm=_REGISTERED_LLM or PluginLlm(plugin_id="refine"),
+                    llm=_session_llm(),
                     session_id=session_id,
                     auto=True,
                 )
@@ -164,6 +177,11 @@ def _on_pre_llm_call(**kwargs) -> Optional[dict]:
         if not config.prompt_notes_enabled():
             return None
         session_id = journal.normalize_prompt_note_session_id(kwargs.get("session_id", ""))
+        # With no store there is nothing to inject, and taking the lock would
+        # create journal_dir on a path that may simply be mistyped. This hook
+        # runs every turn, so it must stay strictly read-only.
+        if not journal.prompt_notes_read_path().is_file():
+            return None
         # Prefer reading under the lock, but never drop notes for a whole turn
         # just because a refine pass owns it: the store is only ever replaced
         # atomically, so a lock-free read still sees one complete generation.
@@ -233,35 +251,32 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
 
     if args == "status":
         try:
-            from .sanitization import scrub_text as _scrub
-        except ImportError:
-            from sanitization import scrub_text as _scrub
-        try:
             status = core.refine_status()
         except Exception as exc:
             logger.exception("refine status failed")
-            return f"❌ Status failed: {exc}"
+            return f"❌ Status failed: {core.scrub_text(str(exc))}"
         lines = [
             f"auto: {'on' if status['auto_enabled'] else 'off'}",
-            f"turn interval: {status['auto_turn_interval']}",
+            f"turn interval: {status['auto_turn_interval']}"
+            + ("" if status["turn_trigger_enabled"] else " (turn trigger off)"),
             f"min messages: {status['auto_min_messages']}",
             f"cooldown: {status['auto_cooldown_minutes']} min",
             f"edits today: {status['edits_today']}/{status['max_edits_per_day']}",
-            f"journal: {status['journal_dir']}",
+            f"journal: {status['journal_dir']} ({status['journal_dir_state_text']})",
         ]
-        if status.get("cooldown_remaining_minutes"):
-            lines.append(f"cooldown remaining: {status['cooldown_remaining_minutes']} min")
+        if status["cooldown_remaining_minutes"] > 0:
+            lines.append(
+                f"cooldown remaining: {status['cooldown_remaining_minutes']} min"
+            )
         if status["blockers"]:
             lines.append("blockers:")
-            for b in status["blockers"]:
-                lines.append(f"  • {b}")
+            lines.extend(f"  • {item['message']}" for item in status["blockers"])
         else:
-            lines.append("blockers: none — auto-refine is active")
+            lines.append("blockers: none — automatic refinement is active")
         if status["warnings"]:
             lines.append("warnings:")
-            for w in status["warnings"]:
-                lines.append(f"  ⚠ {w}")
-        return _scrub("\n".join(lines))
+            lines.extend(f"  ⚠ {item['message']}" for item in status["warnings"])
+        return core.scrub_text("\n".join(lines))
 
     if args == "rollback":
         return (
@@ -277,9 +292,7 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
         return f"❌ Rollback failed: {result.get('error', 'unknown error')}"
 
     try:
-        result = core.refine_run(
-            llm=PluginLlm(plugin_id="refine"), reason=args, auto=False
-        )
+        result = core.refine_run(llm=_session_llm(), reason=args, auto=False)
     except Exception as exc:
         logger.exception("refine command failed")
         return f"❌ Refine failed: {exc}"
@@ -328,9 +341,7 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
 def _handle_refine_run(args: dict, **kw) -> str:
     reason = args.get("reason", "") if isinstance(args, dict) else ""
     try:
-        result = core.refine_run(
-            llm=PluginLlm(plugin_id="refine"), reason=reason, auto=False
-        )
+        result = core.refine_run(llm=_session_llm(), reason=reason, auto=False)
     except Exception as exc:
         logger.exception("refine_run tool failed")
         return json.dumps({"success": False, "error": str(exc)})
@@ -426,19 +437,22 @@ _REGISTER_WARNED = False
 
 
 def _warn_on_register() -> None:
-    """Log once-per-process warnings about configuration issues."""
+    """Warn once per process that runtime data sits in the plugin directory."""
     global _REGISTER_WARNED
     if _REGISTER_WARNED:
         return
-    _REGISTER_WARNED = True
-    jdir = config.journal_dir()
     try:
-        if (jdir / "plugin.yaml").is_file():
-            logger.warning(
-                "Refine journal_dir (%s) contains plugin source code. "
-                "A forced reinstall may delete runtime data (journal, backups, ledger). "
-                "Set plugins.entries.refine.journal_dir to a separate path.",
-                jdir,
-            )
+        jdir = config.journal_dir()
+        if not (jdir / "plugin.yaml").is_file():
+            return
     except Exception:
-        pass
+        return
+    # Set only after the condition held, so a warning is never skipped because
+    # an earlier call returned before there was anything to report.
+    _REGISTER_WARNED = True
+    logger.warning(
+        "Refine journal_dir (%s) contains plugin source code. "
+        "A forced reinstall may delete runtime data (journal, backups, ledger). "
+        "Set plugins.entries.refine.journal_dir to a separate path.",
+        jdir,
+    )

--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ def _load_raw_config() -> Optional[Dict[str, Any]]:
 
 def _get_refine_entry() -> Dict[str, Any]:
     raw = _load_raw_config()
-    if not raw:
+    if not isinstance(raw, dict) or not raw:
         return {}
     plugins_cfg = raw.get("plugins", {})
     if not isinstance(plugins_cfg, dict):
@@ -84,8 +84,29 @@ def get_str(key: str, default: str = "") -> str:
     return default
 
 
+def config_available() -> bool:
+    """Whether the Hermes config was both readable and shaped like a config.
+
+    A file that parses into a non-mapping (a bare list, a string) is as
+    unusable as one that fails to parse, so it must not be reported as
+    available: every accessor below would raise on it.
+    """
+    return isinstance(_load_raw_config(), dict)
+
+
 # Convenience accessors
 def auto_enabled() -> bool:
+    """Automatic refinement is on by default, but never on an unreadable config.
+
+    The default is ``True`` so refinement works right after install. That default
+    may only apply when the config was actually readable: defaulting to ``True``
+    while the file cannot be parsed would silently override an explicit
+    ``auto_enabled: false`` the user did set, and resume model-bound trajectory
+    analysis they had turned off. An unreadable config therefore fails closed,
+    and ``/refine status`` reports that as the reason.
+    """
+    if not config_available():
+        return False
     return get_bool("auto_enabled", True)
 
 
@@ -175,6 +196,29 @@ def overview_max_chars() -> int:
 def history_max_entries() -> int:
     """Maximum prior create/patch outcomes included in a proposal prompt."""
     return get_int("history_max_entries", 20, min_val=1)
+
+
+def _llm_entry() -> Dict[str, Any]:
+    block = _get_refine_entry().get("llm")
+    return block if isinstance(block, dict) else {}
+
+
+def llm_provider() -> str:
+    """Provider to request for refine's own calls; empty means host default."""
+    value = _llm_entry().get("provider")
+    return value.strip() if isinstance(value, str) else ""
+
+
+def llm_model() -> str:
+    """Model to request for refine's own calls; empty means host default.
+
+    Hermes resolves the model inside ``call_llm`` and exposes no session model
+    to plugins, so this is the only way to steer which model refine uses. The
+    host still gates it: without ``allow_model_override`` (and
+    ``allow_provider_override``) the request is refused rather than applied.
+    """
+    value = _llm_entry().get("model")
+    return value.strip() if isinstance(value, str) else ""
 
 
 def journal_dir() -> Path:

--- a/core.py
+++ b/core.py
@@ -343,71 +343,187 @@ def _reconcile_pending() -> List[Dict[str, Any]]:
     return changed
 
 
+def auto_cooldown_remaining_minutes() -> float:
+    """Minutes left on the automatic-attempt cooldown; ``0.0`` when elapsed.
+
+    Single owner of this arithmetic so the hook gate and the status report can
+    never disagree about whether the cooldown has passed.
+    """
+    last_attempt = journal.last_attempt_ts()
+    if last_attempt is None:
+        return 0.0
+    remaining = config.auto_cooldown_minutes() * 60 - (time.time() - last_attempt)
+    return remaining / 60 if remaining > 0 else 0.0
+
+
+_JOURNAL_DIR_STATE_TEXT = {
+    "ok": "usable",
+    "missing_creatable": "does not exist yet, will be created on first write",
+    "not_a_directory": "path exists but is not a directory",
+    "unwritable": "not writable",
+    "unknown": "could not be inspected",
+}
+
+
+def _journal_dir_state(directory: Path) -> str:
+    """Classify the journal directory without creating or writing anything.
+
+    ``missing_creatable`` walks up to the nearest existing ancestor, because a
+    configured path several levels deep is still creatable on first use.
+    """
+    try:
+        if directory.is_dir():
+            return "ok" if os.access(str(directory), os.W_OK) else "unwritable"
+        if directory.exists():
+            return "not_a_directory"
+        for ancestor in directory.parents:
+            if not ancestor.exists():
+                continue
+            if not ancestor.is_dir():
+                return "not_a_directory"
+            return (
+                "missing_creatable"
+                if os.access(str(ancestor), os.W_OK)
+                else "unwritable"
+            )
+        return "unwritable"
+    except Exception:
+        return "unknown"
+
+
 def refine_status() -> Dict[str, Any]:
-    """Report why automatic refinement will or will not run. Read-only."""
+    """Report why automatic refinement will or will not run.
+
+    Strictly read-only: it creates no directory, writes no journal record,
+    consumes no daily budget, and never calls a model. It also does not
+    reconcile pending approvals, so an unresolved staged edit still counts
+    toward the budget it reports.
+    """
+    config_readable = config.config_available()
     auto = config.auto_enabled()
     interval = config.auto_turn_interval()
-    min_msgs = config.auto_min_messages()
-    cooldown_minutes = config.auto_cooldown_minutes()
     max_edits = config.max_edits_per_day()
-    edits_today = journal.count_today_applied()
-    last_ts = journal.last_attempt_ts()
     jdir = config.journal_dir()
+    jdir_state = _journal_dir_state(jdir)
 
+    # Read journal-derived numbers only when a journal actually exists, so a
+    # mistyped journal_dir is reported rather than silently created.
+    journal_present = False
+    journal_readable = True
+    edits_today = 0
+    last_ts: Optional[float] = None
     cooldown_remaining = 0.0
-    if last_ts is not None:
-        elapsed = time.time() - last_ts
-        remaining = cooldown_minutes * 60 - elapsed
-        if remaining > 0:
-            cooldown_remaining = remaining / 60
-
-    jdir_writable = False
     try:
-        jdir.mkdir(parents=True, exist_ok=True)
-        jdir_writable = os.access(str(jdir), os.W_OK)
-    except Exception:
-        pass
+        journal_path = journal.journal_read_path()
+        journal_present = journal_path.is_file()
+        if journal_present:
+            # An unparseable journal yields no entries rather than an error, so
+            # probe readability explicitly: silently reporting "0 edits today"
+            # would also report the cooldown as elapsed and let automatic passes
+            # run unthrottled against a journal nobody can read.
+            journal_path.read_text(encoding="utf-8")
+            edits_today = journal.count_today_applied()
+            last_ts = journal.last_attempt_ts()
+            cooldown_remaining = auto_cooldown_remaining_minutes()
+    except Exception as exc:
+        journal_readable = False
+        logger.warning("Cannot read refine journal for status: %s", scrub_text(str(exc)))
 
-    jdir_is_plugin_source = False
-    try:
-        plugin_yaml = jdir / "plugin.yaml"
-        jdir_is_plugin_source = plugin_yaml.is_file()
-    except Exception:
-        pass
-
-    blockers: List[str] = []
-    if not auto:
-        blockers.append("Автоматичний режим вимкнений у налаштуваннях")
-    if interval <= 0:
-        blockers.append("Тригер за ходами вимкнений (interval=0)")
+    blockers: List[Dict[str, str]] = []
+    if not config_readable:
+        blockers.append({
+            "code": "config_unreadable",
+            "message": (
+                "Hermes config could not be read, so automatic refinement stays "
+                "off rather than overriding a setting that cannot be confirmed"
+            ),
+        })
+    elif not auto:
+        blockers.append({
+            "code": "auto_disabled",
+            "message": "Automatic refinement is disabled in the config",
+        })
     if edits_today >= max_edits:
-        blockers.append("Денний ліміт правок уже використаний")
+        blockers.append({
+            "code": "budget_exhausted",
+            "message": f"Daily edit budget is used up ({edits_today}/{max_edits})",
+        })
+    cooldown_shown = round(cooldown_remaining, 1)
     if cooldown_remaining > 0:
-        blockers.append(f"Ще діє пауза між спробами ({cooldown_remaining:.0f} хв)")
-    if not jdir_writable:
-        blockers.append("Немає доступу до папки журналу")
+        blockers.append({
+            "code": "cooldown_active",
+            # Reuse the rounded value the report prints, so the blocker and the
+            # cooldown line can never contradict each other.
+            "message": f"Cooldown still active ({cooldown_shown} min left)",
+        })
+    if jdir_state in ("unwritable", "not_a_directory"):
+        blockers.append({
+            "code": "journal_dir_unusable",
+            "message": (
+                "Journal directory is not usable "
+                f"({_JOURNAL_DIR_STATE_TEXT.get(jdir_state, jdir_state)})"
+            ),
+        })
+    if not journal_readable:
+        blockers.append({
+            "code": "journal_unreadable",
+            "message": "The journal exists but could not be read",
+        })
 
-    warnings: List[str] = []
-    if jdir_is_plugin_source:
-        warnings.append(
-            "Папка журналу збігається з папкою коду плагіна — "
-            "hermes plugins install --force може видалити журнал"
-        )
+    warnings: List[Dict[str, str]] = []
+    plugin_source_collision = False
+    try:
+        plugin_source_collision = (jdir / "plugin.yaml").is_file()
+    except Exception:
+        pass
+    if plugin_source_collision:
+        warnings.append({
+            "code": "journal_dir_is_plugin_source",
+            "message": (
+                "Journal directory holds the plugin source; "
+                "'hermes plugins install --force' would delete runtime data"
+            ),
+        })
+    if not interval:
+        warnings.append({
+            "code": "turn_trigger_disabled",
+            "message": (
+                "Turn trigger is off (auto_turn_interval=0); the session-end "
+                "fallback still runs"
+            ),
+        })
+    if jdir_state == "unknown":
+        warnings.append({
+            "code": "journal_dir_unknown",
+            "message": (
+                "The journal directory could not be inspected, so this report "
+                "cannot confirm refinement is able to run"
+            ),
+        })
 
     return {
+        "config_readable": config_readable,
         "auto_enabled": auto,
         "auto_turn_interval": interval,
-        "auto_min_messages": min_msgs,
-        "auto_cooldown_minutes": cooldown_minutes,
+        "turn_trigger_enabled": bool(interval),
+        "auto_min_messages": config.auto_min_messages(),
+        "auto_cooldown_minutes": config.auto_cooldown_minutes(),
         "last_attempt_ts": last_ts,
-        "cooldown_remaining_minutes": round(cooldown_remaining, 1),
+        "cooldown_remaining_minutes": cooldown_shown,
         "edits_today": edits_today,
         "max_edits_per_day": max_edits,
+        "journal_present": journal_present,
+        "journal_readable": journal_readable,
+        # The real path, because the report tells the user to move files in and
+        # out of it. Truncating it to a tilde made it unusable in a shell.
         "journal_dir": str(jdir),
-        "journal_dir_writable": jdir_writable,
-        "journal_dir_is_plugin_source": jdir_is_plugin_source,
+        "journal_dir_state": jdir_state,
+        "journal_dir_state_text": _JOURNAL_DIR_STATE_TEXT.get(jdir_state, jdir_state),
+        "journal_dir_is_plugin_source": plugin_source_collision,
         "blockers": blockers,
+        "blocker_codes": [b["code"] for b in blockers],
         "warnings": warnings,
+        "warning_codes": [w["code"] for w in warnings],
     }
 
 

--- a/journal.py
+++ b/journal.py
@@ -42,6 +42,15 @@ def journal_path() -> Path:
     return ensure_dirs() / _JOURNAL_FILE_NAME
 
 
+def journal_read_path() -> Path:
+    """Journal location for readers, without creating anything.
+
+    Readers must not materialize a mistyped ``journal_dir``: a diagnostic that
+    creates the directory it is meant to inspect destroys its own evidence.
+    """
+    return journal_dir() / _JOURNAL_FILE_NAME
+
+
 def backups_dir() -> Path:
     return ensure_dirs() / _BACKUPS_DIR_NAME
 
@@ -49,6 +58,11 @@ def backups_dir() -> Path:
 def prompt_notes_path() -> Path:
     """Return the plugin-owned prompt-note store; never a host memory path."""
     return ensure_dirs() / _PROMPT_NOTES_FILE_NAME
+
+
+def prompt_notes_read_path() -> Path:
+    """Prompt-note store for readers, without creating anything."""
+    return journal_dir() / _PROMPT_NOTES_FILE_NAME
 
 
 def normalize_prompt_note_session_id(session_id: Any) -> str:
@@ -86,7 +100,10 @@ def _normalize_prompt_note(note: Any) -> Optional[Dict[str, str]]:
 
 def _load_prompt_notes() -> Optional[List[Dict[str, str]]]:
     """Return validated prompt notes, [] when absent, or None when unavailable."""
-    path = prompt_notes_path()
+    # A reader must not create journal_dir: this runs on the pre_llm_call path
+    # of every turn, and materializing a mistyped path there would erase the
+    # very evidence /refine status exists to report.
+    path = prompt_notes_read_path()
     if not path.exists():
         return []
     if not path.is_file():
@@ -380,7 +397,7 @@ def _atomic_write_text(path: Path, content: str) -> None:
 
 def _load_entries() -> List[Dict[str, Any]]:
     """Stream journal state, skipping corrupt lines and collapsing updates by id."""
-    path = journal_path()
+    path = journal_read_path()
     if not path.is_file():
         return []
     latest: Dict[str, Dict[str, Any]] = {}

--- a/ledger.py
+++ b/ledger.py
@@ -28,8 +28,13 @@ def stats_path() -> Path:
     return path / _STATS_FILE_NAME
 
 
+def stats_read_path() -> Path:
+    """Ledger location for readers, without creating anything."""
+    return journal_dir() / _STATS_FILE_NAME
+
+
 def load_stats() -> Dict[str, Any]:
-    path = stats_path()
+    path = stats_read_path()
     if not path.is_file():
         return {}
     try:

--- a/llm.py
+++ b/llm.py
@@ -31,6 +31,25 @@ _CHARS_PER_TOKEN = 3
 _PROPOSAL_ENVELOPE_TOKENS = 1024
 
 
+def _pinned_target() -> Dict[str, str]:
+    """Provider/model to request, when the config pins them.
+
+    Hermes resolves the model inside its own ``call_llm`` and gives plugins no
+    access to the model a session switched to, so an explicitly pinned target
+    is the only way to control which model refine uses. Omitted keys leave the
+    host default in place; the host's trust gate still decides whether a
+    request is honored.
+    """
+    target: Dict[str, str] = {}
+    provider = config.llm_provider()
+    model = config.llm_model()
+    if provider:
+        target["provider"] = provider
+    if model:
+        target["model"] = model
+    return target
+
+
 def proposal_max_tokens(edit_count: int = 1) -> int:
     """Budget output for the largest reply the content guardrail actually permits.
 
@@ -254,6 +273,7 @@ def _propose_structured(
         purpose="refine",
         temperature=0.0,
         max_tokens=max_tokens,
+        **_pinned_target(),
     )
     system_prompt = scrub_text(REFINE_SYSTEM_PROMPT)
     try:
@@ -312,6 +332,7 @@ def review_fallback(llm: PluginLlm, evidence_text: str) -> Dict[str, Any]:
             purpose="refine",
             temperature=0.0,
             max_tokens=REVIEWER_MAX_TOKENS,
+            **_pinned_target(),
         )
         reply = _salvage_parsed(result, requested_max_tokens=REVIEWER_MAX_TOKENS)
         if reply.failure:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -382,6 +382,9 @@ class RefineTests(unittest.TestCase):
         # Turn marks are process-lifetime state keyed by session id; clear them so
         # one test's attempt point cannot suppress the next test's trigger.
         plugin_init._AUTO_TURN_MARKS.clear()
+        # Both are process-lifetime globals: left set, they leak across tests.
+        plugin_init._REGISTER_WARNED = False
+        plugin_init._REGISTERED_LLM = None
 
     def tearDown(self):
         self.temp.cleanup()
@@ -3248,34 +3251,142 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
     # ── Autostart / status tests ──────────────────────────────────────────────
 
     def test_status_reports_blockers_when_auto_disabled(self):
-        with patch.object(config, "auto_enabled", return_value=False):
-            status = core.refine_status()
+        FakeHost.entry_config()["auto_enabled"] = False
+        status = core.refine_status()
         self.assertFalse(status["auto_enabled"])
-        self.assertTrue(any("вимкнений" in b for b in status["blockers"]))
+        self.assertIn("auto_disabled", status["blocker_codes"])
 
     def test_status_reports_no_blockers_when_ready(self):
         status = core.refine_status()
         self.assertTrue(status["auto_enabled"])
-        # Fresh journal, no cooldown, budget free → no blockers
-        self.assertEqual(status["blockers"], [])
+        self.assertEqual(status["blocker_codes"], [])
 
-    def test_status_reports_budget_exhausted(self):
-        # Temporarily lower budget to 1 and exhaust it
+    def test_unreadable_config_keeps_auto_off_and_says_so(self):
+        # An unreadable config must not resurrect analysis the user turned off.
+        FakeHost.entry_config()["auto_enabled"] = False
+        with patch.object(config, "_load_raw_config", return_value=None):
+            self.assertFalse(config.auto_enabled())
+            status = core.refine_status()
+        self.assertFalse(status["config_readable"])
+        self.assertIn("config_unreadable", status["blocker_codes"])
+        self.assertNotIn("auto_disabled", status["blocker_codes"])
+
+    def test_status_reports_budget_exhausted_specifically(self):
         FakeHost.entry_config()["max_edits_per_day"] = 1
-        result = self.run_proposal(skill_proposal("status-budget-test"))
-        self.assertTrue(result["success"])
+        self.assertTrue(self.run_proposal(skill_proposal("status-budget"))["success"])
         status = core.refine_status()
         self.assertEqual(status["edits_today"], 1)
-        self.assertGreater(len(status["blockers"]), 0)
+        self.assertIn("budget_exhausted", status["blocker_codes"])
+
+    def test_disabled_turn_trigger_is_a_warning_not_a_blocker(self):
+        # The session-end fallback still runs at interval 0, so calling it a
+        # blocker would tell the user refinement stopped when it has not.
+        FakeHost.entry_config()["auto_turn_interval"] = 0
+        status = core.refine_status()
+        self.assertFalse(status["turn_trigger_enabled"])
+        self.assertNotIn("turn_trigger_disabled", status["blocker_codes"])
+        self.assertIn("turn_trigger_disabled", status["warning_codes"])
 
     def test_status_does_not_create_journal_entries(self):
         before = len(journal.entries())
         core.refine_status()
         self.assertEqual(len(journal.entries()), before)
 
-    def test_status_does_not_call_model(self):
-        with patch.object(core, "refine_run", side_effect=AssertionError("model called")):
-            core.refine_status()  # should not raise
+    def test_status_does_not_create_the_journal_directory(self):
+        missing = self.root / "never-created" / "refine-data"
+        FakeHost.entry_config()["journal_dir"] = str(missing)
+        status = core.refine_status()
+        self.assertFalse(missing.exists())
+        self.assertFalse(status["journal_present"])
+        self.assertEqual(status["journal_dir_state"], "missing_creatable")
+
+    def test_status_reports_unusable_journal_dir_instead_of_raising(self):
+        blocked = self.root / "journal-is-a-file"
+        blocked.write_text("not a directory", encoding="utf-8")
+        FakeHost.entry_config()["journal_dir"] = str(blocked)
+        status = core.refine_status()
+        self.assertEqual(status["journal_dir_state"], "not_a_directory")
+        self.assertIn("journal_dir_unusable", status["blocker_codes"])
+
+    def test_status_never_reaches_an_llm_or_a_run(self):
+        with patch.object(core, "refine_run", side_effect=AssertionError("run called")), \
+             patch.object(core._llm, "propose", side_effect=AssertionError("propose called")), \
+             patch.object(core._llm, "review_fallback", side_effect=AssertionError("reviewer called")), \
+             patch.object(plugin_init, "PluginLlm", side_effect=AssertionError("client built")):
+            core.refine_status()
+            self.assertIn("auto:", plugin_init._handle_refine_command("status"))
+
+    def test_reading_prompt_notes_does_not_create_the_journal_dir(self):
+        # This hook runs every turn, so a reader here would erase the evidence
+        # /refine status is supposed to report.
+        missing = self.root / "mistyped" / "refine-data"
+        FakeHost.entry_config()["journal_dir"] = str(missing)
+        self.assertIsNone(plugin_init._on_pre_llm_call(session_id="session"))
+        self.assertFalse(missing.exists())
+        self.assertEqual(ledger.load_stats(), {})
+        self.assertFalse(missing.exists())
+        self.assertEqual(core.refine_status()["journal_dir_state"], "missing_creatable")
+        self.assertFalse(missing.exists())
+
+    def test_non_mapping_config_is_unavailable_rather_than_raising(self):
+        with patch.object(config, "_load_raw_config", return_value=["not", "a", "mapping"]):
+            self.assertFalse(config.config_available())
+            self.assertFalse(config.auto_enabled())
+            status = core.refine_status()
+            self.assertIsNone(plugin_init._on_post_llm_call(session_id="s"))
+        self.assertIn("config_unreadable", status["blocker_codes"])
+
+    def test_unreadable_journal_is_reported_not_silently_zero(self):
+        journal.log(
+            trigger="manual", reason="seed", session_id="session",
+            proposal={"action": "no_op", "reason": "seed"}, outcome="no_op",
+        )
+        with patch.object(Path, "read_text", side_effect=OSError("unreadable")):
+            status = core.refine_status()
+        self.assertFalse(status["journal_readable"])
+        self.assertIn("journal_unreadable", status["blocker_codes"])
+
+    def test_uninspectable_journal_dir_is_not_silently_clean(self):
+        with patch.object(core, "_journal_dir_state", return_value="unknown"):
+            status = core.refine_status()
+        self.assertIn("journal_dir_unknown", status["warning_codes"])
+
+    def test_cooldown_blocker_matches_the_reported_value(self):
+        journal.log(
+            trigger="auto", reason="recent", session_id="session",
+            proposal={"action": "no_op", "reason": "recent"}, outcome="no_op",
+        )
+        status = core.refine_status()
+        self.assertIn("cooldown_active", status["blocker_codes"])
+        shown = str(status["cooldown_remaining_minutes"])
+        message = next(
+            b["message"] for b in status["blockers"] if b["code"] == "cooldown_active"
+        )
+        self.assertIn(shown, message)
+
+    def test_status_shows_a_usable_journal_path(self):
+        status = core.refine_status()
+        self.assertEqual(status["journal_dir"], str(config.journal_dir()))
+        self.assertIn(status["journal_dir_state_text"], plugin_init._handle_refine_command("status"))
+
+    def test_pinned_provider_and_model_reach_the_host_call(self):
+        FakeHost.entry_config()["llm"] = {"provider": "opencode-go", "model": "deepseek-v4"}
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        llm.propose(model, "evidence", [], [])
+        self.assertEqual(model.calls[0]["provider"], "opencode-go")
+        self.assertEqual(model.calls[0]["model"], "deepseek-v4")
+
+    def test_unpinned_model_leaves_the_host_default(self):
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        llm.propose(model, "evidence", [], [])
+        self.assertNotIn("provider", model.calls[0])
+        self.assertNotIn("model", model.calls[0])
 
     def test_status_command_returns_text_not_dict(self):
         result = plugin_init._handle_refine_command("status")
@@ -3291,39 +3402,61 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         self.assertEqual(run.call_args.kwargs["reason"], "status of gmail failures")
 
     def test_journal_dir_collision_warning(self):
-        # Place a plugin.yaml in journal_dir to simulate collision
         jdir = Path(config.journal_dir())
         jdir.mkdir(parents=True, exist_ok=True)
         (jdir / "plugin.yaml").write_text("name: refine\n", encoding="utf-8")
         status = core.refine_status()
         self.assertTrue(status["journal_dir_is_plugin_source"])
-        self.assertTrue(len(status["warnings"]) > 0)
+        self.assertIn("journal_dir_is_plugin_source", status["warning_codes"])
 
-    def test_register_warns_on_collision(self):
+    def test_register_warns_on_collision_exactly_once(self):
         jdir = Path(config.journal_dir())
         jdir.mkdir(parents=True, exist_ok=True)
         (jdir / "plugin.yaml").write_text("name: refine\n", encoding="utf-8")
-        plugin_init._REGISTER_WARNED = False
-        # The logger name when imported directly is __init__
+        with self.assertLogs(level="WARNING") as cm:
+            plugin_init._warn_on_register()
+            plugin_init._warn_on_register()
+        collision = [msg for msg in cm.output if "journal_dir" in msg]
+        self.assertEqual(len(collision), 1)
+
+    def test_register_does_not_warn_without_collision(self):
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level="WARNING"):
+                plugin_init._warn_on_register()
+        # A later genuine collision must still be reported.
+        jdir = Path(config.journal_dir())
+        jdir.mkdir(parents=True, exist_ok=True)
+        (jdir / "plugin.yaml").write_text("name: refine\n", encoding="utf-8")
         with self.assertLogs(level="WARNING") as cm:
             plugin_init._warn_on_register()
         self.assertTrue(any("journal_dir" in msg for msg in cm.output))
-        # Second call does not warn again due to the flag
-        self.assertTrue(plugin_init._REGISTER_WARNED)
-
-    def test_register_does_not_warn_without_collision(self):
-        plugin_init._REGISTER_WARNED = False
-        # No plugin.yaml in journal_dir — should not log a warning at our level
-        try:
-            with self.assertLogs(level="WARNING"):
-                plugin_init._warn_on_register()
-            self.fail("Should not have logged a warning without collision")
-        except AssertionError as exc:
-            if "no logs" not in str(exc).lower():
-                raise
 
     def test_auto_enabled_defaults_to_true(self):
         self.assertTrue(config.auto_enabled())
+
+    def test_manual_command_and_tool_use_the_session_client(self):
+        # One host-provided facade for every path, instead of a new client per
+        # invocation. A falsy-but-present client must still be honored.
+        class FalsyClient:
+            def __bool__(self):
+                return False
+
+        session_client = FalsyClient()
+        plugin_init._REGISTERED_LLM = session_client
+        with patch.object(plugin_init.core, "refine_run", return_value={
+            "success": True, "message": "done", "outcome": "no_op",
+        }) as run:
+            plugin_init._handle_refine_command("look at gmail failures")
+            plugin_init._handle_refine_run({"reason": "same"})
+        self.assertEqual(len(run.call_args_list), 2)
+        for call in run.call_args_list:
+            self.assertIs(call.kwargs["llm"], session_client)
+
+    def test_session_client_falls_back_when_host_gave_none(self):
+        plugin_init._REGISTERED_LLM = None
+        sentinel = object()
+        with patch.object(plugin_init, "PluginLlm", return_value=sentinel):
+            self.assertIs(plugin_init._session_llm(), sentinel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two independent review passes on the autostart work scored 6.5 and 7. All actionable findings are fixed here. Readers no longer create journal_dir (pre_llm_call previously created a mistyped path every turn). Status now distinguishes an unreadable journal from an empty one, reports an uninspectable directory instead of claiming all clear, and hardens config_available to mean readable AND usable. Corrected diagnosis on model selection: ctx.llm is itself a PluginLlm facade and Hermes resolves the model inside call_llm, so a mid-session switch cannot reach a plugin; README corrected, and llm.py now passes the pinned provider/model the README already documented. 138 tests OK, compiled 9 files, git diff --check clean.