### PR TITLE
Deterministic model selection with /refine model

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -238,6 +238,71 @@ def _on_post_llm_call(
     _start_auto_refine(session_id, _assistant_turn_count(conversation_history))
 
 
+_MODEL_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9._:\-]{1,120}$")
+
+
+def _handle_model_subcommand(remainder: str) -> str:
+    """Handle /refine model [auto | <provider/model> | <model>]."""
+    if not remainder:
+        # Show current effective target
+        effective = config.effective_llm_target()
+        model = effective.get("model") or "(host default)"
+        provider = effective.get("provider") or "(host default)"
+        source = effective["source"]
+        trust_model = config.llm_allow_model_override()
+        trust_prov = config.llm_allow_provider_override()
+        lines = [
+            f"model: {model}",
+            f"provider: {provider}",
+            f"source: {source}",
+            f"trust: model={'allowed' if trust_model else 'denied'}, "
+            f"provider={'allowed' if trust_prov else 'denied'}",
+        ]
+        if not trust_model and source in ("command", "config", "live"):
+            lines.append(
+                "⚠ Model is set but host trust denies overrides. "
+                "Enable plugins.entries.refine.llm.allow_model_override to apply it."
+            )
+        return core.scrub_text("\n".join(lines))
+
+    if remainder == "auto":
+        journal.clear_model_override()
+        effective = config.effective_llm_target()
+        return core.scrub_text(
+            f"Override removed. Effective model: {effective.get('model') or '(host default)'} "
+            f"(source: {effective['source']})"
+        )
+
+    # Parse provider/model or bare model
+    provider = ""
+    model = remainder
+    if "/" in remainder:
+        parts = remainder.split("/", 1)
+        provider = parts[0]
+        model = parts[1]
+
+    if not _MODEL_IDENTIFIER_PATTERN.fullmatch(model):
+        return f"Invalid model identifier: {model!r}"
+    if provider and not _MODEL_IDENTIFIER_PATTERN.fullmatch(provider):
+        return f"Invalid provider identifier: {provider!r}"
+
+    journal.write_model_override(provider, model)
+    trust_model = config.llm_allow_model_override()
+    trust_prov = config.llm_allow_provider_override()
+    lines = [f"Override set: model={model}" + (f" provider={provider}" if provider else "")]
+    if not trust_model:
+        lines.append(
+            "⚠ Host trust denies model overrides. The value is saved but will not "
+            "be sent until plugins.entries.refine.llm.allow_model_override is true."
+        )
+    if provider and not trust_prov:
+        lines.append(
+            "⚠ Host trust denies provider overrides. The provider value is saved but "
+            "will not be sent until plugins.entries.refine.llm.allow_provider_override is true."
+        )
+    return core.scrub_text("\n".join(lines))
+
+
 def _handle_refine_command(raw_args: str) -> Optional[str]:
     """Handle exact audit/rollback subcommands; all other text is a reason."""
     args = raw_args.strip()
@@ -276,6 +341,20 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
             lines.append("warnings:")
             lines.extend(f"  ⚠ {item['message']}" for item in status["warnings"])
         return core.scrub_text("\n".join(lines))
