### PR TITLE
Correct how refine's model is resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,13 +316,23 @@ serialized flow with an optional reason.
 
 ### Which model refine uses
 
-**Refine cannot follow the model you switch to inside a chat session.** Hermes
-resolves provider and model inside its own `call_llm`, and the plugin surface
-(`ctx.llm`, which is itself a `PluginLlm(plugin_id="refine")`) carries no
-session runtime. A mid-session `/model` switch is therefore invisible to this
-plugin, and no arrangement of plugin-side code changes that.
+By default refine inherits the user's **live main model**. Hermes resolves the
+model inside its own `call_llm`: with no explicit provider/model it takes the
+`auto` path, whose first step is "main provider + main model", and the main
+model is read from a process-local runtime override that the agent refreshes at
+the top of every turn. So a model switched mid-session is intended to apply to
+refine as well, without any plugin-side plumbing.
 
-What does work is pinning refine's own target explicitly:
+One caveat is worth knowing, because it is not a refine bug and refine cannot
+fix it: Hermes caches auxiliary clients under a key that does **not** include
+the resolved model, and the plugin call passes no live-runtime dict, so the key
+is constant. In a long-running gateway the first cached client keeps supplying
+the model captured when it was built, which can outlive a mid-session switch
+until that entry is evicted or the process restarts. Restarting the gateway is
+the reliable way to clear it.
+
+Pinning refine's own target sidesteps all of that and makes the choice
+deterministic:
 
 ```yaml
 plugins:
@@ -336,8 +346,8 @@ plugins:
 ```
 
 Both `allow_*` flags are fail-closed in Hermes: with them off, a pinned value is
-refused rather than applied. Leave `provider`/`model` unset to accept whatever
-the host resolves by default. Every path — the `/refine` command, the
+refused rather than applied. Leave `provider`/`model` unset to inherit the live
+main model as described above. Every path — the `/refine` command, the
 `refine_run` tool, and both automatic triggers — shares the one host-provided
 client and honors this setting identically.
 
@@ -402,12 +412,14 @@ llm:
   reasoning and no final text is reported as `llm_incomplete`; pin a
   non-reasoning model for refine with `plugins.entries.refine.llm` (`model` /
   `provider`) under the existing trust policy when that mitigation is needed.
-- **No access to the session's active model:** `ctx.llm` is a
-  `PluginLlm(plugin_id=...)` facade, and Hermes resolves provider and model
-  inside `call_llm` without passing any session runtime to plugins. A model
-  switched mid-session cannot reach refine, so the pinned `llm.model` /
-  `llm.provider` keys above are the only way to steer it. Closing this would
-  need Hermes to expose the resolved session provider/model to the plugin call.
+- **A model switch can be masked by Hermes's auxiliary client cache:** plugin
+  calls resolve through the `auto` path, which prefers the live main model, but
+  the client cache key omits the resolved model and the plugin call supplies no
+  live-runtime dict, so the key never changes. A cached client therefore keeps
+  its original model until it is evicted or the process restarts. Refine cannot
+  close this from the plugin side; the fix is host-side (include the resolved
+  model in the cache key, or pass the live runtime through the plugin call).
+  Pin `llm.model` / `llm.provider` when a deterministic target is needed.
 - **No host approval for the prompt-note store:** it is a plugin-owned atomic
   file, not a host memory or skill write. Host-managed skill and memory changes
   still respect staged approvals and reconciliation.

--- a/__init__.py
+++ b/__init__.py
@@ -64,11 +64,10 @@ def _session_llm() -> PluginLlm:
     """Return the host-provided client, falling back to a fresh one.
 
     Reusing the host-provided facade keeps every path on one client instead of
-    building a new one per invocation. It does **not** change which model is
-    used: ``ctx.llm`` is itself a ``PluginLlm(plugin_id=...)``, and Hermes
-    resolves provider and model inside its own ``call_llm``. A model switched
-    during a chat session is not visible to plugins; pin
-    ``plugins.entries.refine.llm.model`` to steer refine's own calls.
+    building a new one per invocation. It does not by itself decide the model:
+    ``ctx.llm`` is a ``PluginLlm(plugin_id=...)`` and Hermes resolves the model
+    inside its own ``call_llm``, preferring the live main model. Pin
+    ``plugins.entries.refine.llm.model`` when a deterministic target is needed.
     """
     return _REGISTERED_LLM if _REGISTERED_LLM is not None else PluginLlm(
         plugin_id="refine"

--- a/config.py
+++ b/config.py
@@ -212,8 +212,9 @@ def llm_provider() -> str:
 def llm_model() -> str:
     """Model to request for refine's own calls; empty means host default.
 
-    Hermes resolves the model inside ``call_llm`` and exposes no session model
-    to plugins, so this is the only way to steer which model refine uses. The
+    Unset, Hermes resolves refine's model through its ``auto`` path, which
+    prefers the live main model. Pinning makes the target deterministic and
+    immune to the host's auxiliary client cache keeping an older model. The
     host still gates it: without ``allow_model_override`` (and
     ``allow_provider_override``) the request is refused rather than applied.
     """

--- a/llm.py
+++ b/llm.py
@@ -34,11 +34,9 @@ _PROPOSAL_ENVELOPE_TOKENS = 1024
 def _pinned_target() -> Dict[str, str]:
     """Provider/model to request, when the config pins them.
 
-    Hermes resolves the model inside its own ``call_llm`` and gives plugins no
-    access to the model a session switched to, so an explicitly pinned target
-    is the only way to control which model refine uses. Omitted keys leave the
-    host default in place; the host's trust gate still decides whether a
-    request is honored.
+    Omitted keys leave resolution to Hermes, which prefers the live main model.
+    A pinned value makes the target deterministic instead; the host's trust
+    gate still decides whether the request is honored.
     """
     target: Dict[str, str] = {}
     provider = config.llm_provider()


### PR DESCRIPTION
Previous text claimed refine cannot follow a mid-session model switch. That was wrong. Hermes routes a plugin call with no explicit model through its auto path, whose first step is main provider + main model, read from a process-local runtime override the agent refreshes at the top of every turn. Inheriting the live model is the designed behavior. What is real is a host-side staleness window: the auxiliary client cache key omits the resolved model and the plugin call passes no live-runtime dict, so a cached client keeps its original model until eviction or restart. Documented as a host gap with the host-side fix. Pinning llm.provider/llm.model stays the deterministic option. 138 tests OK, compiled 9 files.