+
+    if args == "model" or args.startswith("model "):
+        remainder = args[5:].strip()
+        # Only treat as a subcommand when:
+        # - no remainder (show current)
+        # - remainder is "auto"
+        # - remainder is a valid model identifier (possibly with one slash)
+        # Anything else ("model of gmail failures") is a free-form reason.
+        if not remainder or remainder == "auto":
+            return _handle_model_subcommand(remainder)
+        parts = remainder.split("/", 1)
+        if all(_MODEL_IDENTIFIER_PATTERN.fullmatch(p) for p in parts if p):
+            return _handle_model_subcommand(remainder)
+        # Fall through to the proposal path below
 
     if args == "rollback":
         return (

--- a/config.py
+++ b/config.py
@@ -222,6 +222,88 @@ def llm_model() -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+def llm_allow_model_override() -> bool:
+    """Whether the trust policy allows refine to request a specific model."""
+    return bool(_llm_entry().get("allow_model_override", False))
+
+
+def llm_allow_provider_override() -> bool:
+    """Whether the trust policy allows refine to request a specific provider."""
+    return bool(_llm_entry().get("allow_provider_override", False))
+
+
+def live_main_target() -> Dict[str, str]:
+    """Best-effort read of the host's live main provider/model.
+
+    Uses an internal Hermes API (``_read_main_provider`` / ``_read_main_model``
+    in ``agent.auxiliary_client``). When unavailable — import fails, function
+    removed — returns ``{}`` silently. The caller must not treat a failure
+    here as an error; it merely means no live model information is available.
+    """
+    try:
+        from agent.auxiliary_client import _read_main_provider, _read_main_model
+
+        provider = _read_main_provider()
+        model = _read_main_model()
+        result: Dict[str, str] = {}
+        if provider:
+            result["provider"] = provider
+        if model:
+            result["model"] = model
+        return result
+    except Exception:
+        return {}
+
+
+def effective_llm_target() -> Dict[str, str]:
+    """Resolve one effective model/provider target for refine.
+
+    Priority:
+      1. Command override (``/refine model <target>``)
+      2. Config (``plugins.entries.refine.llm.model`` / ``.provider``)
+      3. Live Hermes main model (best-effort, internal API)
+      4. Nothing — let the host decide
+
+    Returns ``{"provider": ..., "model": ..., "source": ...}``.
+    Provider/model may be empty strings; source is always set.
+    """
+    try:
+        from . import journal
+    except ImportError:
+        import journal  # type: ignore
+
+    # 1. Command override
+    override = journal.read_model_override()
+    if override:
+        return {
+            "provider": override.get("provider", ""),
+            "model": override.get("model", ""),
+            "source": "command",
+        }
+
+    # 2. Config
+    cfg_provider = llm_provider()
+    cfg_model = llm_model()
+    if cfg_provider or cfg_model:
+        return {
+            "provider": cfg_provider,
+            "model": cfg_model,
+            "source": "config",
+        }
+
+    # 3. Live Hermes main model
+    live = live_main_target()
+    if live.get("model") or live.get("provider"):
+        return {
+            "provider": live.get("provider", ""),
+            "model": live.get("model", ""),
+            "source": "live",
+        }
+
+    # 4. Nothing
+    return {"provider": "", "model": "", "source": "host_default"}
+
+
 def journal_dir() -> Path:
     default = hermes_home() / "plugins" / "refine"
     return Path(get_str("journal_dir", str(default)))

--- a/journal.py
+++ b/journal.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 _BACKUPS_DIR_NAME = "backups"
 _JOURNAL_FILE_NAME = "refine_journal.jsonl"
 _PROMPT_NOTES_FILE_NAME = "prompt_notes.json"
+_MODEL_OVERRIDE_FILE_NAME = "model_override.json"
 _LOCK_FILE_NAME = ".mutation.lock"
 _LOCK_STALE_SECONDS = 300
 _THREAD_LOCK = threading.RLock()
@@ -63,6 +64,49 @@ def prompt_notes_path() -> Path:
 def prompt_notes_read_path() -> Path:
     """Prompt-note store for readers, without creating anything."""
     return journal_dir() / _PROMPT_NOTES_FILE_NAME
+
+
+def model_override_read_path() -> Path:
+    """Model override store for readers, without creating anything."""
+    return journal_dir() / _MODEL_OVERRIDE_FILE_NAME
+
+
+def read_model_override() -> Optional[Dict[str, str]]:
+    """Return the user's command-set model override, or None when absent/corrupt."""
+    path = model_override_read_path()
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return None
+        model = str(data.get("model", "") or "").strip()
+        provider = str(data.get("provider", "") or "").strip()
+        if not model and not provider:
+            return None
+        return {"model": model, "provider": provider}
+    except Exception:
+        return None
+
+
+def write_model_override(provider: str, model: str) -> None:
+    """Persist the model override atomically."""
+    import time as _time
+
+    payload = json.dumps(
+        {"provider": provider, "model": model, "set_ts": _time.time()},
+        ensure_ascii=False,
+    )
+    _atomic_write_text(ensure_dirs() / _MODEL_OVERRIDE_FILE_NAME, payload)
+
+
+def clear_model_override() -> None:
+    """Remove the model override file."""
+    path = journal_dir() / _MODEL_OVERRIDE_FILE_NAME
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:
+        pass
 
 
 def normalize_prompt_note_session_id(session_id: Any) -> str:

--- a/llm.py
+++ b/llm.py
@@ -37,13 +37,18 @@ def _pinned_target() -> Dict[str, str]:
     Omitted keys leave resolution to Hermes, which prefers the live main model.
     A pinned value makes the target deterministic instead; the host's trust
     gate still decides whether the request is honored.
+
+    This function filters the effective target through trust flags so that a
+    plugin installation without ``allow_model_override`` silently falls back to
+    the host default instead of causing PluginLlmTrustError on every call.
     """
+    effective = config.effective_llm_target()
     target: Dict[str, str] = {}
-    provider = config.llm_provider()
-    model = config.llm_model()
-    if provider:
+    provider = effective.get("provider", "")
+    model = effective.get("model", "")
+    if provider and config.llm_allow_provider_override():
         target["provider"] = provider
-    if model:
+    if model and config.llm_allow_model_override():
         target["model"] = model
     return target
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -3370,7 +3370,10 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         self.assertIn(status["journal_dir_state_text"], plugin_init._handle_refine_command("status"))
 
     def test_pinned_provider_and_model_reach_the_host_call(self):
-        FakeHost.entry_config()["llm"] = {"provider": "opencode-go", "model": "deepseek-v4"}
+        FakeHost.entry_config()["llm"] = {
+            "provider": "opencode-go", "model": "deepseek-v4",
+            "allow_model_override": True, "allow_provider_override": True,
+        }
         model = MockLlm({
             "action": "no_op", "reason": "nothing", "evidence": [],
             "kind": "", "name": "", "content": "",
@@ -3387,6 +3390,132 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         llm.propose(model, "evidence", [], [])
         self.assertNotIn("provider", model.calls[0])
         self.assertNotIn("model", model.calls[0])
+
+    # ── Model selection tests ─────────────────────────────────────────────────
+
+    def test_effective_target_no_sources_is_host_default(self):
+        target = config.effective_llm_target()
+        self.assertEqual(target["source"], "host_default")
+        self.assertEqual(target["model"], "")
+        self.assertEqual(target["provider"], "")
+
+    def test_effective_target_config_wins_over_host_default(self):
+        FakeHost.entry_config()["llm"] = {"model": "from-config"}
+        target = config.effective_llm_target()
+        self.assertEqual(target["source"], "config")
+        self.assertEqual(target["model"], "from-config")
+
+    def test_effective_target_command_wins_over_config(self):
+        FakeHost.entry_config()["llm"] = {"model": "from-config"}
+        journal.write_model_override("", "from-command")
+        target = config.effective_llm_target()
+        self.assertEqual(target["source"], "command")
+        self.assertEqual(target["model"], "from-command")
+
+    def test_effective_target_live_when_no_override_or_config(self):
+        with patch.object(config, "live_main_target", return_value={"model": "live-model", "provider": "live-prov"}):
+            target = config.effective_llm_target()
+        self.assertEqual(target["source"], "live")
+        self.assertEqual(target["model"], "live-model")
+        self.assertEqual(target["provider"], "live-prov")
+
+    def test_live_main_target_failure_returns_empty(self):
+        with patch.dict("sys.modules", {"agent.auxiliary_client": None}):
+            result = config.live_main_target()
+        self.assertEqual(result, {})
+
+    def test_corrupt_override_file_treated_as_absent(self):
+        path = journal.model_override_read_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json!", encoding="utf-8")
+        self.assertIsNone(journal.read_model_override())
+        target = config.effective_llm_target()
+        self.assertNotEqual(target["source"], "command")
+
+    def test_trust_gate_blocks_model_without_allow_flag(self):
+        journal.write_model_override("blocked-prov", "blocked-model")
+        # No allow_model_override/allow_provider_override in config
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        llm.propose(model, "evidence", [], [])
+        self.assertNotIn("model", model.calls[0])
+        self.assertNotIn("provider", model.calls[0])
+
+    def test_trust_gate_passes_model_with_allow_flag(self):
+        journal.write_model_override("allowed-prov", "allowed-model")
+        FakeHost.entry_config()["llm"] = {
+            "allow_model_override": True,
+            "allow_provider_override": True,
+        }
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        llm.propose(model, "evidence", [], [])
+        self.assertEqual(model.calls[0]["model"], "allowed-model")
+        self.assertEqual(model.calls[0]["provider"], "allowed-prov")
+
+    def test_clear_override_removes_the_file(self):
+        journal.write_model_override("p", "m")
+        self.assertIsNotNone(journal.read_model_override())
+        journal.clear_model_override()
+        self.assertIsNone(journal.read_model_override())
+
+    # ── /refine model command tests ───────────────────────────────────────────
+
+    def test_model_command_show_effective_target(self):
+        result = plugin_init._handle_refine_command("model")
+        self.assertIn("model:", result)
+        self.assertIn("source:", result)
+
+    def test_model_command_set_override(self):
+        result = plugin_init._handle_refine_command("model deepseek-v4-flash")
+        self.assertIn("Override set", result)
+        override = journal.read_model_override()
+        self.assertEqual(override["model"], "deepseek-v4-flash")
+        self.assertEqual(override["provider"], "")
+
+    def test_model_command_set_provider_and_model(self):
+        result = plugin_init._handle_refine_command("model opencode-go/deepseek-v4")
+        self.assertIn("Override set", result)
+        override = journal.read_model_override()
+        self.assertEqual(override["model"], "deepseek-v4")
+        self.assertEqual(override["provider"], "opencode-go")
+
+    def test_model_command_auto_removes_override(self):
+        journal.write_model_override("p", "m")
+        result = plugin_init._handle_refine_command("model auto")
+        self.assertIn("removed", result.lower())
+        self.assertIsNone(journal.read_model_override())
+
+    def test_model_command_invalid_identifier_goes_as_reason(self):
+        # "model !!!" is not a valid identifier, so it falls through to a proposal reason.
+        with patch.object(plugin_init.core, "refine_run", return_value={
+            "success": True, "message": "done", "outcome": "no_op",
+        }) as run:
+            plugin_init._handle_refine_command("model !!!")
+        run.assert_called_once()
+        self.assertIsNone(journal.read_model_override())
+
+    def test_model_as_reason_word_goes_to_proposal(self):
+        with patch.object(plugin_init.core, "refine_run", return_value={
+            "success": True, "message": "done", "outcome": "no_op",
+        }) as run:
+            plugin_init._handle_refine_command("model of gmail failures")
+        run.assert_called_once()
+        self.assertEqual(run.call_args.kwargs["reason"], "model of gmail failures")
+
+    def test_model_command_warns_when_trust_denies(self):
+        result = plugin_init._handle_refine_command("model blocked-model")
+        self.assertIn("trust denies", result.lower())
+
+    def test_model_command_does_not_write_journal(self):
+        before = len(journal.entries())
+        plugin_init._handle_refine_command("model test-m")
+        plugin_init._handle_refine_command("model auto")
+        self.assertEqual(len(journal.entries()), before)
 
     def test_status_command_returns_text_not_dict(self):
         result = plugin_init._handle_refine_command("status")


### PR DESCRIPTION
Three sources, strict priority: command override > config pin > live Hermes model > host default. Trust gate filters the effective target so installations without allow_model_override keep working silently. /refine model shows the effective target. /refine model <target> sets override. /refine model auto clears it. 155 tests OK.