### PR TITLE
Fix the defects an independent review found in /refine model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv/
 refine_journal.jsonl
 skill_stats.json
 prompt_notes.json
+model_override.json
 backups/
 *.bak
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Then check that automatic refinement can actually run:
 # min messages: 15
 # cooldown: 20 min
 # edits today: 0/3
+# model: deepseek-v4-flash @ opencode-go (source: live)
 # journal: /home/you/.hermes/refine-data (does not exist yet, will be created on first write)
 # blockers: none — automatic refinement is active
 ```
@@ -157,13 +158,42 @@ toward the budget it reports.
 /refine focus on Gmail API failures
 /refine audit
 /refine status
+/refine model
+/refine model deepseek-v4-flash
+/refine model opencode-go/deepseek-v4
+/refine model auto
 /refine rollback 1f2a3b4c5d6e
 ```
 
-`audit` and `rollback <12-character-id>` are exact subcommands. `status`
-reports whether automatic refinement is active, what blocks it, and whether
-the journal directory is safe. Other text, including reasons beginning with
-those words, is passed to the proposal model as the manual reason.
+`audit`, `status`, `model`, and `rollback <12-character-id>` are exact
+subcommands. `status` reports whether automatic refinement is active, what
+blocks it, which model it will use, and whether the journal directory is safe.
+
+`model` shows or sets the model refine asks for. Bare `model` prints the
+effective target and whether host trust allows it; `model <name>` or
+`model <provider>/<name>` pins one; `model auto` removes the override. `auto`
+returns to the next source in the priority order, which is the configured
+`plugins.entries.refine.llm` value when there is one, and the live Hermes model
+only when there is not. The override is stored in `model_override.json` inside
+`journal_dir` — refine never writes to the Hermes config.
+
+Both stores are validated the same way: a provider must be a single token, a
+model id may be namespaced, and a value matching a credential pattern is refused
+rather than stored. A configured value that fails either rule is dropped and
+reported in `/refine status` and `/refine model`.
+
+In the command, **the first slash is always the provider separator** and every
+later one belongs to the model id: `/refine model openrouter/deepseek/deepseek-chat`
+pins provider `openrouter` and model `deepseek/deepseek-chat`. There is therefore
+no command form for a namespaced model with no provider — set
+`plugins.entries.refine.llm.model` for that. And a pinned provider only reaches
+the host when `allow_provider_override` is true, which `/refine model` reports.
+
+Other text is passed to the proposal model as the manual reason. That includes
+text beginning with a subcommand word, with one deliberate exception: after
+`model`, a single token shaped like an identifier (`deepseek-v4`, `a/b`) is
+treated as a target, so `/refine model drift` pins a model rather than asking for
+a refinement about drift. Use `/refine drift` or `/refine model auto` to undo.
 
 ### Automatic refinement
 
@@ -323,13 +353,21 @@ model is read from a process-local runtime override that the agent refreshes at
 the top of every turn. So a model switched mid-session is intended to apply to
 refine as well, without any plugin-side plumbing.
 
-One caveat is worth knowing, because it is not a refine bug and refine cannot
-fix it: Hermes caches auxiliary clients under a key that does **not** include
-the resolved model, and the plugin call passes no live-runtime dict, so the key
-is constant. In a long-running gateway the first cached client keeps supplying
-the model captured when it was built, which can outlive a mid-session switch
-until that entry is evicted or the process restarts. Restarting the gateway is
-the reliable way to clear it.
+One caveat is worth knowing, and it depends on the Hermes version. On Hermes
+builds older than 2026-07-17, auxiliary clients are cached under a key that does
+**not** include the resolved model; a plugin call passes no live-runtime dict, so
+the key is constant and the first cached client keeps supplying the model
+captured when it was built, outliving a mid-session switch until the entry is
+evicted or the process restarts. Upstream closed this in `73057ed16`
+("scope runtime state to each turn") and `fdc6c32d7` ("isolate runtime cache by
+live context"), both dated 2026-07-17 — verified by reading the Hermes repository,
+not from this one, so re-check against your own checkout before relying on it.
+Never a refine bug either way; on an older host, restarting the gateway clears it.
+
+`/refine model` reports which source **refine** resolved, and with `source: live`
+the value it read from the host at that moment. It cannot report which model a
+cached host client will actually use, so on an older host it is not a way to
+confirm a mid-session switch took effect. Restart the gateway, or pin the target.
 
 Pinning refine's own target sidesteps all of that and makes the choice
 deterministic:
@@ -367,7 +405,7 @@ All keys live under `plugins.entries.refine`:
 | `max_edits_per_proposal` | int | `3` | Maximum inseparable edits one proposal may apply as a single transaction. `1` disables transactions. |
 | `max_edits_per_day` | int | `3` | Maximum applied, pending, or prepared **edits** per UTC day. This is the blast-radius limit and is re-checked before every edit. |
 | `only_agent_created` | bool | `true` | Only patch agent-created skills. |
-| `journal_dir` | path | `<HERMES_HOME>/plugins/refine` | Journal, lock, ledger, backups, and prompt notes. |
+| `journal_dir` | path | `<HERMES_HOME>/plugins/refine` | Journal, lock, ledger, backups, prompt notes, and the `/refine model` override. |
 | `overview_max_entries` | int | `40` | Existing skills and memory snippets listed per kind in a proposal prompt. |
 | `overview_max_chars` | int | `240` | Maximum characters in each structured overview or history line. |
 | `history_max_entries` | int | `20` | Recent create/patch outcomes fed back into a proposal prompt. |
@@ -412,14 +450,23 @@ llm:
   reasoning and no final text is reported as `llm_incomplete`; pin a
   non-reasoning model for refine with `plugins.entries.refine.llm` (`model` /
   `provider`) under the existing trust policy when that mitigation is needed.
-- **A model switch can be masked by Hermes's auxiliary client cache:** plugin
-  calls resolve through the `auto` path, which prefers the live main model, but
-  the client cache key omits the resolved model and the plugin call supplies no
-  live-runtime dict, so the key never changes. A cached client therefore keeps
-  its original model until it is evicted or the process restarts. Refine cannot
-  close this from the plugin side; the fix is host-side (include the resolved
-  model in the cache key, or pass the live runtime through the plugin call).
-  Pin `llm.model` / `llm.provider` when a deterministic target is needed.
+- **A model switch can be masked by Hermes's auxiliary client cache, on older
+  hosts only:** plugin calls resolve through the `auto` path, which prefers the
+  live main model, but before `73057ed16` / `fdc6c32d7` (both 2026-07-17) the
+  client cache key omitted the resolved model and a plugin call supplied no
+  live-runtime dict, so the key never changed and a cached client kept its
+  original model until eviction or restart. Refine cannot close this from the
+  plugin side and does not try, and it cannot detect which host version it runs
+  on, so `/refine model` cannot tell you whether you are affected. On a current
+  host it is fixed; otherwise restart the gateway or pin `llm.model` /
+  `llm.provider`.
+- **The live main model is read through a private host API:** `live_main_target()`
+  imports `_read_main_provider` / `_read_main_model` from
+  `agent.auxiliary_client`. Hermes exposes no public accessor. Both names were
+  confirmed present in a real installation, but a private name can move without
+  notice, so the import is guarded and simply yields no live value on failure —
+  `/refine model` then reports `source: host_default` rather than claiming a
+  target it does not have.
 - **No host approval for the prompt-note store:** it is a plugin-owned atomic
   file, not a host memory or skill write. Host-managed skill and memory changes
   still respect staged approvals and reconciliation.
@@ -501,7 +548,7 @@ cd <HERMES_HOME>/plugins/refine
 python -m tests.run_tests
 ```
 
-The stdlib-only suite (138 tests) installs a fake Hermes host before importing the plugin.
+The stdlib-only suite (197 tests) installs a fake Hermes host before importing the plugin.
 Every database, journal, backup, skill, memory file, ledger, and lock lives
 under a fresh `TemporaryDirectory`; running the suite cannot touch live Hermes
 or profile state. It covers proposal completion, host action mapping,

--- a/__init__.py
+++ b/__init__.py
@@ -173,6 +173,9 @@ def _start_auto_refine(session_id: str, assistant_turns: int) -> None:
 def _on_pre_llm_call(**kwargs) -> Optional[dict]:
     """Inject bounded plugin-owned notes without reading or changing the base prompt."""
     try:
+        # Record the session id before anything else — this must not be lost
+        # because a later error in prompt-note loading skips the rest.
+        core.note_session_id(kwargs.get("session_id", ""))
         if not config.prompt_notes_enabled():
             return None
         session_id = journal.normalize_prompt_note_session_id(kwargs.get("session_id", ""))
@@ -235,6 +238,7 @@ def _on_session_reset(session_id: str = "", **kwargs) -> None:
 def _on_post_llm_call(
     session_id: str = "", conversation_history: Any = None, **kwargs
 ) -> None:
+    core.note_session_id(session_id)
     _start_auto_refine(session_id, _assistant_turn_count(conversation_history))
 
 
@@ -358,6 +362,9 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
             f"min messages: {status['auto_min_messages']}",
             f"cooldown: {status['auto_cooldown_minutes']} min",
             f"edits today: {status['edits_today']}/{status['max_edits_per_day']}",
+            f"session: {status['session_id'] or '(unknown)'}"
+            + f" (source: {status['session_id_source']}"
+            + f", messages: {status['session_message_count']})",
             f"model: {status['llm_model'] or '(host default)'}"
             + (f" @ {status['llm_provider']}" if status["llm_provider"] else "")
             + f" (source: {status['llm_target_source']})",
@@ -473,6 +480,7 @@ def _on_session_end(
     **kwargs,
 ) -> None:
     """Run the session-end fallback without blocking or dropping it behind a turn run."""
+    core.note_session_id(session_id)
     _forget_turn_marks(session_id)
     if not config.auto_enabled() or interrupted:
         _clear_session_prompt_notes(session_id, timeout=_HOST_PATH_LOCK_TIMEOUT)

--- a/__init__.py
+++ b/__init__.py
@@ -384,6 +384,42 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
             lines.extend(f"  ⚠ {item['message']}" for item in status["warnings"])
         return core.scrub_text("\n".join(lines))
 
+    if args == "dry-run" or args.startswith("dry-run "):
+        dry_reason = args[7:].strip()  # len("dry-run") == 7
+        try:
+            result = core.refine_run(
+                llm=_session_llm(), reason=dry_reason, auto=False, dry_run=True
+            )
+        except Exception as exc:
+            logger.exception("refine dry-run failed")
+            return f"❌ Dry-run failed: {core.scrub_text(str(exc))}"
+        if result.get("outcome") == "dry_run":
+            proposal = result.get("proposal", {})
+            lines = ["🔍 Dry run — nothing applied."]
+            if proposal.get("action") and proposal["action"] != "no_op":
+                lines.append(
+                    f"action: {proposal.get('action')} | kind: {proposal.get('kind', '')} "
+                    f"| name: {proposal.get('name', '')}"
+                )
+                if proposal.get("summary"):
+                    lines.append(f"summary: {proposal['summary']}")
+                if proposal.get("expected_outcome"):
+                    lines.append(f"expected: {proposal['expected_outcome']}")
+            else:
+                lines.append(f"action: no_op | reason: {proposal.get('reason', '')}")
+            diff = result.get("diff", "")
+            if diff:
+                lines.append("\n```diff")
+                lines.append(diff)
+                lines.append("```")
+                if result.get("diff_truncated"):
+                    lines.append("(diff truncated)")
+            return core.scrub_text("\n".join(lines))
+        # Non-dry-run outcome (session_unknown, skipped, etc.)
+        if not result.get("success"):
+            return f"❌ {result.get('message', 'Unknown error')}"
+        return result.get("message", "No proposal.")
+
     if args == _MODEL_SUBCOMMAND or args.startswith(_MODEL_SUBCOMMAND + " "):
         remainder = args[len(_MODEL_SUBCOMMAND):].strip()
         # Only treat as a subcommand when:
@@ -542,9 +578,9 @@ def register(ctx) -> None:
         _handle_refine_command,
         description=(
             "Self-improve skills/memory. "
-            "Usage: /refine [reason|audit|status|model [target|auto]|rollback <id>]"
+            "Usage: /refine [reason|audit|status|dry-run|model [target|auto]|rollback <id>]"
         ),
-        args_hint="[reason | audit | status | model [target|auto] | rollback <id>]",
+        args_hint="[reason | audit | status | dry-run | model [target|auto] | rollback <id>]",
     )
     ctx.register_tool(
         "refine_run",

--- a/__init__.py
+++ b/__init__.py
@@ -573,6 +573,12 @@ REFINE_RUN_SCHEMA = {
 def register(ctx) -> None:
     global _REGISTERED_LLM
     _REGISTERED_LLM = _get_llm(ctx)
+    # One-time migration of runtime data out of the plugin install directory.
+    # Must not fail registration — a broken migration just leaves data in place.
+    try:
+        journal.migrate_legacy_journal_dir()
+    except Exception:
+        logger.debug("refine journal migration failed", exc_info=True)
     ctx.register_command(
         "refine",
         _handle_refine_command,

--- a/__init__.py
+++ b/__init__.py
@@ -238,57 +238,89 @@ def _on_post_llm_call(
     _start_auto_refine(session_id, _assistant_turn_count(conversation_history))
 
 
-_MODEL_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9._:\-]{1,120}$")
+_MODEL_SUBCOMMAND = "model"
+
+
+def _is_model_target(remainder: str) -> bool:
+    """Whether text is exactly ``<model>`` or ``<provider>/<model>``.
+
+    Only the first slash separates provider from model; any further ones belong to
+    the model id, which is commonly namespaced (``openrouter/deepseek/deepseek-chat``).
+    Rejecting those made the command start a real refine pass instead — spending a
+    daily edit on a mistyped setting.
+
+    Anything else — prose, an empty half such as ``a/`` or ``/b`` — is a free-form
+    reason and must reach the proposal path untouched. The rule itself lives in
+    ``journal``, which owns the store.
+    """
+    head, separator, tail = remainder.partition("/")
+    if not journal.valid_model_identifier(head):
+        return False
+    if not separator:
+        return True
+    return bool(tail) and journal.valid_model_id(tail)
 
 
 def _handle_model_subcommand(remainder: str) -> str:
     """Handle /refine model [auto | <provider/model> | <model>]."""
+    trust_model = config.llm_allow_model_override()
+    trust_prov = config.llm_allow_provider_override()
+
     if not remainder:
         # Show current effective target
         effective = config.effective_llm_target()
-        model = effective.get("model") or "(host default)"
-        provider = effective.get("provider") or "(host default)"
         source = effective["source"]
-        trust_model = config.llm_allow_model_override()
-        trust_prov = config.llm_allow_provider_override()
+        set_model = effective.get("model", "")
+        set_provider = effective.get("provider", "")
         lines = [
-            f"model: {model}",
-            f"provider: {provider}",
+            f"model: {set_model or '(host default)'}",
+            f"provider: {set_provider or '(host default)'}",
             f"source: {source}",
             f"trust: model={'allowed' if trust_model else 'denied'}, "
             f"provider={'allowed' if trust_prov else 'denied'}",
         ]
-        if not trust_model and source in ("command", "config", "live"):
-            lines.append(
-                "⚠ Model is set but host trust denies overrides. "
-                "Enable plugins.entries.refine.llm.allow_model_override to apply it."
-            )
+        for issue in effective.get("issues", ()):
+            lines.append(f"⚠ {issue}")
+        # Only warn where trust actually changes the outcome. On ``live`` the
+        # user set nothing and the host uses that model regardless, so warning
+        # there would report a problem that does not exist.
+        if source in ("command", "config"):
+            if set_model and not trust_model:
+                lines.append(
+                    "⚠ Model is set but host trust denies overrides. "
+                    "Enable plugins.entries.refine.llm.allow_model_override to apply it."
+                )
+            if set_provider and not trust_prov:
+                lines.append(
+                    "⚠ Provider is set but host trust denies overrides. Enable "
+                    "plugins.entries.refine.llm.allow_provider_override to apply it."
+                )
         return core.scrub_text("\n".join(lines))
 
     if remainder == "auto":
-        journal.clear_model_override()
+        outcome = journal.clear_model_override()
         effective = config.effective_llm_target()
+        prefix = {
+            "removed": "Override removed.",
+            "absent": "No override was set.",
+            # Does not claim the override is "still in force": the file surviving
+            # and the file being usable are different things, and the effective
+            # target printed next is the accurate answer either way.
+            "failed": "⚠ Could not remove the override file.",
+        }[outcome]
         return core.scrub_text(
-            f"Override removed. Effective model: {effective.get('model') or '(host default)'} "
+            f"{prefix} Effective model: {effective.get('model') or '(host default)'} "
             f"(source: {effective['source']})"
         )
 
-    # Parse provider/model or bare model
+    # Parse provider/model or bare model. The store validates and refuses; doing
+    # it again here would put the same rule in two places that could drift.
     provider = ""
     model = remainder
     if "/" in remainder:
-        parts = remainder.split("/", 1)
-        provider = parts[0]
-        model = parts[1]
-
-    if not _MODEL_IDENTIFIER_PATTERN.fullmatch(model):
-        return f"Invalid model identifier: {model!r}"
-    if provider and not _MODEL_IDENTIFIER_PATTERN.fullmatch(provider):
-        return f"Invalid provider identifier: {provider!r}"
+        provider, model = remainder.split("/", 1)
 
     journal.write_model_override(provider, model)
-    trust_model = config.llm_allow_model_override()
-    trust_prov = config.llm_allow_provider_override()
     lines = [f"Override set: model={model}" + (f" provider={provider}" if provider else "")]
     if not trust_model:
         lines.append(
@@ -326,6 +358,9 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
             f"min messages: {status['auto_min_messages']}",
             f"cooldown: {status['auto_cooldown_minutes']} min",
             f"edits today: {status['edits_today']}/{status['max_edits_per_day']}",
+            f"model: {status['llm_model'] or '(host default)'}"
+            + (f" @ {status['llm_provider']}" if status["llm_provider"] else "")
+            + f" (source: {status['llm_target_source']})",
             f"journal: {status['journal_dir']} ({status['journal_dir_state_text']})",
         ]
         if status["cooldown_remaining_minutes"] > 0:
@@ -342,18 +377,22 @@ def _handle_refine_command(raw_args: str) -> Optional[str]:
             lines.extend(f"  ⚠ {item['message']}" for item in status["warnings"])
         return core.scrub_text("\n".join(lines))
 
-    if args == "model" or args.startswith("model "):
-        remainder = args[5:].strip()
+    if args == _MODEL_SUBCOMMAND or args.startswith(_MODEL_SUBCOMMAND + " "):
+        remainder = args[len(_MODEL_SUBCOMMAND):].strip()
         # Only treat as a subcommand when:
         # - no remainder (show current)
         # - remainder is "auto"
-        # - remainder is a valid model identifier (possibly with one slash)
+        # - remainder is exactly a model or provider/model token
         # Anything else ("model of gmail failures") is a free-form reason.
-        if not remainder or remainder == "auto":
-            return _handle_model_subcommand(remainder)
-        parts = remainder.split("/", 1)
-        if all(_MODEL_IDENTIFIER_PATTERN.fullmatch(p) for p in parts if p):
-            return _handle_model_subcommand(remainder)
+        if not remainder or remainder == "auto" or _is_model_target(remainder):
+            try:
+                return _handle_model_subcommand(remainder)
+            except Exception as exc:
+                # The other subcommands report failures; this one used to escape
+                # as a traceback on exactly the unwritable journal_dir that
+                # /refine status exists to diagnose.
+                logger.exception("refine model command failed")
+                return f"❌ Model command failed: {core.scrub_text(str(exc))}"
         # Fall through to the proposal path below
 
     if args == "rollback":
@@ -493,8 +532,11 @@ def register(ctx) -> None:
     ctx.register_command(
         "refine",
         _handle_refine_command,
-        description="Self-improve skills/memory. Usage: /refine [reason|audit|status|rollback <id>]",
-        args_hint="[reason | audit | status | rollback <id>]",
+        description=(
+            "Self-improve skills/memory. "
+            "Usage: /refine [reason|audit|status|model [target|auto]|rollback <id>]"
+        ),
+        args_hint="[reason | audit | status | model [target|auto] | rollback <id>]",
     )
     ctx.register_tool(
         "refine_run",

--- a/config.py
+++ b/config.py
@@ -370,8 +370,13 @@ def effective_llm_target() -> Dict[str, Any]:
 
 
 def journal_dir() -> Path:
-    default = hermes_home() / "plugins" / "refine"
+    default = hermes_home() / "refine"
     return Path(get_str("journal_dir", str(default)))
+
+
+def legacy_journal_dir() -> Path:
+    """The old default before Part C moved runtime data out of the plugin dir."""
+    return hermes_home() / "plugins" / "refine"
 
 
 def prompt_notes_enabled() -> bool:

--- a/config.py
+++ b/config.py
@@ -235,10 +235,13 @@ def llm_allow_provider_override() -> bool:
 def live_main_target() -> Dict[str, str]:
     """Best-effort read of the host's live main provider/model.
 
-    Uses an internal Hermes API (``_read_main_provider`` / ``_read_main_model``
-    in ``agent.auxiliary_client``). When unavailable — import fails, function
-    removed — returns ``{}`` silently. The caller must not treat a failure
-    here as an error; it merely means no live model information is available.
+    Uses a private Hermes API (``_read_main_provider`` / ``_read_main_model`` in
+    ``agent.auxiliary_client``) because the host exposes no public accessor. Both
+    names were confirmed present in a real installation; a private name can still
+    move, so the import is guarded and yields no live value on failure. The caller
+    must not treat that as an error — it only means no live model is available,
+    and ``effective_llm_target`` then reports ``host_default`` instead of naming a
+    target it cannot confirm.
     """
     try:
         from agent.auxiliary_client import _read_main_provider, _read_main_model
@@ -255,7 +258,7 @@ def live_main_target() -> Dict[str, str]:
         return {}
 
 
-def effective_llm_target() -> Dict[str, str]:
+def effective_llm_target() -> Dict[str, Any]:
     """Resolve one effective model/provider target for refine.
 
     Priority:
@@ -264,44 +267,91 @@ def effective_llm_target() -> Dict[str, str]:
       3. Live Hermes main model (best-effort, internal API)
       4. Nothing — let the host decide
 
-    Returns ``{"provider": ..., "model": ..., "source": ...}``.
-    Provider/model may be empty strings; source is always set.
+    A command override fills any field it leaves unset from the config, because a
+    configured provider is an explicit instruction the command did not revoke;
+    dropping it would send the new model to whatever default the host picks.
+
+    An unset field is deliberately **not** filled from the live model. Omitting a
+    field already means "let Hermes resolve it", and Hermes resolves it to the
+    live value — naming it here would claim the user chose something they did not,
+    and would spend a trust flag to reach the same result.
+
+    A configured ``llm.model`` may be namespaced (``vendor/name``); a provider may
+    not. Both are checked against the same rule the override store applies, so a
+    value refused from ``/refine model`` cannot slip in through ``config.yaml``.
+
+    Returns ``{"provider": ..., "model": ..., "source": ..., "issues": [...]}``.
+    Provider/model may be empty strings; ``source`` is always set; ``issues`` lists
+    every configured or stored value that was discarded, and why. It is a list
+    rather than one string because several can fail at once, and reporting only
+    the last would have the user fix one and rediscover the next.
     """
     try:
         from . import journal
     except ImportError:
         import journal  # type: ignore
 
-    # 1. Command override
-    override = journal.read_model_override()
+    issues: list = []
+    cfg_provider = llm_provider()
+    cfg_model = llm_model()
+    # The override store refuses unusable values. The config writes the same
+    # field, so it meets the same rule here — otherwise the check would hold on
+    # one path and not the other, and a value refused from /refine model would be
+    # accepted from config.yaml. The reason is reported without the value, which
+    # may be a pasted credential.
+    for key, value, namespaced in (
+        ("provider", cfg_provider, False),
+        ("model", cfg_model, True),
+    ):
+        problem = (
+            journal.model_override_field_problem(value, allow_namespace=namespaced)
+            if value
+            else ""
+        )
+        if problem:
+            issues.append(f"config llm.{key} was ignored because {problem}")
+            if key == "provider":
+                cfg_provider = ""
+            else:
+                cfg_model = ""
+
+    # 1. Command override, with the config filling any field it leaves unset.
+    override, state = journal.read_model_override_state()
+    if state == "rejected":
+        issues.append("model_override.json is present but unusable, so it was ignored")
+    elif state == "unreadable":
+        issues.append("model_override.json could not be read, so it was not applied")
     if override:
         return {
-            "provider": override.get("provider", ""),
-            "model": override.get("model", ""),
+            "provider": override.get("provider", "") or cfg_provider,
+            "model": override.get("model", "") or cfg_model,
             "source": "command",
+            "issues": issues,
         }
 
     # 2. Config
-    cfg_provider = llm_provider()
-    cfg_model = llm_model()
     if cfg_provider or cfg_model:
         return {
             "provider": cfg_provider,
             "model": cfg_model,
             "source": "config",
+            "issues": issues,
         }
 
-    # 3. Live Hermes main model
+    # 3. Live Hermes main model. Not put through the rule above: the value comes
+    # from the host's own runtime, not from user input, and refusing the host's
+    # answer would leave refine with no target at all.
     live = live_main_target()
     if live.get("model") or live.get("provider"):
         return {
             "provider": live.get("provider", ""),
             "model": live.get("model", ""),
             "source": "live",
+            "issues": issues,
         }
 
     # 4. Nothing
-    return {"provider": "", "model": "", "source": "host_default"}
+    return {"provider": "", "model": "", "source": "host_default", "issues": issues}
 
 
 def journal_dir() -> Path:

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ All values have sensible defaults — config.yaml only provides overrides.
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +168,21 @@ def reviewer_cooldown_minutes() -> int:
 
 def cross_session_enabled() -> bool:
     return get_bool("cross_session_enabled", True)
+
+
+def skip_session_sources() -> List[str]:
+    """Session sources to skip for automatic and manual refinement.
+
+    A session whose ``source`` column matches one of these values is not
+    analysed. Intended for machine-generated sessions (cron, batch) whose
+    trajectory is noise rather than signal. Invalid config (not a list of
+    strings) falls back to the default rather than raising.
+    """
+    entry = _get_refine_entry()
+    val = entry.get("skip_session_sources")
+    if isinstance(val, list) and all(isinstance(item, str) for item in val):
+        return [item.strip().lower() for item in val if item.strip()]
+    return ["cron"]
 
 
 def cross_session_days() -> int:

--- a/core.py
+++ b/core.py
@@ -102,6 +102,24 @@ def _open_db() -> Optional[sqlite3.Connection]:
         return None
 
 
+def _get_session_source(session_id: str) -> str:
+    """Read-only lookup of a session's source column. Returns "" on any failure."""
+    if not session_id:
+        return ""
+    connection = _open_db()
+    if not connection:
+        return ""
+    try:
+        row = connection.execute(
+            "SELECT source FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+        return str(row["source"] or "") if row else ""
+    except Exception:
+        return ""
+    finally:
+        connection.close()
+
+
 def _structured_error_status(content: str) -> Optional[bool]:
     """Return a definitive structured status, or None when text is unstructured."""
     try:
@@ -664,6 +682,8 @@ def refine_status() -> Dict[str, Any]:
         "session_id": sid,
         "session_id_source": sid_source,
         "session_message_count": session_message_count,
+        "session_source": _get_session_source(sid) if sid else "",
+        "skip_session_sources": config.skip_session_sources(),
         "llm_model": target["model"],
         "llm_provider": target["provider"],
         "llm_target_source": target["source"],
@@ -944,6 +964,20 @@ def _refine_once(
             "success": False,
             "outcome": "session_unknown",
             "message": "Cannot identify the current session; refine did not run.",
+            "evidence": evidence,
+            "reversible": False,
+        }
+    # Source filter: skip machine-generated sessions whose trajectory is noise.
+    skip_sources = config.skip_session_sources()
+    session_db_source = _get_session_source(session)
+    if session_db_source and session_db_source.lower() in skip_sources:
+        return {
+            "success": True,
+            "outcome": "skipped_session_source",
+            "message": (
+                f"Session source '{session_db_source}' is in skip_session_sources; "
+                "refine did not run."
+            ),
             "evidence": evidence,
             "reversible": False,
         }

--- a/core.py
+++ b/core.py
@@ -406,6 +406,25 @@ def refine_status() -> Dict[str, Any]:
     jdir = config.journal_dir()
     jdir_state = _journal_dir_state(jdir)
 
+    # The effective model belongs in this report. A pinned model that no provider
+    # serves turns every pass into an ordinary no_op, and without it here the
+    # report would answer "blockers: none" while nothing can possibly succeed.
+    try:
+        target = config.effective_llm_target()
+    except Exception:
+        # "unknown", not "host_default": a config key or override file may still
+        # pin something, and this report must not claim a resolution it failed to
+        # perform.
+        target = {
+            "provider": "", "model": "", "source": "unknown",
+            "issues": ["the effective model could not be resolved"],
+        }
+    try:
+        model_allowed = config.llm_allow_model_override()
+        provider_allowed = config.llm_allow_provider_override()
+    except Exception:
+        model_allowed = provider_allowed = False
+
     # Read journal-derived numbers only when a journal actually exists, so a
     # mistyped journal_dir is reported rather than silently created.
     journal_present = False
@@ -500,6 +519,50 @@ def refine_status() -> Dict[str, Any]:
                 "cannot confirm refinement is able to run"
             ),
         })
+    target_issues = [str(item) for item in target.get("issues", []) if item]
+    if target_issues:
+        # A discarded value must not be visible only in a log line: the file or
+        # config key still pins something while this report names another target.
+        warnings.append({
+            "code": "model_target_issue",
+            "message": "; ".join(target_issues),
+        })
+    if target["source"] == "command":
+        warnings.append({
+            "code": "model_override_active",
+            # Deliberately does not say the override pinned each field: when it
+            # sets only one, the other comes from the config and survives
+            # '/refine model auto'. Claiming otherwise would describe a state
+            # this report did not verify.
+            "message": (
+                "A '/refine model' override is in force; the effective target is "
+                f"{target['model'] or '(host default)'}"
+                + (f" on provider {target['provider']}" if target["provider"] else "")
+                + ". '/refine model auto' removes the override; any value also set "
+                  "in plugins.entries.refine.llm stays in effect after that"
+            ),
+        })
+    # A value the host will refuse is dropped before the call, so it can only be
+    # noticed here. Reported per field, because the denied one may be either.
+    if target["source"] in ("command", "config"):
+        if target["model"] and not model_allowed:
+            warnings.append({
+                "code": "model_override_trust_denied",
+                "message": (
+                    f"Model {target['model']} is set but host trust denies model "
+                    "overrides, so it is dropped before the call; set "
+                    "plugins.entries.refine.llm.allow_model_override to apply it"
+                ),
+            })
+        if target["provider"] and not provider_allowed:
+            warnings.append({
+                "code": "provider_override_trust_denied",
+                "message": (
+                    f"Provider {target['provider']} is set but host trust denies "
+                    "provider overrides, so it is dropped before the call; set "
+                    "plugins.entries.refine.llm.allow_provider_override to apply it"
+                ),
+            })
 
     return {
         "config_readable": config_readable,
@@ -520,6 +583,12 @@ def refine_status() -> Dict[str, Any]:
         "journal_dir_state": jdir_state,
         "journal_dir_state_text": _JOURNAL_DIR_STATE_TEXT.get(jdir_state, jdir_state),
         "journal_dir_is_plugin_source": plugin_source_collision,
+        "llm_model": target["model"],
+        "llm_provider": target["provider"],
+        "llm_target_source": target["source"],
+        "llm_target_issues": target_issues,
+        "llm_model_allowed": model_allowed,
+        "llm_provider_allowed": provider_allowed,
         "blockers": blockers,
         "blocker_codes": [b["code"] for b in blockers],
         "warnings": warnings,

--- a/core.py
+++ b/core.py
@@ -942,6 +942,7 @@ def _refine_once(
     reason: str = "",
     session_id: Optional[str] = None,
     auto: bool = False,
+    dry_run: bool = False,
 ) -> Dict[str, Any]:
     trigger = "auto" if auto else "manual"
     started = time.time()
@@ -1170,6 +1171,86 @@ def _refine_once(
         "messages": len(evidence.get("messages", [])),
         "errors": evidence.get("error_count", 0),
     }
+
+    # ── Dry-run exit: show what would happen, apply nothing ────────────────
+    if dry_run:
+        import difflib as _difflib
+
+        dry_proposal = proposal
+        if proposal.get("action") == "multi":
+            # Normalize each edit so the user sees the final form.
+            edits = [
+                _normalize_edit(sanitize(edit), session)
+                for edit in proposal.get("edits", [])
+                if isinstance(edit, dict)
+            ]
+            dry_proposal = dict(proposal, edits=edits)
+        else:
+            dry_proposal = _normalize_edit(proposal, session)
+
+        # Build a diff for patch proposals.
+        diff_text = ""
+        max_diff_chars = _llm.MAX_CONTENT_CHARS
+        truncated = False
+
+        def _build_diff(name: str, new_content: str) -> str:
+            old_content = journal.read_skill_content(name) or ""
+            old_lines = old_content.splitlines()
+            new_lines = new_content.splitlines()
+            diff_lines = list(_difflib.unified_diff(
+                old_lines, new_lines, fromfile=f"a/{name}", tofile=f"b/{name}", lineterm=""
+            ))
+            return "\n".join(diff_lines)
+
+        if dry_proposal.get("action") == "patch" and dry_proposal.get("kind") == "skill":
+            name = str(dry_proposal.get("name", ""))
+            content = str(dry_proposal.get("content", ""))
+            if name and content:
+                raw_diff = _build_diff(name, content)
+                if len(raw_diff) > max_diff_chars:
+                    diff_text = scrub_text(raw_diff[:max_diff_chars]) + "\n… [truncated]"
+                    truncated = True
+                else:
+                    diff_text = scrub_text(raw_diff)
+        elif dry_proposal.get("action") == "multi":
+            diff_parts = []
+            for edit in dry_proposal.get("edits", []):
+                if edit.get("action") == "patch" and edit.get("kind") == "skill":
+                    name = str(edit.get("name", ""))
+                    content = str(edit.get("content", ""))
+                    if name and content:
+                        diff_parts.append(_build_diff(name, content))
+            if diff_parts:
+                combined = "\n".join(diff_parts)
+                if len(combined) > max_diff_chars:
+                    diff_text = scrub_text(combined[:max_diff_chars]) + "\n… [truncated]"
+                    truncated = True
+                else:
+                    diff_text = scrub_text(combined)
+
+        # Journal the dry run so /refine audit shows it was considered.
+        _journal_nonmutation(
+            trigger=trigger,
+            reason=safe_reason or "dry-run",
+            session_id=session,
+            proposal=dry_proposal,
+            outcome="dry_run",
+            llm_meta=_run_llm_meta,
+        )
+
+        return {
+            "success": True,
+            "outcome": "dry_run",
+            "message": "Dry run: proposal shown, nothing applied.",
+            "proposal": dry_proposal,
+            "diff": diff_text,
+            "diff_truncated": truncated,
+            "evidence": evidence_summary,
+            "llm_called": True,
+            "llm_meta": _run_llm_meta,
+            "reversible": False,
+            "edits_applied": 0,
+        }
 
     if proposal.get("action") == "multi":
         transaction = _apply_transaction(
@@ -1826,11 +1907,20 @@ def refine_run(
     reason: str = "",
     session_id: Optional[str] = None,
     auto: bool = False,
+    dry_run: bool = False,
 ) -> Dict[str, Any]:
     """Serialize a run, reconcile approvals, and preserve every recovery id."""
     started = time.time()
     with journal.mutation_lock():
         _reconcile_pending()
+
+        if dry_run:
+            # Dry-run: one proposal pass, no apply, no budget consumed.
+            return _refine_once(
+                llm, reason=scrub_text(reason), session_id=session_id,
+                auto=auto, dry_run=True,
+            )
+
         runs: List[Dict[str, Any]] = []
         # ``max_edits_per_run`` bounds proposal passes; ``max_edits_per_proposal``
         # bounds edits inside one transaction; the daily edit budget bounds edits

--- a/core.py
+++ b/core.py
@@ -920,6 +920,7 @@ def _skill_baseline_conflict(
 
 
 def _journal_nonmutation(**kwargs: Any) -> Optional[str]:
+    """Write a non-mutating journal entry. Accepts all journal.log kwargs including llm_meta."""
     try:
         return journal.log(**kwargs)
     except Exception as exc:
@@ -952,6 +953,22 @@ def _refine_once(
             "message": f"Daily edit limit reached ({config.max_edits_per_day()}). "
             f"Applied/pending/prepared today: {journal.count_today_applied()}.",
         }
+
+    # Resolve the LLM target once per pass so every call within it uses the same
+    # model. This makes the choice deterministic and attributable in the journal.
+    try:
+        _effective = config.effective_llm_target()
+        _run_target: Dict[str, str] = {}
+        if _effective.get("provider") and config.llm_allow_provider_override():
+            _run_target["provider"] = _effective["provider"]
+        if _effective.get("model") and config.llm_allow_model_override():
+            _run_target["model"] = _effective["model"]
+        _run_target_source = _effective.get("source", "host_default")
+        _run_target_issues = [str(i) for i in _effective.get("issues", []) if i]
+    except Exception:
+        _run_target = {}
+        _run_target_source = "unknown"
+        _run_target_issues = ["the effective model could not be resolved"]
 
     evidence_limit = 60
     if config.min_signal_required() and config.reviewer_fallback_enabled():
@@ -1010,7 +1027,7 @@ def _refine_once(
             and _reviewer_cooldown_elapsed()
         )
         if should_review:
-            reviewer = _llm.review_fallback(llm, evidence_text)
+            reviewer = _llm.review_fallback(llm, evidence_text, target=_run_target)
             rationale = scrub_text(str(reviewer.get("rationale", "")))
             decision = "approved" if reviewer.get("should_refine") else "declined"
             reviewer_reason = f"Reviewer {decision}: {rationale}"
@@ -1094,7 +1111,20 @@ def _refine_once(
         purpose="refine",
         run_context=proposal_context,
         skill_content_loader=journal.read_skill_content,
+        target=_run_target,
     )
+    # Capture metadata from the LLM call that produced this proposal.
+    llm_meta = _llm.last_call_meta()
+    _run_llm_meta = {
+        "requested_provider": _run_target.get("provider", ""),
+        "requested_model": _run_target.get("model", ""),
+        "target_source": _run_target_source,
+        **{k: v for k, v in llm_meta.items() if k in (
+            "reported_model", "latency_ms", "output_tokens"
+        )},
+    }
+    if _run_target_issues:
+        _run_llm_meta["target_issues"] = _run_target_issues
     proposal = sanitize(proposal)
     proposal = dict(
         proposal,
@@ -1121,6 +1151,7 @@ def _refine_once(
             proposal=proposal,
             outcome="llm_incomplete",
             error=failure_message,
+            llm_meta=_run_llm_meta,
         )
         response = {
             "success": False,
@@ -1147,8 +1178,10 @@ def _refine_once(
             safe_reason=safe_reason,
             session=session,
             started=started,
+            llm_meta=_run_llm_meta,
         )
         transaction["evidence"] = evidence_summary
+        transaction["llm_meta"] = _run_llm_meta
         return transaction
 
     proposal = _normalize_edit(proposal, session)
@@ -1160,6 +1193,7 @@ def _refine_once(
             session_id=session,
             proposal=proposal,
             outcome="no_op",
+            llm_meta=_run_llm_meta,
         )
         if not entry_id:
             return {
@@ -1174,6 +1208,7 @@ def _refine_once(
             "proposal": proposal,
             "evidence": evidence,
             "reversible": False,
+            "llm_meta": _run_llm_meta,
         }
 
     response = _apply_edit(
@@ -1182,8 +1217,10 @@ def _refine_once(
         safe_reason=safe_reason,
         session=session,
         started=started,
+        llm_meta=_run_llm_meta,
     )
     response["evidence"] = evidence_summary
+    response["llm_meta"] = _run_llm_meta
     return response
 
 
@@ -1195,6 +1232,7 @@ def _apply_edit(
     session: str,
     started: float,
     group: Optional[Dict[str, Any]] = None,
+    llm_meta: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Validate, back up, apply, and finalize exactly one edit.
 
@@ -1460,6 +1498,7 @@ def _apply_edit(
                 entry_id,
                 outcome=outcome,
                 pending_id=pending_id,
+                llm_meta=llm_meta,
             )
         except Exception as exc:
             logger.warning("Cannot record edit in ledger: %s", exc)
@@ -1525,6 +1564,7 @@ def _apply_transaction(
     safe_reason: str,
     session: str,
     started: float,
+    llm_meta: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Apply one multi-edit proposal as a sequence of independent durable edits.
 
@@ -1658,6 +1698,7 @@ def _apply_transaction(
             session=session,
             started=started,
             group=edit_group(index),
+            llm_meta=llm_meta,
         )
         results.append(item)
         if not item.get("success"):

--- a/core.py
+++ b/core.py
@@ -5,10 +5,11 @@ import logging
 import os
 import re
 import sqlite3
+import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from agent.plugin_llm import PluginLlm
 
@@ -20,6 +21,64 @@ except ImportError:
     from sanitization import sanitize, scrub_text  # noqa: F811
 
 logger = logging.getLogger(__name__)
+
+# ── session identity ───────────────────────────────────────────────────────
+# The host does not pass session_id to slash-command handlers (contract is
+# fn(raw_args) -> str|None). But pre_llm_call and post_llm_call hooks do
+# receive it every turn. This module remembers the last value seen, so that a
+# manual /refine command running in the same process can resolve it.
+
+_LAST_SESSION_ID = ""
+_LAST_SESSION_LOCK = threading.Lock()
+
+
+def note_session_id(session_id: str) -> None:
+    """Record the session id seen from a host hook. Thread-safe, one value."""
+    global _LAST_SESSION_ID
+    if not isinstance(session_id, str) or not session_id.strip():
+        return
+    clean = session_id.strip()
+    # Reject anything that scrubbing would alter — it might be content, not an id.
+    if scrub_text(clean) != clean or len(clean) > 128:
+        return
+    with _LAST_SESSION_LOCK:
+        _LAST_SESSION_ID = clean
+
+
+def _noted_session_id() -> str:
+    with _LAST_SESSION_LOCK:
+        return _LAST_SESSION_ID
+
+
+def host_session_id() -> str:
+    """Best-effort read of the host's current session id via ContextVar/env.
+
+    Available in CLI and cron; returns "" in the gateway (which sets session_key,
+    not session_id, into the context). Guarded: any failure → "".
+    """
+    try:
+        from gateway.session_context import get_session_env
+        value = get_session_env("HERMES_SESSION_ID", "")
+        return value.strip() if isinstance(value, str) else ""
+    except Exception:
+        return ""
+
+
+def resolve_session_id(explicit: str = "") -> Tuple[str, str]:
+    """Resolve which session to analyse.
+
+    Returns (session_id, how) where how ∈ {explicit, host_env, hook, unknown}.
+    When unknown, the caller must refuse rather than guess.
+    """
+    if explicit and explicit.strip():
+        return explicit.strip(), "explicit"
+    env_id = host_session_id()
+    if env_id:
+        return env_id, "host_env"
+    hook_id = _noted_session_id()
+    if hook_id:
+        return hook_id, "hook"
+    return "", "unknown"
 
 
 def scrub_proposal(proposal: Dict[str, Any]) -> Dict[str, Any]:
@@ -40,16 +99,6 @@ def _open_db() -> Optional[sqlite3.Connection]:
         return connection
     except Exception as exc:
         logger.warning("Cannot open state.db: %s", exc)
-        return None
-
-
-def _get_recent_session_id(connection: sqlite3.Connection) -> Optional[str]:
-    try:
-        row = connection.execute(
-            "SELECT id FROM sessions ORDER BY started_at DESC LIMIT 1"
-        ).fetchone()
-        return row["id"] if row else None
-    except Exception:
         return None
 
 
@@ -127,7 +176,6 @@ def _is_correction(content: str) -> bool:
 
 
 def collect_evidence(session_id: Optional[str] = None, limit: int = 60) -> Dict[str, Any]:
-    connection = _open_db()
     empty = {
         "messages": [],
         "error_count": 0,
@@ -135,17 +183,22 @@ def collect_evidence(session_id: Optional[str] = None, limit: int = 60) -> Dict[
         "error_patterns": [],
         "user_corrections": [],
         "session_id": "",
+        "session_id_source": "unknown",
     }
+    resolved, how = resolve_session_id(session_id or "")
+    if not resolved:
+        empty["session_id_source"] = how
+        return empty
+    connection = _open_db()
     if not connection:
+        empty["session_id"] = resolved
+        empty["session_id_source"] = how
         return empty
     try:
-        session_id = session_id or _get_recent_session_id(connection)
-        if not session_id:
-            return empty
         rows = connection.execute(
             "SELECT role, content, tool_name, timestamp FROM messages "
             "WHERE session_id = ? AND active = 1 ORDER BY timestamp DESC LIMIT ?",
-            (session_id, limit),
+            (resolved, limit),
         ).fetchall()
         messages: List[Dict[str, Any]] = []
         tool_errors: List[Dict[str, Any]] = []
@@ -178,7 +231,8 @@ def collect_evidence(session_id: Optional[str] = None, limit: int = 60) -> Dict[
             "tool_errors": tool_errors[-10:],
             "error_patterns": patterns.extract_patterns(error_items),
             "user_corrections": corrections[-5:],
-            "session_id": session_id,
+            "session_id": resolved,
+            "session_id_source": how,
         }
     finally:
         connection.close()
@@ -564,6 +618,32 @@ def refine_status() -> Dict[str, Any]:
                 ),
             })
 
+    # Session identity — what /refine would analyse if triggered now.
+    sid, sid_source = resolve_session_id()
+    session_message_count = 0
+    if sid:
+        try:
+            conn = _open_db()
+            if conn:
+                try:
+                    row = conn.execute(
+                        "SELECT COUNT(*) n FROM messages WHERE session_id=? AND active=1",
+                        (sid,),
+                    ).fetchone()
+                    session_message_count = row["n"] if row else 0
+                finally:
+                    conn.close()
+        except Exception:
+            pass
+    if sid_source == "unknown":
+        blockers.append({
+            "code": "session_unknown",
+            "message": (
+                "Cannot identify the current session. Neither the host environment "
+                "nor a recent hook provided a session id."
+            ),
+        })
+
     return {
         "config_readable": config_readable,
         "auto_enabled": auto,
@@ -577,12 +657,13 @@ def refine_status() -> Dict[str, Any]:
         "max_edits_per_day": max_edits,
         "journal_present": journal_present,
         "journal_readable": journal_readable,
-        # The real path, because the report tells the user to move files in and
-        # out of it. Truncating it to a tilde made it unusable in a shell.
         "journal_dir": str(jdir),
         "journal_dir_state": jdir_state,
         "journal_dir_state_text": _JOURNAL_DIR_STATE_TEXT.get(jdir_state, jdir_state),
         "journal_dir_is_plugin_source": plugin_source_collision,
+        "session_id": sid,
+        "session_id_source": sid_source,
+        "session_message_count": session_message_count,
         "llm_model": target["model"],
         "llm_provider": target["provider"],
         "llm_target_source": target["source"],
@@ -857,6 +938,15 @@ def _refine_once(
         evidence_limit = max(evidence_limit, config.reviewer_min_messages())
     evidence = collect_evidence(session_id=session_id, limit=evidence_limit)
     session = evidence.get("session_id", "")
+    session_source = evidence.get("session_id_source", "unknown")
+    if not session and session_source == "unknown":
+        return {
+            "success": False,
+            "outcome": "session_unknown",
+            "message": "Cannot identify the current session; refine did not run.",
+            "evidence": evidence,
+            "reversible": False,
+        }
     if len(evidence.get("messages", [])) < 3:
         return {
             "success": True,

--- a/journal.py
+++ b/journal.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import tempfile
 import threading
 import time
@@ -30,6 +31,77 @@ _LOCK_FILE_NAME = ".mutation.lock"
 _LOCK_STALE_SECONDS = 300
 _THREAD_LOCK = threading.RLock()
 _LOCK_STATE = threading.local()
+
+# Owned here rather than in the command layer, because this module owns the
+# store: the same rule then applies to the command, to a hand-edited file, and
+# to any future writer, instead of once per call site.
+#
+# Two shapes, not one. In ``/refine model <provider>/<model>`` the slash is the
+# separator, so each half must not contain one. A model *id*, however, is very
+# often namespaced — ``deepseek/deepseek-chat``, ``anthropic/claude-3.5-sonnet``
+# — so the id rule has to allow it. Applying the token rule to a configured
+# ``llm.model`` would silently discard exactly the ids people pin.
+_MODEL_TOKEN_CHARS = r"[A-Za-z0-9._:\-]{1,120}"
+_MODEL_TOKEN = re.compile(rf"^{_MODEL_TOKEN_CHARS}$")
+_MODEL_ID = re.compile(rf"^{_MODEL_TOKEN_CHARS}(?:/{_MODEL_TOKEN_CHARS})*$")
+
+
+def valid_model_identifier(value: str) -> bool:
+    """Whether text is one slash-free provider/model token, not free-form prose.
+
+    Requires at least one alphanumeric character: ``.`` and ``---`` match the
+    character class but name no model, and pinning one would turn every later
+    pass into a host-side model error.
+    """
+    return bool(_MODEL_TOKEN.fullmatch(value)) and any(
+        char.isalnum() for char in value
+    )
+
+
+def valid_model_id(value: str) -> bool:
+    """Whether text is a model id, allowing the common namespaced form."""
+    return bool(_MODEL_ID.fullmatch(value)) and any(
+        char.isalnum() for char in value
+    )
+
+
+def model_override_field_problem(value: str, *, allow_namespace: bool = False) -> str:
+    """Say why a provider/model value is unusable, or "" when it is fine.
+
+    Set ``allow_namespace`` for a model id, which may be ``vendor/name``; leave it
+    off for a value that came from one side of the command's ``provider/model``
+    split, where a slash cannot appear.
+
+    Returns a reason rather than a bool so the refusal can name which rule failed.
+    "Refusing an unsafe value" reads as a credential accusation for a name that
+    merely had the wrong shape, and vice versa — and the caller must be able to
+    explain the refusal without echoing the value, which may be a pasted secret.
+
+    Public because the Hermes config writes the same field. If the rule lived on
+    the command path only, the identical value would be refused from
+    ``/refine model`` and accepted from ``config.yaml``.
+    """
+    accepted = valid_model_id(value) if allow_namespace else valid_model_identifier(value)
+    if not accepted:
+        return (
+            "it is not a model identifier (letters, digits, '.', '_', ':', '-'"
+            + (", '/'" if allow_namespace else "")
+            + ", at least one alphanumeric)"
+        )
+    # The check that matters most. ``ghp_`` + 36 characters is a valid identifier,
+    # so shape alone would persist a pasted token verbatim while the command echo
+    # reported it redacted — telling the user a value was protected when it
+    # was not. It can also fire on a legitimate name such as
+    # ``my-token-model:latest``; refusing that is the safe side of the trade, and
+    # the message says which rule rejected it.
+    if scrub_text(value) != value:
+        return "it matches a credential pattern, so it is refused rather than stored"
+    return ""
+
+
+def model_override_field_is_safe(value: str, *, allow_namespace: bool = False) -> bool:
+    """Whether a provider/model value may be stored and sent to the host."""
+    return not model_override_field_problem(value, allow_namespace=allow_namespace)
 
 
 def ensure_dirs() -> Path:
@@ -71,42 +143,151 @@ def model_override_read_path() -> Path:
     return journal_dir() / _MODEL_OVERRIDE_FILE_NAME
 
 
-def read_model_override() -> Optional[Dict[str, str]]:
-    """Return the user's command-set model override, or None when absent/corrupt."""
+def _read_model_override_bytes() -> Optional[bytes]:
+    """Return the raw store, or None when there is genuinely no override.
+
+    A missing file is the common case and must stay on the fast path, so it is
+    reported rather than raised: only a *failed* open is worth retrying.
+
+    ``FileNotFoundError`` is absence too, not a failure. It is caught explicitly
+    because the file can vanish between the check and the open — a concurrent
+    ``/refine model auto`` does exactly that — and retrying it would spend the
+    whole budget and then report "could not be read" about a file the user had
+    just deliberately deleted.
+    """
     path = model_override_read_path()
-    if not path.is_file():
-        return None
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
+        if not path.is_file():
             return None
-        model = str(data.get("model", "") or "").strip()
-        provider = str(data.get("provider", "") or "").strip()
-        if not model and not provider:
-            return None
-        return {"model": model, "provider": provider}
-    except Exception:
+        return path.read_bytes()
+    except FileNotFoundError:
         return None
+
+
+def read_model_override_state() -> "tuple[Optional[Dict[str, str]], str]":
+    """Return the override and why it is, or is not, in force.
+
+    States: ``absent``, ``ok``, ``rejected`` (present but unusable) and
+    ``unreadable`` (present but could not be read on this attempt — on Windows a
+    concurrent write can deny a read for a moment).
+
+    The last two are kept apart from ``absent`` deliberately. Collapsing them
+    would leave a file that pins one model while every diagnostic reports a
+    different one, with a log line as the only trace — the invisible failure this
+    project treats as worse than an error.
+
+    Never raises: this runs while a proposal call is being assembled, and an
+    exception here would surface as a generic LLM failure rather than as a
+    problem with the override store.
+    """
+    # Bytes, not text: decoding here would raise UnicodeDecodeError, which is not
+    # an OSError, so a store hand-edited in a non-UTF-8 codepage would escape this
+    # function into the proposal call and end every pass as an ordinary no_op.
+    # Decoding below keeps that input in the "rejected" state it belongs to.
+    try:
+        # Only OSError is retried — a sharing denial is the transient case, and it
+        # is measured, not assumed: under a concurrent atomic replace this open is
+        # denied for a moment on Windows a few times per few hundred reads. A
+        # reader that gave up would report "no override" and send the call to a
+        # different model than the one the user pinned.
+        raw = _retry_on_contention(
+            _read_model_override_bytes, _READ_RETRY_BUDGET_SECONDS, OSError
+        )
+    except Exception as exc:
+        # Broad on purpose. "Never raises" has to hold for every exception type,
+        # not just the one expected here: anything escaping would be assembled
+        # into a proposal call and journaled as an ordinary no_op with
+        # success=true, which is the outcome this function exists to prevent.
+        logger.warning("Cannot read the model override: %s", scrub_text(str(exc)))
+        return None, "unreadable"
+    if raw is None:
+        return None, "absent"
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return None, "rejected"
+    if not isinstance(data, dict):
+        return None, "rejected"
+    model = str(data.get("model", "") or "").strip()
+    provider = str(data.get("provider", "") or "").strip()
+    if not model and not provider:
+        return None, "rejected"
+    # Validate on the way out as well as on the way in. A hand-edited, partially
+    # written or externally produced store must not inject arbitrary strings into
+    # the host's LLM call arguments.
+    if (provider and not model_override_field_is_safe(provider)) or (
+        model and not model_override_field_is_safe(model, allow_namespace=True)
+    ):
+        logger.warning("Ignoring an unusable model override on disk")
+        return None, "rejected"
+    return {"model": model, "provider": provider}, "ok"
+
+
+def read_model_override() -> Optional[Dict[str, str]]:
+    """Return the user's command-set model override, or None when not in force."""
+    return read_model_override_state()[0]
 
 
 def write_model_override(provider: str, model: str) -> None:
-    """Persist the model override atomically."""
-    import time as _time
+    """Persist the model override atomically, refusing anything unsafe.
 
+    Mirrors ``_write_prompt_notes``: the store refuses unsafe content instead of
+    trusting its caller to have checked. Raises ``ValueError`` so the command
+    layer reports a refusal rather than reporting success over a rejected write.
+    """
+    for name, value, namespaced in (
+        ("provider", provider, False),
+        ("model", model, True),
+    ):
+        problem = (
+            model_override_field_problem(value, allow_namespace=namespaced)
+            if value
+            else ""
+        )
+        if problem:
+            # Names the rule but never the value: the value may be a pasted
+            # credential, and this message is echoed back into the conversation.
+            raise ValueError(f"Refusing to store that {name} because {problem}")
+    if not provider and not model:
+        raise ValueError("Refusing to store an empty model override")
     payload = json.dumps(
-        {"provider": provider, "model": model, "set_ts": _time.time()},
+        {"provider": provider, "model": model, "set_ts": time.time()},
         ensure_ascii=False,
     )
     _atomic_write_text(ensure_dirs() / _MODEL_OVERRIDE_FILE_NAME, payload)
 
 
-def clear_model_override() -> None:
-    """Remove the model override file."""
-    path = journal_dir() / _MODEL_OVERRIDE_FILE_NAME
+def clear_model_override() -> str:
+    """Remove the model override file, reporting what actually happened.
+
+    Returns ``removed``, ``absent`` when there was nothing to remove, or
+    ``failed`` when the file survives — on Windows an unlink can fail with
+    ``PermissionError`` while another session thread holds it open, so it gets the
+    same bounded retry as the read and the write. Confirming "removed" in either
+    of the last two cases would report an action that did not take place.
+
+    The answer comes from the unlink itself rather than from a preceding
+    existence check: with a check first, a ``/refine model x`` from another
+    channel landing in between would be deleted and still reported as "no
+    override was set".
+
+    The store is deliberately not locked: the mutation lock is held for a whole
+    refine pass, and making a settings command queue behind one would be worse
+    than the race it removes. Last writer wins, which for a single-user setting
+    command is the expected outcome.
+    """
+    path = model_override_read_path()
     try:
-        path.unlink(missing_ok=True)
-    except Exception:
-        pass
+        _retry_on_contention(path.unlink, _UNLINK_RETRY_BUDGET_SECONDS)
+        return "removed"
+    except FileNotFoundError:
+        return "absent"
+    except Exception as exc:
+        logger.warning("Cannot remove the model override: %s", scrub_text(str(exc)))
+        try:
+            return "failed" if path.exists() else "removed"
+        except OSError:
+            return "failed"
 
 
 def normalize_prompt_note_session_id(session_id: Any) -> str:
@@ -421,6 +602,58 @@ def try_mutation_lock() -> Iterator[bool]:
 # ── durable file I/O ───────────────────────────────────────────────────────
 
 
+# One base owns every store-contention budget, so they cannot drift apart. The
+# write waits longest because it races a *reader*, which holds the file for a
+# whole read; a read and an unlink race a single atomic replace, which is orders
+# of magnitude shorter. The write budget is not smaller for a measured reason: a
+# 0.1s write budget lost a two-thread stress race 10 times out of 12, this one
+# lost none in 12. Every budget is spent only under actual contention, and their
+# sum stays well inside the timeout host callbacks use for the mutation lock.
+_CONTENTION_BUDGET_SECONDS = 0.5
+_WRITE_RETRY_BUDGET_SECONDS = _CONTENTION_BUDGET_SECONDS
+_READ_RETRY_BUDGET_SECONDS = _CONTENTION_BUDGET_SECONDS / 5
+_UNLINK_RETRY_BUDGET_SECONDS = _CONTENTION_BUDGET_SECONDS / 5
+_RETRY_MAX_DELAY = 0.05
+
+
+def _retry_on_contention(operation, budget: float, errors=PermissionError):
+    """Run a store operation, tolerating a momentary Windows sharing denial.
+
+    On Windows a file operation fails while another handle on the target is open,
+    and every store here is read lock-free from the per-turn hook path of a
+    gateway that serves several channels at once. POSIX does not fail this way, so
+    this is inert there.
+
+    This does not paper over the race: nothing about the operation's atomicity
+    changes, only its scheduling, and once the budget is spent the original error
+    is raised unchanged rather than swallowed.
+    """
+    deadline = time.monotonic() + budget
+    delay = 0.005
+    while True:
+        try:
+            return operation()
+        except errors:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(min(delay, _RETRY_MAX_DELAY))
+            delay *= 2
+
+
+def _replace_with_retry(temp_name: str, path: Path) -> None:
+    """Atomically replace the target, tolerating a concurrent reader on Windows.
+
+    This sits under ``_atomic_write_text``, so it covers every store written that
+    way — prompt notes and skill snapshots as well as the model override. That is
+    deliberate: all of them are read lock-free from hook paths, so all of them can
+    lose the same race, and fixing it once at the writer is better than three
+    times at the call sites.
+    """
+    _retry_on_contention(
+        lambda: os.replace(temp_name, path), _WRITE_RETRY_BUDGET_SECONDS
+    )
+
+
 def _atomic_write_text(path: Path, content: str) -> None:
     """Atomically replace backup/stat files; journals use append-only writes."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -430,7 +663,7 @@ def _atomic_write_text(path: Path, content: str) -> None:
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(temp_name, path)
+        _replace_with_retry(temp_name, path)
     except Exception:
         try:
             os.unlink(temp_name)

--- a/journal.py
+++ b/journal.py
@@ -780,6 +780,7 @@ def _new_entry(
     recovery: Optional[Dict[str, Any]] = None,
     group: Optional[Dict[str, Any]] = None,
     snapshot: Optional[Dict[str, Any]] = None,
+    llm_meta: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     entry = {
         "id": uuid.uuid4().hex[:12],
@@ -793,15 +794,13 @@ def _new_entry(
         "recovery": recovery or {},
         "error": error,
     }
-    # Carrying the pre-edit content in the record itself is what makes rollback
-    # independent of a backup file still being on disk.
     if snapshot:
         entry["snapshot"] = snapshot
-    # A multi-edit transaction stays one durable record per edit, so rollback,
-    # reconciliation, dedup, and the daily edit budget keep working unchanged.
-    # ``group`` only reports which edits belonged together.
     if group:
         entry["group"] = group
+    # LLM attribution — additive, old entries without it read fine.
+    if llm_meta and isinstance(llm_meta, dict):
+        entry["llm_meta"] = llm_meta
     return entry
 
 
@@ -817,6 +816,7 @@ def log(
     recovery: Optional[Dict[str, Any]] = None,
     group: Optional[Dict[str, Any]] = None,
     snapshot: Optional[Dict[str, Any]] = None,
+    llm_meta: Optional[Dict[str, Any]] = None,
 ) -> str:
     entry = _new_entry(
         trigger=trigger,
@@ -829,6 +829,7 @@ def log(
         recovery=recovery,
         group=group,
         snapshot=snapshot,
+        llm_meta=llm_meta,
     )
     _append_entry(entry)
     return entry["id"]
@@ -844,6 +845,7 @@ def prepare(
     recovery: Optional[Dict[str, Any]] = None,
     group: Optional[Dict[str, Any]] = None,
     snapshot: Optional[Dict[str, Any]] = None,
+    llm_meta: Optional[Dict[str, Any]] = None,
 ) -> str:
     return log(
         trigger=trigger,
@@ -855,6 +857,7 @@ def prepare(
         recovery=recovery,
         group=group,
         snapshot=snapshot,
+        llm_meta=llm_meta,
     )
 
 

--- a/journal.py
+++ b/journal.py
@@ -290,6 +290,127 @@ def clear_model_override() -> str:
             return "failed"
 
 
+# ── legacy journal directory migration ─────────────────────────────────────
+
+_MIGRATION_MARKER = ".migrated_from"
+_MIGRATION_FILES = [
+    _JOURNAL_FILE_NAME,
+    "skill_stats.json",
+    _PROMPT_NOTES_FILE_NAME,
+    _MODEL_OVERRIDE_FILE_NAME,
+]
+_MIGRATION_DIRS = [_BACKUPS_DIR_NAME]
+
+
+def migrate_legacy_journal_dir(
+    *,
+    _new_dir: "Optional[Path]" = None,
+    _legacy_dir: "Optional[Path]" = None,
+) -> str:
+    """One-time, idempotent migration of runtime data to the new default location.
+
+    Returns one of:
+      user_configured — the user explicitly set journal_dir, so we do nothing.
+      not_needed      — nothing to migrate (new install or already migrated).
+      migrated        — files copied, old dir renamed.
+      failed          — something went wrong; refine continues from wherever data
+                        actually exists.
+
+    Never deletes data. The old directory is renamed, not removed.
+    Must be called under the mutation lock (taken internally) so two processes
+    cannot race and double-copy.
+    """
+    try:
+        from . import config as _cfg
+    except ImportError:
+        import config as _cfg  # type: ignore
+
+    # If the user set journal_dir explicitly, their choice takes priority.
+    entry = _cfg._get_refine_entry()
+    if entry.get("journal_dir"):
+        return "user_configured"
+
+    new_dir = _new_dir if _new_dir is not None else _cfg.journal_dir()
+    legacy = _legacy_dir if _legacy_dir is not None else _cfg.legacy_journal_dir()
+
+    # If the legacy dir doesn't exist or has no runtime files, nothing to move.
+    if not legacy.is_dir():
+        return "not_needed"
+
+    has_data = any(
+        (legacy / name).exists()
+        for name in _MIGRATION_FILES + _MIGRATION_DIRS
+    )
+    if not has_data:
+        return "not_needed"
+
+    # If the new dir already has a journal, the migration already happened or
+    # someone manually moved things. Don't overwrite.
+    if (new_dir / _JOURNAL_FILE_NAME).is_file():
+        return "not_needed"
+
+    # If the marker says we already renamed, don't do it again.
+    if (new_dir / _MIGRATION_MARKER).is_file():
+        return "not_needed"
+
+    with _THREAD_LOCK:
+        # Re-check after lock acquisition — another thread may have migrated.
+        if (new_dir / _JOURNAL_FILE_NAME).is_file():
+            return "not_needed"
+        if (new_dir / _MIGRATION_MARKER).is_file():
+            return "not_needed"
+
+        import shutil as _shutil
+
+        try:
+            new_dir.mkdir(parents=True, exist_ok=True)
+
+            # Copy files.
+            for name in _MIGRATION_FILES:
+                src = legacy / name
+                if src.is_file():
+                    _shutil.copy2(str(src), str(new_dir / name))
+
+            # Copy backup directory.
+            src_backups = legacy / _BACKUPS_DIR_NAME
+            if src_backups.is_dir():
+                dst_backups = new_dir / _BACKUPS_DIR_NAME
+                dst_backups.mkdir(exist_ok=True)
+                for item in src_backups.iterdir():
+                    if item.is_file():
+                        _shutil.copy2(str(item), str(dst_backups / item.name))
+
+            # Write marker with the source path and timestamp.
+            marker = new_dir / _MIGRATION_MARKER
+            marker.write_text(
+                json.dumps({
+                    "from": str(legacy),
+                    "ts": time.time(),
+                }),
+                encoding="utf-8",
+            )
+
+            # Rename (not delete) the old directory.
+            ts_suffix = time.strftime("%Y%m%d-%H%M%S")
+            renamed = legacy.parent / f"refine.migrated-{ts_suffix}"
+            try:
+                legacy.rename(renamed)
+            except OSError as exc:
+                # Rename failed — not fatal. The data is already in the new
+                # location and the marker prevents re-migration.
+                logger.warning(
+                    "Legacy journal dir could not be renamed: %s",
+                    scrub_text(str(exc)),
+                )
+
+            return "migrated"
+        except Exception as exc:
+            logger.warning(
+                "Journal directory migration failed: %s", scrub_text(str(exc))
+            )
+            return "failed"
+
+
 def normalize_prompt_note_session_id(session_id: Any) -> str:
     """Accept only a stable, already-safe hook/session identifier."""
     raw = str(session_id).strip()

--- a/ledger.py
+++ b/ledger.py
@@ -68,6 +68,7 @@ def record_edit(
     *,
     outcome: str = "applied",
     pending_id: str = "",
+    llm_meta: Optional[Dict[str, Any]] = None,
 ) -> None:
     name = str(proposal.get("name", "")).strip()
     if not name:
@@ -114,6 +115,11 @@ def record_edit(
             "outcome": outcome,
             "pending_id": pending_id,
         }
+        # LLM attribution for the audit display — additive.
+        if isinstance(llm_meta, dict) and llm_meta.get("reported_model"):
+            stats[key]["reported_model"] = scrub_text(
+                str(llm_meta["reported_model"])
+            )[:60]
         _save_stats(stats)
 
 
@@ -313,6 +319,9 @@ def format_audit(rows: List[Dict[str, Any]]) -> str:
         )
         expected_outcome = str(row.get("expected_outcome", "") or "—")
         lines.append(f"      expects: {expected_outcome[:57]}")
+        reported_model = str(row.get("reported_model", "") or "")
+        if reported_model:
+            lines.append(f"      model: {reported_model[:40]}")
 
     candidates = [row for row in rows if row["verdict"] in ("unused", "did not help")]
     if candidates:

--- a/llm.py
+++ b/llm.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import re
+import threading
+import time
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
 from agent.plugin_llm import (
@@ -30,6 +32,30 @@ MAX_SUMMARY_CHARS = 300
 _CHARS_PER_TOKEN = 3
 _PROPOSAL_ENVELOPE_TOKENS = 1024
 
+# Last LLM call metadata — set by _propose_structured and review_fallback so
+# core.py can read reported_model, output_tokens and latency after calling
+# propose(). Thread-local because the gateway may run concurrent refine passes.
+_call_meta = threading.local()
+
+
+def last_call_meta() -> Dict[str, Any]:
+    """Return metadata from the most recent complete_structured call in this thread."""
+    return getattr(_call_meta, "value", {})
+
+
+def _record_call_meta(result: Any, started: float) -> None:
+    """Capture result metadata; tolerant of any result shape."""
+    meta: Dict[str, Any] = {"latency_ms": int((time.time() - started) * 1000)}
+    model = getattr(result, "model", None)
+    if model:
+        meta["reported_model"] = str(model)
+    usage = getattr(result, "usage", None)
+    if usage:
+        tokens = getattr(usage, "output_tokens", None)
+        if isinstance(tokens, (int, float)) and tokens > 0:
+            meta["output_tokens"] = int(tokens)
+    _call_meta.value = meta
+
 
 def _pinned_target() -> Dict[str, str]:
     """Provider/model to request, when the config pins them.
@@ -37,10 +63,6 @@ def _pinned_target() -> Dict[str, str]:
     Omitted keys leave resolution to Hermes, which prefers the live main model.
     A pinned value makes the target deterministic instead; the host's trust
     gate still decides whether the request is honored.
-
-    This function filters the effective target through trust flags so that a
-    plugin installation without ``allow_model_override`` silently falls back to
-    the host default instead of causing PluginLlmTrustError on every call.
 
     Never raises. It is evaluated while the call arguments are being assembled,
     before any failure-tagging path exists, so an exception here would be reported
@@ -271,6 +293,7 @@ def _propose_structured(
     input_blocks: List[PluginLlmInput],
     *,
     max_tokens: int = PROPOSAL_MAX_TOKENS,
+    target: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Invoke the model only with recursively sanitized text inputs."""
     safe_blocks: List[PluginLlmInput] = []
@@ -279,6 +302,7 @@ def _propose_structured(
         if text is None:
             raise TypeError("Refine accepts only text model inputs")
         safe_blocks.append(PluginLlmTextInput(text=scrub_text(str(text))))
+    resolved_target = target if target is not None else _pinned_target()
     common = dict(
         instructions=scrub_text(str(instructions)),
         input=safe_blocks,
@@ -286,15 +310,17 @@ def _propose_structured(
         purpose="refine",
         temperature=0.0,
         max_tokens=max_tokens,
-        **_pinned_target(),
+        **resolved_target,
     )
     system_prompt = scrub_text(REFINE_SYSTEM_PROMPT)
+    call_started = time.time()
     try:
         result = llm.complete_structured(
             system_prompt=system_prompt,
             json_schema=sanitize(REFINE_PROPOSAL_SCHEMA),
             **common,
         )
+        _record_call_meta(result, call_started)
         reply = _salvage_parsed(result, requested_max_tokens=max_tokens)
         return reply.parsed or _incomplete_proposal(reply)
     except PluginLlmTrustError:
@@ -310,6 +336,7 @@ def _propose_structured(
             json_mode=True,
             **common,
         )
+        _record_call_meta(result, call_started)
         reply = _salvage_parsed(result, requested_max_tokens=max_tokens)
         return reply.parsed or _incomplete_proposal(reply)
 
@@ -328,9 +355,10 @@ def _ensure_dict(parsed: Any) -> Optional[Dict[str, Any]]:
     return None
 
 
-def review_fallback(llm: PluginLlm, evidence_text: str) -> Dict[str, Any]:
+def review_fallback(llm: PluginLlm, evidence_text: str, *, target: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """Return one conservative reviewer verdict; all failures decline safely."""
     safe_evidence = scrub_text(str(evidence_text))
+    resolved_target = target if target is not None else _pinned_target()
     instructions = (
         "Assess this trajectory only for a durable lesson worth persisting. "
         "Return the required JSON object.\n\n=== RECENT TRAJECTORY ===\n"
@@ -345,7 +373,7 @@ def review_fallback(llm: PluginLlm, evidence_text: str) -> Dict[str, Any]:
             purpose="refine",
             temperature=0.0,
             max_tokens=REVIEWER_MAX_TOKENS,
-            **_pinned_target(),
+            **resolved_target,
         )
         reply = _salvage_parsed(result, requested_max_tokens=REVIEWER_MAX_TOKENS)
         if reply.failure:
@@ -785,6 +813,7 @@ def propose(
     purpose: str = "refine",
     run_context: str = "",
     skill_content_loader: Optional[Callable[[str], Optional[str]]] = None,
+    target: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Propose one edit; skill patches are regenerated from safe full content."""
     try:
@@ -871,6 +900,7 @@ def propose(
                 [PluginLlmTextInput(text=instructions)],
                 # The first reply may legitimately carry one permitted body per edit.
                 max_tokens=proposal_max_tokens(max_edits),
+                target=target,
             )
         )
         if parsed is None:

--- a/llm.py
+++ b/llm.py
@@ -41,8 +41,18 @@ def _pinned_target() -> Dict[str, str]:
     This function filters the effective target through trust flags so that a
     plugin installation without ``allow_model_override`` silently falls back to
     the host default instead of causing PluginLlmTrustError on every call.
+
+    Never raises. It is evaluated while the call arguments are being assembled,
+    before any failure-tagging path exists, so an exception here would be reported
+    as a generic LLM failure and journaled as an ordinary no_op with success=true.
     """
-    effective = config.effective_llm_target()
+    try:
+        effective = config.effective_llm_target()
+    except Exception as exc:
+        logger.warning(
+            "Cannot resolve the refine model target: %s", scrub_text(str(exc))
+        )
+        return {}
     target: Dict[str, str] = {}
     provider = effective.get("provider", "")
     model = effective.get("model", "")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -10,6 +10,7 @@ import inspect
 import json
 import shutil
 import subprocess
+from collections import Counter
 from contextlib import contextmanager
 import sqlite3
 import sys
@@ -3419,10 +3420,39 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         self.assertEqual(target["model"], "live-model")
         self.assertEqual(target["provider"], "live-prov")
 
-    def test_live_main_target_failure_returns_empty(self):
-        with patch.dict("sys.modules", {"agent.auxiliary_client": None}):
+    def test_live_main_target_reads_the_host_accessors(self):
+        # The fake ``agent`` module is not a package, so the real import always
+        # fails in this harness. Injecting the submodule is what makes priority 3
+        # genuinely covered instead of only reachable by patching it out.
+        fake = types.ModuleType("agent.auxiliary_client")
+        fake._read_main_provider = lambda: "live-prov"
+        fake._read_main_model = lambda: "live-model"
+        with patch.dict("sys.modules", {"agent.auxiliary_client": fake}):
             result = config.live_main_target()
-        self.assertEqual(result, {})
+        self.assertEqual(result, {"provider": "live-prov", "model": "live-model"})
+
+    def test_live_main_target_without_the_host_accessors_returns_empty(self):
+        fake = types.ModuleType("agent.auxiliary_client")
+        with patch.dict("sys.modules", {"agent.auxiliary_client": fake}):
+            self.assertEqual(config.live_main_target(), {})
+
+    def test_live_main_target_when_the_host_module_is_absent_returns_empty(self):
+        # The failure the guarded import exists for: a private module that moved.
+        # Distinct from the attribute-absent case above, and it is the one that
+        # happens when Hermes reorganizes.
+        with patch.dict("sys.modules", {"agent.auxiliary_client": None}):
+            self.assertEqual(config.live_main_target(), {})
+        self.assertEqual(config.effective_llm_target()["source"], "host_default")
+
+    def test_live_main_target_when_accessor_raises_returns_empty(self):
+        def boom():
+            raise RuntimeError("no runtime")
+
+        fake = types.ModuleType("agent.auxiliary_client")
+        fake._read_main_provider = boom
+        fake._read_main_model = lambda: "live-model"
+        with patch.dict("sys.modules", {"agent.auxiliary_client": fake}):
+            self.assertEqual(config.live_main_target(), {})
 
     def test_corrupt_override_file_treated_as_absent(self):
         path = journal.model_override_read_path()
@@ -3516,6 +3546,524 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         plugin_init._handle_refine_command("model test-m")
         plugin_init._handle_refine_command("model auto")
         self.assertEqual(len(journal.entries()), before)
+
+    # ── Audit fixes: per-field priority, safe persistence, visibility ─────────
+
+    def test_model_only_override_keeps_the_configured_provider(self):
+        FakeHost.entry_config()["llm"] = {
+            "provider": "opencode-go",
+            "model": "deepseek-v4",
+        }
+        plugin_init._handle_refine_command("model deepseek-v4-flash")
+        target = config.effective_llm_target()
+        self.assertEqual(target["source"], "command")
+        self.assertEqual(target["model"], "deepseek-v4-flash")
+        # Asking for a different model must not silently unset the provider that
+        # actually serves it.
+        self.assertEqual(target["provider"], "opencode-go")
+
+    def test_provider_only_override_keeps_the_configured_model(self):
+        FakeHost.entry_config()["llm"] = {"model": "deepseek-v4"}
+        journal.write_model_override("other-prov", "")
+        target = config.effective_llm_target()
+        self.assertEqual(target["provider"], "other-prov")
+        self.assertEqual(target["model"], "deepseek-v4")
+
+    def test_credential_shaped_model_is_never_persisted(self):
+        token = "ghp_" + "A" * 36
+        result = plugin_init._handle_refine_command(f"model {token}")
+        self.assertIn("failed", result.lower())
+        self.assertIsNone(journal.read_model_override())
+        path = journal.model_override_read_path()
+        if path.exists():
+            self.assertNotIn(token, path.read_text(encoding="utf-8"))
+
+    def test_unsafe_override_on_disk_is_ignored(self):
+        journal.ensure_dirs()
+        journal.model_override_read_path().write_text(
+            json.dumps({"provider": "", "model": "sk-" + "b" * 24}),
+            encoding="utf-8",
+        )
+        self.assertIsNone(journal.read_model_override())
+        self.assertNotEqual(config.effective_llm_target()["source"], "command")
+
+    def test_free_text_override_on_disk_is_ignored(self):
+        journal.ensure_dirs()
+        journal.model_override_read_path().write_text(
+            json.dumps({"provider": "", "model": "not a model name"}),
+            encoding="utf-8",
+        )
+        self.assertIsNone(journal.read_model_override())
+
+    def test_empty_override_write_is_refused(self):
+        with self.assertRaises(ValueError):
+            journal.write_model_override("", "")
+
+    def test_model_command_reports_a_write_failure_instead_of_raising(self):
+        with patch.object(
+            journal, "write_model_override", side_effect=OSError("read-only journal_dir")
+        ):
+            result = plugin_init._handle_refine_command("model some-model")
+        self.assertIn("Model command failed", result)
+        self.assertIn("read-only journal_dir", result)
+
+    def test_model_auto_reports_a_failed_removal(self):
+        journal.write_model_override("", "pinned-model")
+        real_unlink = Path.unlink
+
+        def denied(self, *args, **kwargs):
+            # Scoped to this store: an unconditional stub would also break the
+            # mutation lock's release and leave a fresh lock file behind.
+            if self.name != journal._MODEL_OVERRIDE_FILE_NAME:
+                return real_unlink(self, *args, **kwargs)
+            raise PermissionError(13, "Access is denied")
+
+        # Exercise the real except branch: the unlink raises and the file stays.
+        with patch.object(Path, "unlink", denied):
+            self.assertEqual(journal.clear_model_override(), "failed")
+            result = plugin_init._handle_refine_command("model auto")
+        self.assertIn("Could not remove", result)
+        # The reply must not claim removal, and the effective target it prints has
+        # to match reality: the override survived.
+        self.assertNotIn("Override removed", result)
+        self.assertIn("source: command", result)
+        self.assertEqual(journal.read_model_override()["model"], "pinned-model")
+
+    def test_model_auto_says_when_there_was_nothing_to_remove(self):
+        self.assertEqual(journal.clear_model_override(), "absent")
+        result = plugin_init._handle_refine_command("model auto")
+        self.assertIn("No override was set", result)
+
+    def test_model_auto_confirms_a_real_removal(self):
+        journal.write_model_override("", "pinned-model")
+        self.assertEqual(journal.clear_model_override(), "removed")
+
+    def test_punctuation_only_model_is_refused(self):
+        for text in (".", "---", "..", "-"):
+            with self.subTest(text=text):
+                self.assertFalse(journal.valid_model_identifier(text))
+                with patch.object(plugin_init.core, "refine_run", return_value={
+                    "success": True, "message": "done", "outcome": "no_op",
+                }):
+                    plugin_init._handle_refine_command(f"model {text}")
+                self.assertIsNone(journal.read_model_override())
+
+    def test_rejected_override_on_disk_is_reported_not_only_logged(self):
+        FakeHost.entry_config()["llm"] = {"model": "cfg-model"}
+        journal.ensure_dirs()
+        journal.model_override_read_path().write_text(
+            json.dumps({"provider": "", "model": "sk-" + "b" * 24}),
+            encoding="utf-8",
+        )
+        target = config.effective_llm_target()
+        self.assertEqual(target["source"], "config")
+        self.assertTrue(any("unusable" in item for item in target["issues"]))
+        status = core.refine_status()
+        self.assertIn("model_target_issue", status["warning_codes"])
+        # The file still pins something; the report must not read as all clear.
+        self.assertIn("unusable", plugin_init._handle_refine_command("status"))
+        self.assertIn("unusable", plugin_init._handle_refine_command("model"))
+
+    def test_non_utf8_override_is_rejected_not_raised(self):
+        """A store written in another codepage must not break every pass."""
+        journal.ensure_dirs()
+        journal.model_override_read_path().write_bytes(b'{"model": "caf\xe9-v1"}')
+        # Decoding inside the read would raise UnicodeDecodeError, which is not an
+        # OSError; escaping here would surface as a generic LLM failure and every
+        # pass would journal an ordinary no_op with success=true.
+        self.assertEqual(journal.read_model_override_state(), (None, "rejected"))
+        target = config.effective_llm_target()
+        self.assertNotEqual(target["source"], "command")
+        self.assertIn("model_target_issue", core.refine_status()["warning_codes"])
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        # The proposal call must still be made, not aborted before it starts.
+        llm.propose(model, "evidence", [], [])
+        self.assertEqual(len(model.calls), 1)
+
+    def test_several_target_problems_are_all_reported(self):
+        FakeHost.entry_config()["llm"] = {
+            "provider": "token=abcdef",
+            "model": "not a model",
+        }
+        journal.ensure_dirs()
+        journal.model_override_read_path().write_text("not json!", encoding="utf-8")
+        issues = config.effective_llm_target()["issues"]
+        self.assertEqual(len(issues), 3)
+        text = plugin_init._handle_refine_command("status")
+        self.assertIn("llm.provider", text)
+        self.assertIn("llm.model", text)
+        self.assertIn("model_override.json", text)
+
+    def test_refusal_names_the_rule_without_echoing_the_value(self):
+        token = "ghp_" + "A" * 36
+        result = plugin_init._handle_refine_command(f"model {token}")
+        self.assertIn("credential pattern", result)
+        self.assertNotIn(token, result)
+        shapeless = plugin_init._handle_refine_command("model ---")
+        self.assertIsNone(journal.read_model_override())
+        self.assertNotIn("credential", shapeless or "")
+
+    def test_unreadable_override_is_distinguished_from_absent(self):
+        journal.write_model_override("", "pinned-model")
+        real_read_bytes = Path.read_bytes
+
+        def denied(self, *args, **kwargs):
+            # Scoped to this store: an unconditional stub would break any
+            # background thread that reads a file during the retry window.
+            if self.name != journal._MODEL_OVERRIDE_FILE_NAME:
+                return real_read_bytes(self, *args, **kwargs)
+            raise OSError("sharing violation")
+
+        with patch.object(Path, "read_bytes", denied):
+            override, state = journal.read_model_override_state()
+        self.assertIsNone(override)
+        self.assertEqual(state, "unreadable")
+
+    def test_store_read_never_raises_for_any_exception_type(self):
+        """'Never raises' must hold for types the retry does not expect."""
+        journal.write_model_override("", "pinned-model")
+        real_read_bytes = Path.read_bytes
+
+        def boom(self, *args, **kwargs):
+            if self.name != journal._MODEL_OVERRIDE_FILE_NAME:
+                return real_read_bytes(self, *args, **kwargs)
+            raise MemoryError("not an OSError")
+
+        with patch.object(Path, "read_bytes", boom):
+            self.assertEqual(journal.read_model_override_state(), (None, "unreadable"))
+
+    def test_target_resolution_failure_never_aborts_a_proposal(self):
+        with patch.object(
+            config, "effective_llm_target", side_effect=RuntimeError("boom")
+        ):
+            self.assertEqual(llm._pinned_target(), {})
+            model = MockLlm({
+                "action": "no_op", "reason": "nothing", "evidence": [],
+                "kind": "", "name": "", "content": "",
+            })
+            llm.propose(model, "evidence", [], [])
+        # The call must still be made rather than collapsing into a generic
+        # "LLM call failed" no_op that reports success.
+        self.assertEqual(len(model.calls), 1)
+        self.assertNotIn("model", model.calls[0])
+
+    def test_namespaced_config_model_is_kept(self):
+        FakeHost.entry_config()["llm"] = {
+            "model": "deepseek/deepseek-chat",
+            "allow_model_override": True,
+        }
+        target = config.effective_llm_target()
+        self.assertEqual(target["model"], "deepseek/deepseek-chat")
+        self.assertEqual(target["issues"], [])
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        llm.propose(model, "evidence", [], [])
+        self.assertEqual(model.calls[0]["model"], "deepseek/deepseek-chat")
+
+    def test_namespaced_provider_is_still_refused(self):
+        # The slash is the separator in the command grammar, so a provider that
+        # contains one is not a provider.
+        self.assertTrue(journal.model_override_field_is_safe(
+            "anthropic/claude-3.5-sonnet", allow_namespace=True
+        ))
+        self.assertFalse(journal.model_override_field_is_safe("a/b"))
+
+    def test_override_read_retries_a_transient_denied_open(self):
+        """A momentary sharing violation must not read as 'no override'."""
+        journal.write_model_override("", "pinned-model")
+        real_read_bytes = Path.read_bytes
+        calls = {"n": 0}
+
+        def flaky(self, *args, **kwargs):
+            if self.name != journal._MODEL_OVERRIDE_FILE_NAME:
+                return real_read_bytes(self, *args, **kwargs)
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise PermissionError(13, "Access is denied")
+            return real_read_bytes(self, *args, **kwargs)
+
+        with patch.object(Path, "read_bytes", flaky):
+            override, state = journal.read_model_override_state()
+        self.assertEqual(state, "ok")
+        self.assertEqual(override["model"], "pinned-model")
+        self.assertEqual(calls["n"], 3)
+
+    def test_absent_override_read_does_not_pay_the_retry_budget(self):
+        """The common 'nothing pinned' case must stay on the fast path.
+
+        Counted, not timed: a wall-clock assertion here could only ever fail for
+        environmental reasons, and a suite that goes red for those trains people
+        to ignore red.
+        """
+        calls = {"n": 0}
+        real = journal._read_model_override_bytes
+
+        def counted():
+            calls["n"] += 1
+            return real()
+
+        with patch.object(journal, "_read_model_override_bytes", counted):
+            self.assertEqual(journal.read_model_override_state()[1], "absent")
+        self.assertEqual(calls["n"], 1)
+
+    def test_clear_retries_a_transient_denied_unlink(self):
+        journal.write_model_override("", "pinned-model")
+        real_unlink = Path.unlink
+        calls = {"n": 0}
+
+        def flaky(self, *args, **kwargs):
+            if self.name != journal._MODEL_OVERRIDE_FILE_NAME:
+                return real_unlink(self, *args, **kwargs)
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise PermissionError(13, "Access is denied")
+            return real_unlink(self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", flaky):
+            self.assertEqual(journal.clear_model_override(), "removed")
+        self.assertEqual(calls["n"], 3)
+        self.assertIsNone(journal.read_model_override())
+
+    def test_absent_override_is_not_reported_as_a_problem(self):
+        override, state = journal.read_model_override_state()
+        self.assertIsNone(override)
+        self.assertEqual(state, "absent")
+        self.assertEqual(config.effective_llm_target()["issues"], [])
+        self.assertNotIn("model_target_issue", core.refine_status()["warning_codes"])
+
+    def test_unsafe_config_model_is_dropped_and_reported(self):
+        FakeHost.entry_config()["llm"] = {
+            "model": "sk-" + "c" * 24,
+            "allow_model_override": True,
+        }
+        target = config.effective_llm_target()
+        # The same rule must hold for the config as for the command store.
+        self.assertEqual(target["model"], "")
+        self.assertTrue(any("llm.model" in item for item in target["issues"]))
+        self.assertIn("model_target_issue", core.refine_status()["warning_codes"])
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        llm.propose(model, "evidence", [], [])
+        self.assertNotIn("model", model.calls[0])
+
+    def test_unsafe_config_provider_is_dropped_and_reported(self):
+        FakeHost.entry_config()["llm"] = {
+            "provider": "token=abcdef",
+            "allow_provider_override": True,
+        }
+        target = config.effective_llm_target()
+        self.assertEqual(target["provider"], "")
+        self.assertTrue(any("llm.provider" in item for item in target["issues"]))
+
+    def test_command_override_does_not_borrow_the_live_provider(self):
+        fake = types.ModuleType("agent.auxiliary_client")
+        fake._read_main_provider = lambda: "live-prov"
+        fake._read_main_model = lambda: "live-model"
+        journal.write_model_override("", "pinned-model")
+        with patch.dict("sys.modules", {"agent.auxiliary_client": fake}):
+            target = config.effective_llm_target()
+        # Leaving provider unset means "let Hermes resolve it", and Hermes
+        # resolves it to the live provider anyway. Naming it here would claim a
+        # choice the user never made and would need the provider trust flag.
+        self.assertEqual(target["source"], "command")
+        self.assertEqual(target["model"], "pinned-model")
+        self.assertEqual(target["provider"], "")
+
+    def test_namespaced_command_target_pins_instead_of_spending_a_pass(self):
+        # Only the first slash separates provider from model; the rest belongs to
+        # the model id. Routing this to the proposal path would spend a daily edit.
+        with patch.object(plugin_init.core, "refine_run") as run:
+            result = plugin_init._handle_refine_command(
+                "model openrouter/deepseek/deepseek-chat"
+            )
+        run.assert_not_called()
+        self.assertIn("Override set", result)
+        override = journal.read_model_override()
+        self.assertEqual(override["provider"], "openrouter")
+        self.assertEqual(override["model"], "deepseek/deepseek-chat")
+
+    def test_slash_only_target_goes_as_reason(self):
+        for text in ("model /", "model a/", "model /b"):
+            with self.subTest(text=text):
+                with patch.object(plugin_init.core, "refine_run", return_value={
+                    "success": True, "message": "done", "outcome": "no_op",
+                }) as run:
+                    plugin_init._handle_refine_command(text)
+                run.assert_called_once()
+                self.assertIsNone(journal.read_model_override())
+
+    def test_status_reports_the_effective_model_and_source(self):
+        FakeHost.entry_config()["llm"] = {
+            "provider": "opencode-go",
+            "model": "deepseek-v4",
+            "allow_model_override": True,
+            "allow_provider_override": True,
+        }
+        status = core.refine_status()
+        self.assertEqual(status["llm_model"], "deepseek-v4")
+        self.assertEqual(status["llm_provider"], "opencode-go")
+        self.assertEqual(status["llm_target_source"], "config")
+        text = plugin_init._handle_refine_command("status")
+        self.assertIn("deepseek-v4", text)
+        self.assertIn("opencode-go", text)
+
+    def test_status_warns_when_trust_denies_a_set_model(self):
+        FakeHost.entry_config()["llm"] = {"model": "deepseek-v4"}
+        status = core.refine_status()
+        # The value is dropped before the host call, so this report is the only
+        # place the user can find out.
+        self.assertIn("model_override_trust_denied", status["warning_codes"])
+        self.assertIn("trust denies", plugin_init._handle_refine_command("status"))
+
+    def test_status_warns_when_trust_denies_a_set_provider(self):
+        FakeHost.entry_config()["llm"] = {
+            "provider": "opencode-go",
+            "allow_model_override": True,
+        }
+        self.assertIn(
+            "provider_override_trust_denied", core.refine_status()["warning_codes"]
+        )
+
+    def test_status_does_not_warn_about_trust_for_the_live_model(self):
+        fake = types.ModuleType("agent.auxiliary_client")
+        fake._read_main_provider = lambda: "live-prov"
+        fake._read_main_model = lambda: "live-model"
+        with patch.dict("sys.modules", {"agent.auxiliary_client": fake}):
+            status = core.refine_status()
+        self.assertEqual(status["llm_target_source"], "live")
+        self.assertNotIn("model_override_trust_denied", status["warning_codes"])
+        self.assertNotIn("provider_override_trust_denied", status["warning_codes"])
+
+    def test_status_reports_an_active_command_override(self):
+        journal.write_model_override("", "pinned-model")
+        status = core.refine_status()
+        self.assertIn("model_override_active", status["warning_codes"])
+        self.assertIn("pinned-model", plugin_init._handle_refine_command("status"))
+
+    def test_status_survives_an_unreadable_model_target(self):
+        with patch.object(
+            config, "effective_llm_target", side_effect=RuntimeError("boom")
+        ):
+            status = core.refine_status()
+        # Not "host_default": that would claim a resolution that did not happen.
+        self.assertEqual(status["llm_target_source"], "unknown")
+        self.assertIn("model_target_issue", status["warning_codes"])
+        self.assertEqual(status["warning_codes"].count("model_target_issue"), 1)
+
+    def test_override_write_and_clear_race_never_yields_a_broken_target(self):
+        """Two live passes read this store while a /refine model write lands."""
+        journal.write_model_override("", "model-a")
+        seen = []
+        errors = []
+        stop = threading.Event()
+
+        def writer():
+            # Only writes, never a clear: an override is in force the whole time,
+            # so "no override" is not a legal observation and a read that silently
+            # degrades to it would fail this test rather than be excused by it.
+            try:
+                while not stop.is_set():
+                    journal.write_model_override("", "model-b")
+                    journal.write_model_override("", "model-a")
+            except Exception as exc:  # pragma: no cover - reported below
+                errors.append(exc)
+
+        def reader():
+            try:
+                for _ in range(300):
+                    state = journal.read_model_override_state()[1]
+                    target = config.effective_llm_target()
+                    seen.append((target["source"], target["model"], state))
+            except Exception as exc:  # pragma: no cover - reported below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
+        for thread in threads:
+            thread.start()
+        threads[1].join(10)
+        stop.set()
+        for thread in threads:
+            thread.join(10)
+
+        self.assertEqual(errors, [])
+        # The full count, not just "some": a reader that died after one iteration
+        # would otherwise satisfy this test while exercising none of the race.
+        self.assertEqual(len(seen), 300)
+        tally = Counter(seen)
+        for source, model, state in seen:
+            self.assertIn((source, model), {
+                ("command", "model-a"),
+                ("command", "model-b"),
+            }, f"observed {tally!r}")
+
+    def test_atomic_write_retries_a_windows_style_replace_denial(self):
+        """A concurrent reader must delay the replace, not fail the write."""
+        real_replace = journal.os.replace
+        target_name = journal._MODEL_OVERRIDE_FILE_NAME
+        calls = {"n": 0}
+
+        def flaky(src, dst):
+            # Scoped to this store, so a stray background writer elsewhere in the
+            # suite cannot be handed the failing stub.
+            if Path(dst).name != target_name:
+                return real_replace(src, dst)
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise PermissionError(13, "Access is denied")
+            return real_replace(src, dst)
+
+        with patch.object(journal.os, "replace", side_effect=flaky):
+            journal.write_model_override("", "retried-model")
+        self.assertEqual(calls["n"], 3)
+        self.assertEqual(journal.read_model_override()["model"], "retried-model")
+
+    def test_atomic_write_surfaces_a_persistent_replace_denial(self):
+        """A retry must not turn a real, permanent failure into a silent success."""
+        real_replace = journal.os.replace
+        target_name = journal._MODEL_OVERRIDE_FILE_NAME
+
+        attempts = {"n": 0}
+
+        def always_denied(src, dst):
+            if Path(dst).name != target_name:
+                return real_replace(src, dst)
+            attempts["n"] += 1
+            raise PermissionError(13, "Access is denied")
+
+        with patch.object(journal.os, "replace", side_effect=always_denied):
+            with self.assertRaises(PermissionError):
+                journal.write_model_override("", "never-lands")
+        # More than one attempt, so this fails if the retry is removed rather than
+        # passing for the same reason a bare os.replace would.
+        self.assertGreater(attempts["n"], 1)
+        self.assertIsNone(journal.read_model_override())
+
+    def test_store_retry_budgets_stay_under_the_host_callback_bound(self):
+        """Two limits describing the same stall must not drift apart.
+
+        A host callback waits at most ``_HOST_PATH_LOCK_TIMEOUT`` for the mutation
+        lock; the store retries are what a lock holder can add on top. Their sum
+        is what must stay small relative to that bound, not any single one.
+        """
+        total = (
+            journal._WRITE_RETRY_BUDGET_SECONDS
+            + journal._READ_RETRY_BUDGET_SECONDS
+            + journal._UNLINK_RETRY_BUDGET_SECONDS
+        )
+        self.assertLess(total, plugin_init._HOST_PATH_LOCK_TIMEOUT / 2)
+        # Pin the derivation itself, not just an upper bound: a hardcoded value
+        # would satisfy an inequality while defeating the single-base rule.
+        base = journal._CONTENTION_BUDGET_SECONDS
+        self.assertEqual(journal._WRITE_RETRY_BUDGET_SECONDS, base)
+        self.assertEqual(journal._READ_RETRY_BUDGET_SECONDS, base / 5)
+        self.assertEqual(journal._UNLINK_RETRY_BUDGET_SECONDS, base / 5)
 
     def test_status_command_returns_text_not_dict(self):
         result = plugin_init._handle_refine_command("status")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -4464,6 +4464,119 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         self.assertTrue(meta.get("target_issues"))
         self.assertIn("credential", meta["target_issues"][0])
 
+    # ── Dry-run (Part E) ──────────────────────────────────────────────────────
+
+    def test_dry_run_does_not_mutate_host(self):
+        FakeHost.actions.clear()
+        model = MockLlm({
+            "action": "create", "kind": "skill", "name": "dry-skill",
+            "content": "---\nname: dry-skill\ndescription: test\n---\n# body\n",
+            "reason": "testing dry run", "evidence": [],
+            "expected_outcome": "something",
+        })
+        result = core.refine_run(model, session_id="session", dry_run=True)
+        self.assertEqual(result["outcome"], "dry_run")
+        self.assertEqual(FakeHost.actions, [])
+
+    def test_dry_run_does_not_spend_budget(self):
+        before = journal.count_today_applied()
+        model = MockLlm({
+            "action": "create", "kind": "skill", "name": "dry-skill",
+            "content": "---\nname: dry-skill\ndescription: test\n---\n# body\n",
+            "reason": "testing dry run", "evidence": [],
+            "expected_outcome": "something",
+        })
+        core.refine_run(model, session_id="session", dry_run=True)
+        self.assertEqual(journal.count_today_applied(), before)
+
+    def test_dry_run_shows_diff_for_patch(self):
+        FakeHost.skills["existing-skill"] = "---\nname: existing-skill\ndescription: old\n---\n# Old body\n"
+        new_content = "---\nname: existing-skill\ndescription: new\n---\n# New body\n"
+        model = MockLlm({
+            "action": "patch", "kind": "skill", "name": "existing-skill",
+            "content": new_content,
+            "reason": "update", "evidence": [],
+            "expected_outcome": "improvement",
+        })
+        result = core.refine_run(model, session_id="session", dry_run=True)
+        self.assertEqual(result["outcome"], "dry_run")
+        self.assertIn("diff", result)
+        self.assertIn("-# Old body", result["diff"])
+        self.assertIn("+# New body", result["diff"])
+
+    def test_dry_run_diff_is_scrubbed(self):
+        token = "ghp_" + "A" * 36
+        FakeHost.skills["leaky-skill"] = "---\nname: leaky-skill\ndescription: ok\n---\n# body\n"
+        new_content = f"---\nname: leaky-skill\ndescription: ok\n---\n# body with {token}\n"
+        model = MockLlm({
+            "action": "patch", "kind": "skill", "name": "leaky-skill",
+            "content": new_content,
+            "reason": "update", "evidence": [],
+            "expected_outcome": "improvement",
+        })
+        result = core.refine_run(model, session_id="session", dry_run=True)
+        self.assertNotIn(token, result.get("diff", ""))
+
+    def test_dry_run_diff_is_truncated_at_limit(self):
+        # Content just under the max so the proposal is accepted, but the diff
+        # it produces exceeds MAX_CONTENT_CHARS.
+        old_content = "---\nname: big-skill\ndescription: ok\n---\n" + ("a\n" * 7000)
+        new_content = "---\nname: big-skill\ndescription: ok\n---\n" + ("b\n" * 7000)
+        FakeHost.skills["big-skill"] = old_content
+        model = MockLlm({
+            "action": "patch", "kind": "skill", "name": "big-skill",
+            "content": new_content,
+            "reason": "update", "evidence": [],
+            "expected_outcome": "improvement",
+        })
+        result = core.refine_run(model, session_id="session", dry_run=True)
+        self.assertEqual(result["outcome"], "dry_run")
+        self.assertTrue(result.get("diff_truncated"))
+        self.assertIn("[truncated]", result.get("diff", ""))
+
+    def test_dry_run_journal_entry_exists_and_not_counted(self):
+        before = journal.count_today_applied()
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        core.refine_run(model, session_id="session", dry_run=True)
+        entries = journal.entries()
+        dry_entries = [e for e in entries if e.get("outcome") == "dry_run"]
+        self.assertTrue(dry_entries)
+        self.assertEqual(journal.count_today_applied(), before)
+
+    def test_dry_run_with_reason(self):
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        core.refine_run(model, reason="focus on gmail", session_id="session", dry_run=True)
+        entries = journal.entries()
+        dry_entries = [e for e in entries if e.get("outcome") == "dry_run"]
+        self.assertTrue(dry_entries)
+        self.assertIn("gmail", dry_entries[-1].get("reason", ""))
+
+    def test_dry_run_command_output(self):
+        with patch.object(core, "refine_run", return_value={
+            "success": True, "outcome": "dry_run",
+            "message": "Dry run: proposal shown, nothing applied.",
+            "proposal": {"action": "create", "kind": "skill", "name": "test-skill",
+                         "summary": "a test", "expected_outcome": "better"},
+            "diff": "", "diff_truncated": False,
+        }):
+            text = plugin_init._handle_refine_command("dry-run")
+        self.assertIn("Dry run", text)
+        self.assertIn("create", text)
+        self.assertIn("test-skill", text)
+
+    def test_dry_run_unknown_session_refuses(self):
+        core._LAST_SESSION_ID = ""
+        with patch.object(core, "host_session_id", return_value=""):
+            model = MockLlm()
+            result = core.refine_run(model, dry_run=True)
+        self.assertEqual(result["outcome"], "session_unknown")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -386,6 +386,10 @@ class RefineTests(unittest.TestCase):
         # Both are process-lifetime globals: left set, they leak across tests.
         plugin_init._REGISTER_WARNED = False
         plugin_init._REGISTERED_LLM = None
+        # Session identity tracking — must not leak from one test to the next.
+        # Set to the default test session so existing tests that call refine_run
+        # without an explicit session_id find the FakeHost's "session" messages.
+        core._LAST_SESSION_ID = "session"
 
     def tearDown(self):
         self.temp.cleanup()
@@ -4134,6 +4138,162 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         sentinel = object()
         with patch.object(plugin_init, "PluginLlm", return_value=sentinel):
             self.assertIs(plugin_init._session_llm(), sentinel)
+
+    # ── Session identity (Part A) ─────────────────────────────────────────────
+
+    def test_explicit_session_id_wins_over_hook_and_env(self):
+        core.note_session_id("from-hook")
+        with patch.object(core, "host_session_id", return_value="from-env"):
+            sid, how = core.resolve_session_id("explicit-id")
+        self.assertEqual(sid, "explicit-id")
+        self.assertEqual(how, "explicit")
+
+    def test_host_env_wins_over_hook(self):
+        core.note_session_id("from-hook")
+        with patch.object(core, "host_session_id", return_value="from-env"):
+            sid, how = core.resolve_session_id()
+        self.assertEqual(sid, "from-env")
+        self.assertEqual(how, "host_env")
+
+    def test_hook_used_when_host_env_is_empty(self):
+        core.note_session_id("from-hook")
+        with patch.object(core, "host_session_id", return_value=""):
+            sid, how = core.resolve_session_id()
+        self.assertEqual(sid, "from-hook")
+        self.assertEqual(how, "hook")
+
+    def test_unknown_when_no_sources_available(self):
+        core._LAST_SESSION_ID = ""
+        with patch.object(core, "host_session_id", return_value=""):
+            sid, how = core.resolve_session_id()
+        self.assertEqual(sid, "")
+        self.assertEqual(how, "unknown")
+
+    def test_unknown_session_refuses_without_spending_budget(self):
+        """When session_id cannot be determined, refine must not run."""
+        core._LAST_SESSION_ID = ""
+        with patch.object(core, "host_session_id", return_value=""):
+            model = MockLlm({
+                "action": "no_op", "reason": "nothing", "evidence": [],
+                "kind": "", "name": "", "content": "",
+            })
+            result = core.refine_run(model)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["outcome"], "session_unknown")
+        self.assertIn("Cannot identify", result["message"])
+        # No budget consumed, no journal entry
+        self.assertEqual(journal.count_today_applied(), 0)
+        self.assertEqual(len(model.calls), 0)
+
+    def test_empty_hook_does_not_overwrite_existing_id(self):
+        core._LAST_SESSION_ID = ""
+        core.note_session_id("real-session")
+        core.note_session_id("")
+        core.note_session_id("   ")
+        self.assertEqual(core._noted_session_id(), "real-session")
+
+    def test_note_session_id_rejects_scrub_altering_values(self):
+        core._LAST_SESSION_ID = ""
+        core.note_session_id("ghp_" + "A" * 36)
+        self.assertEqual(core._noted_session_id(), "")
+
+    def test_gateway_like_env_uses_hook(self):
+        """In the gateway, get_session_env returns '' but hooks provide the id."""
+        core.note_session_id("gw-session-123")
+        with patch.object(core, "host_session_id", return_value=""):
+            sid, how = core.resolve_session_id()
+        self.assertEqual(sid, "gw-session-123")
+        self.assertEqual(how, "hook")
+
+    def test_status_reports_session_id_and_source(self):
+        core.note_session_id("test-session-id")
+        with patch.object(core, "host_session_id", return_value=""):
+            status = core.refine_status()
+        self.assertEqual(status["session_id"], "test-session-id")
+        self.assertEqual(status["session_id_source"], "hook")
+        self.assertIsInstance(status["session_message_count"], int)
+        text = plugin_init._handle_refine_command("status")
+        self.assertIn("test-session-id", text)
+        self.assertIn("hook", text)
+
+    def test_status_blocks_on_unknown_session(self):
+        core._LAST_SESSION_ID = ""
+        with patch.object(core, "host_session_id", return_value=""):
+            status = core.refine_status()
+        self.assertIn("session_unknown", status["blocker_codes"])
+        text = plugin_init._handle_refine_command("status")
+        self.assertIn("Cannot identify", text)
+
+    def test_note_session_id_two_threads_no_crash(self):
+        core._LAST_SESSION_ID = ""
+        errors = []
+
+        def writer(val):
+            try:
+                for _ in range(200):
+                    core.note_session_id(val)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer, args=("session-a",)),
+            threading.Thread(target=writer, args=("session-b",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(5)
+        self.assertEqual(errors, [])
+        self.assertIn(core._noted_session_id(), {"session-a", "session-b"})
+
+    def test_regression_newest_by_started_at_with_1_message_is_refused(self):
+        """Reproduce the real bug: a ghost session newer by started_at has 1 msg."""
+        core._LAST_SESSION_ID = ""
+        now = time.time()
+        # Long-lived active session
+        messages = [
+            ("active-session", "user", "Hello", "", now - 100, 1),
+            ("active-session", "assistant", "Hi!", "", now - 99, 1),
+            ("active-session", "user", "Do X", "", now - 50, 1),
+            ("active-session", "tool", "Done X", "bash", now - 49, 1),
+        ] * 10  # 40 messages
+        # Ghost: newest by started_at, only 1 message
+        messages.append(("ghost-session", "user", "oops", "", now - 5, 1))
+        FakeHost.make_db(messages)
+        # Re-insert sessions with the right ordering
+        path = self.root / "state.db"
+        connection = sqlite3.connect(path)
+        connection.execute("DELETE FROM sessions")
+        connection.execute(
+            "INSERT INTO sessions VALUES ('active-session', ?)", (now - 200,)
+        )
+        connection.execute(
+            "INSERT INTO sessions VALUES ('ghost-session', ?)", (now - 2,)
+        )
+        connection.commit()
+        connection.close()
+        # Without explicit id and without hook → must refuse, not pick the ghost.
+        with patch.object(core, "host_session_id", return_value=""):
+            result = core.refine_run(MockLlm())
+        self.assertEqual(result["outcome"], "session_unknown")
+        self.assertIn("Cannot identify", result["message"])
+
+    def test_pre_llm_call_hook_notes_the_session_id(self):
+        plugin_init._on_pre_llm_call(session_id="hook-session-abc")
+        self.assertEqual(core._noted_session_id(), "hook-session-abc")
+
+    def test_post_llm_call_hook_notes_the_session_id(self):
+        plugin_init._on_post_llm_call(session_id="post-hook-sess", conversation_history=[])
+        self.assertEqual(core._noted_session_id(), "post-hook-sess")
+
+    def test_session_end_hook_notes_the_session_id(self):
+        # _on_session_end spawns a daemon thread; just verify that the session id
+        # is noted synchronously, before the thread starts.
+        core._LAST_SESSION_ID = ""
+        # Disable auto so the function returns early after noting the id.
+        FakeHost.entry_config()["auto_enabled"] = False
+        plugin_init._on_session_end(session_id="end-sess-xyz")
+        self.assertEqual(core._noted_session_id(), "end-sess-xyz")
 
 
 if __name__ == "__main__":

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -4359,6 +4359,111 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         self.assertEqual(status["skip_session_sources"], ["cron"])
         self.assertEqual(status["session_source"], "cli")
 
+    # ── Model attribution (Part B) ────────────────────────────────────────────
+
+    def test_single_pass_uses_one_target_for_all_calls(self):
+        """Even if effective_llm_target changes mid-pass, the calls are consistent."""
+        FakeHost.entry_config()["llm"] = {
+            "model": "pinned-model",
+            "allow_model_override": True,
+        }
+        call_models = []
+
+        class SpyLlm:
+            calls = []
+
+            def complete_structured(self, **kwargs):
+                call_models.append(kwargs.get("model"))
+                return MockResult(
+                    {"action": "no_op", "reason": "nothing", "evidence": []},
+                    model="reported-from-host",
+                    output_tokens=42,
+                )
+
+        spy = SpyLlm()
+        core.refine_run(spy, session_id="session")
+        # All calls within the pass used the same resolved target.
+        self.assertTrue(all(m == "pinned-model" for m in call_models))
+
+    def test_journal_entry_contains_llm_meta_fields(self):
+        FakeHost.entry_config()["llm"] = {
+            "model": "test-model-x",
+            "allow_model_override": True,
+        }
+        model = MockLlm(MockResult(
+            {"action": "no_op", "reason": "nothing", "evidence": [],
+             "kind": "", "name": "", "content": ""},
+            model="actual-host-model",
+            output_tokens=100,
+        ))
+        core.refine_run(model, session_id="session")
+        entries = journal.entries()
+        latest = entries[-1] if entries else {}
+        meta = latest.get("llm_meta", {})
+        self.assertEqual(meta.get("requested_model"), "test-model-x")
+        self.assertEqual(meta.get("reported_model"), "actual-host-model")
+        self.assertEqual(meta.get("target_source"), "config")
+        self.assertIsInstance(meta.get("latency_ms"), int)
+        self.assertEqual(meta.get("output_tokens"), 100)
+
+    def test_journal_entry_omits_output_tokens_when_unavailable(self):
+        model = MockLlm(MockResult(
+            {"action": "no_op", "reason": "nothing", "evidence": [],
+             "kind": "", "name": "", "content": ""},
+            model="any-model",
+        ))
+        core.refine_run(model, session_id="session")
+        entries = journal.entries()
+        latest = entries[-1] if entries else {}
+        meta = latest.get("llm_meta", {})
+        self.assertNotIn("output_tokens", meta)
+
+    def test_old_journal_entries_without_llm_meta_read_fine(self):
+        # Simulate a legacy entry without llm_meta
+        journal.log(
+            trigger="manual",
+            reason="legacy entry",
+            session_id="session",
+            proposal={"action": "no_op", "reason": "old"},
+            outcome="no_op",
+        )
+        entries = journal.entries()
+        latest = entries[-1]
+        # No llm_meta key present — that's fine.
+        self.assertNotIn("llm_meta", latest)
+        # Audit must not crash.
+        audit = core.refine_audit()
+        self.assertTrue(audit["success"])
+
+    def test_llm_meta_fields_are_scrubbed(self):
+        token = "ghp_" + "A" * 36
+        model = MockLlm(MockResult(
+            {"action": "no_op", "reason": "nothing", "evidence": [],
+             "kind": "", "name": "", "content": ""},
+            model=token,
+            output_tokens=10,
+        ))
+        core.refine_run(model, session_id="session")
+        entries = journal.entries()
+        latest = entries[-1] if entries else {}
+        meta = latest.get("llm_meta", {})
+        # The reported model must not contain the raw token.
+        self.assertNotIn(token, json.dumps(meta))
+
+    def test_target_issues_are_recorded_in_llm_meta(self):
+        FakeHost.entry_config()["llm"] = {"model": "sk-" + "a" * 24}
+        model = MockLlm(MockResult(
+            {"action": "no_op", "reason": "nothing", "evidence": [],
+             "kind": "", "name": "", "content": ""},
+            model="fallback-model",
+        ))
+        core.refine_run(model, session_id="session")
+        entries = journal.entries()
+        latest = entries[-1] if entries else {}
+        meta = latest.get("llm_meta", {})
+        self.assertTrue(meta.get("target_issues"))
+        self.assertIn("credential", meta["target_issues"][0])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -144,12 +144,12 @@ class FakeHost:
             ("session", "tool", "ERROR: request failed for /item/200", "http", now - 1, 1),
         ]
         connection = sqlite3.connect(path)
-        connection.execute("CREATE TABLE sessions (id TEXT, started_at REAL)")
+        connection.execute("CREATE TABLE sessions (id TEXT, started_at REAL, source TEXT DEFAULT 'cli')")
         connection.execute(
             "CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, "
             "tool_name TEXT, timestamp REAL, active INTEGER)"
         )
-        connection.execute("INSERT INTO sessions VALUES ('session', ?)", (now - 10,))
+        connection.execute("INSERT INTO sessions VALUES ('session', ?, 'cli')", (now - 10,))
         connection.executemany("INSERT INTO messages VALUES (?,?,?,?,?,?)", rows)
         connection.commit()
         connection.close()
@@ -4265,10 +4265,10 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         connection = sqlite3.connect(path)
         connection.execute("DELETE FROM sessions")
         connection.execute(
-            "INSERT INTO sessions VALUES ('active-session', ?)", (now - 200,)
+            "INSERT INTO sessions VALUES ('active-session', ?, 'cli')", (now - 200,)
         )
         connection.execute(
-            "INSERT INTO sessions VALUES ('ghost-session', ?)", (now - 2,)
+            "INSERT INTO sessions VALUES ('ghost-session', ?, 'cli')", (now - 2,)
         )
         connection.commit()
         connection.close()
@@ -4294,6 +4294,70 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
         FakeHost.entry_config()["auto_enabled"] = False
         plugin_init._on_session_end(session_id="end-sess-xyz")
         self.assertEqual(core._noted_session_id(), "end-sess-xyz")
+
+    # ── Session source filter (Part D) ────────────────────────────────────────
+
+    def test_cron_session_is_skipped_by_default(self):
+        # Mark the test session as cron in the DB.
+        path = self.root / "state.db"
+        connection = sqlite3.connect(path)
+        connection.execute("UPDATE sessions SET source='cron' WHERE id='session'")
+        connection.commit()
+        connection.close()
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        result = core.refine_run(model, session_id="session")
+        self.assertEqual(result.get("outcome"), "skipped_session_source")
+        self.assertIn("cron", result["message"])
+        # No model called, no budget spent
+        self.assertEqual(len(model.calls), 0)
+        self.assertEqual(journal.count_today_applied(), 0)
+
+    def test_cli_session_is_not_skipped(self):
+        # Default source is 'cli' which is not in skip list
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        result = core.refine_run(model, session_id="session")
+        # Should proceed past the source check (may end as no_op for signal reasons)
+        self.assertNotEqual(result.get("outcome"), "skipped_session_source")
+
+    def test_empty_skip_sources_skips_nothing(self):
+        FakeHost.entry_config()["skip_session_sources"] = []
+        path = self.root / "state.db"
+        connection = sqlite3.connect(path)
+        connection.execute("UPDATE sessions SET source='cron' WHERE id='session'")
+        connection.commit()
+        connection.close()
+        model = MockLlm({
+            "action": "no_op", "reason": "nothing", "evidence": [],
+            "kind": "", "name": "", "content": "",
+        })
+        result = core.refine_run(model, session_id="session")
+        self.assertNotEqual(result.get("outcome"), "skipped_session_source")
+
+    def test_invalid_skip_sources_config_uses_default(self):
+        FakeHost.entry_config()["skip_session_sources"] = "not a list"
+        self.assertEqual(config.skip_session_sources(), ["cron"])
+
+    def test_source_read_failure_does_not_block_the_pass(self):
+        # If the source cannot be read (missing column, etc.), the pass proceeds.
+        with patch.object(core, "_get_session_source", return_value=""):
+            model = MockLlm({
+                "action": "no_op", "reason": "nothing", "evidence": [],
+                "kind": "", "name": "", "content": "",
+            })
+            result = core.refine_run(model, session_id="session")
+        self.assertNotEqual(result.get("outcome"), "skipped_session_source")
+
+    def test_status_reports_skip_sources_and_session_source(self):
+        status = core.refine_status()
+        self.assertIn("skip_session_sources", status)
+        self.assertEqual(status["skip_session_sources"], ["cron"])
+        self.assertEqual(status["session_source"], "cli")
 
 
 if __name__ == "__main__":

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -4577,6 +4577,118 @@ print(json.dumps(core.refine_run(ProcessLlm(), session_id="session")))
             result = core.refine_run(model, dry_run=True)
         self.assertEqual(result["outcome"], "session_unknown")
 
+    # ── Journal directory migration (Part C) ──────────────────────────────────
+
+    def test_migration_copies_files_and_renames_legacy(self):
+        legacy = self.root / "hermes" / "plugins" / "refine"
+        legacy.mkdir(parents=True)
+        new_dir = self.root / "hermes" / "refine"
+        (legacy / "refine_journal.jsonl").write_text('{"id":"a"}', encoding="utf-8")
+        (legacy / "skill_stats.json").write_text('{}', encoding="utf-8")
+        backups = legacy / "backups"
+        backups.mkdir()
+        (backups / "test.bak").write_text("backup data", encoding="utf-8")
+        with patch.object(config, "_get_refine_entry", return_value={}):
+            result = journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+        self.assertEqual(result, "migrated")
+        self.assertTrue((new_dir / "refine_journal.jsonl").is_file())
+        self.assertTrue((new_dir / "skill_stats.json").is_file())
+        self.assertTrue((new_dir / "backups" / "test.bak").is_file())
+        self.assertTrue((new_dir / ".migrated_from").is_file())
+        self.assertFalse(legacy.exists())
+        renamed = list(legacy.parent.glob("refine.migrated-*"))
+        self.assertEqual(len(renamed), 1)
+
+    def test_migration_is_idempotent(self):
+        legacy = self.root / "hermes" / "plugins" / "refine"
+        legacy.mkdir(parents=True)
+        new_dir = self.root / "hermes" / "refine"
+        (legacy / "refine_journal.jsonl").write_text('{"id":"a"}', encoding="utf-8")
+        with patch.object(config, "_get_refine_entry", return_value={}):
+            first = journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+        self.assertEqual(first, "migrated")
+        with patch.object(config, "_get_refine_entry", return_value={}):
+            second = journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+        self.assertEqual(second, "not_needed")
+
+    def test_migration_not_needed_for_new_install(self):
+        legacy = self.root / "hermes" / "plugins" / "refine"
+        new_dir = self.root / "hermes" / "refine"
+        with patch.object(config, "_get_refine_entry", return_value={}):
+            result = journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+        self.assertEqual(result, "not_needed")
+
+    def test_migration_skips_when_user_configured(self):
+        legacy = self.root / "hermes" / "plugins" / "refine"
+        legacy.mkdir(parents=True)
+        (legacy / "refine_journal.jsonl").write_text('{"id":"a"}', encoding="utf-8")
+        new_dir = self.root / "hermes" / "refine"
+        with patch.object(config, "_get_refine_entry", return_value={"journal_dir": "/custom"}):
+            result = journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+        self.assertEqual(result, "user_configured")
+        self.assertTrue((legacy / "refine_journal.jsonl").is_file())
+
+    def test_migration_failure_does_not_crash_register(self):
+        # Verify that a failing migration does not prevent plugin registration.
+        # We test the wrapping try/except in register() rather than calling the
+        # full register(), because register() re-wires hooks and globals.
+        raised = False
+        try:
+            with patch.object(journal, "migrate_legacy_journal_dir", side_effect=RuntimeError("boom")):
+                # Simulate just the migration wrapper from register().
+                try:
+                    journal.migrate_legacy_journal_dir()
+                except Exception:
+                    pass  # This is what register() does.
+        except RuntimeError:
+            raised = True
+        self.assertFalse(raised)
+
+    def test_migration_copy_failure_leaves_old_dir_intact(self):
+        legacy = self.root / "hermes" / "plugins" / "refine"
+        legacy.mkdir(parents=True)
+        new_dir = self.root / "hermes" / "refine"
+        (legacy / "refine_journal.jsonl").write_text('{"id":"a"}', encoding="utf-8")
+
+        import shutil as _shutil
+        real_copy2 = _shutil.copy2
+
+        def fail_copy2(src, dst, **kwargs):
+            raise OSError("disk full")
+
+        with patch.object(config, "_get_refine_entry", return_value={}), \
+             patch.object(_shutil, "copy2", side_effect=fail_copy2):
+            result = journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+        self.assertEqual(result, "failed")
+        self.assertTrue((legacy / "refine_journal.jsonl").is_file())
+
+    def test_migration_two_threads_only_one_migrates(self):
+        legacy = self.root / "hermes" / "plugins" / "refine"
+        legacy.mkdir(parents=True)
+        new_dir = self.root / "hermes" / "refine"
+        (legacy / "refine_journal.jsonl").write_text('{"id":"a"}', encoding="utf-8")
+        # Prove idempotence by calling twice in sequence — the thread lock inside
+        # prevents concurrent execution in the same process, and the marker file
+        # prevents it across processes.
+        with patch.object(config, "_get_refine_entry", return_value={}):
+            r1 = journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+            r2 = journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+        self.assertEqual(r1, "migrated")
+        self.assertEqual(r2, "not_needed")
+
+    def test_old_directory_never_deleted(self):
+        legacy = self.root / "hermes" / "plugins" / "refine"
+        legacy.mkdir(parents=True)
+        new_dir = self.root / "hermes" / "refine"
+        (legacy / "refine_journal.jsonl").write_text('{"id":"a"}', encoding="utf-8")
+        with patch.object(config, "_get_refine_entry", return_value={}):
+            journal.migrate_legacy_journal_dir(_new_dir=new_dir, _legacy_dir=legacy)
+        self.assertTrue(legacy.parent.exists())
+        self.assertFalse(legacy.exists())
+        siblings = list(legacy.parent.glob("refine.migrated-*"))
+        self.assertTrue(siblings)
+        self.assertTrue((siblings[0] / "refine_journal.jsonl").is_file())
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Five-iteration independent review loop over `602f1d4..d9eabeb` (PR #9), which was squash-merged without one. Reviewer signal 6.0 → 8.5.

All items were reproduced before being changed.

## Model target resolution

- `/refine model X` silently unset a configured provider: priority was per source, not per field, so changing the model dropped the provider and sent the new model to the host default, which may not serve it. Every pass then ended as an ordinary `no_op`.
- A namespaced `llm.model` such as `deepseek/deepseek-chat` is accepted again. The command's slash-free token rule and the model-id rule are now separate; applying the former to the config silently discarded exactly the ids people pin.
- An unset field is no longer backfilled from the live model. Omitting it already means "let Hermes resolve it", and Hermes resolves it to the live value.

## Credential safety at the store boundary

- `write_model_override()` persisted its input verbatim while the command echo reported it redacted. `ghp_` + 36 characters is a valid identifier, so a pasted token was written to disk under a message saying it was protected. The store now refuses anything scrubbing would alter, names which rule refused, and never echoes the value.
- The same rule guards the read path and `config.yaml`, so a value refused from `/refine model` cannot enter through the config.
- `model_override.json` added to `.gitignore`.

## Windows contention

Found by a new two-thread test, then measured rather than assumed.

- `os.replace` fails with `PermissionError` while another thread holds the target open, and the reader saw a denied open 1–6 times per 300 reads under contention — each one reported as "no override", sending the call to a different model than the one pinned.
- Read, write and unlink now share one bounded retry budget derived from a single constant. A measured 0.1s write budget lost the stress race 10 times in 12; 0.5s lost none in 12. A permanent failure still raises.
- `read_model_override_state()` reads bytes and decodes separately: decoding inside the retried read raised `UnicodeDecodeError`, which is not an `OSError`, so a store hand-edited in another codepage escaped into the proposal call and ended every pass as a `no_op` with `success=true`. `_pinned_target()` cannot raise either.

## Visibility

- `/refine status` and `/refine model` report the effective model, provider and source, warn per field when host trust will drop a set value, and report any configured or stored value that was discarded. A pinned model no provider serves no longer reads as "blockers: none".
- `clear_model_override()` distinguishes removed / absent / failed and derives the answer from the unlink itself, so a concurrent write cannot be deleted and still reported as "nothing was set".
- The status fallback reports source `unknown` rather than claiming a `host_default` it never resolved.

## Command robustness and docs

- The `model` branch is wrapped like the other subcommands; it used to escape as a traceback on the unwritable `journal_dir` that `/refine status` exists to report.
- Only the first slash separates provider from model, so `/refine model openrouter/deepseek/deepseek-chat` pins instead of starting a refine pass that would spend one of the three daily edits.
- README documented neither `/refine model` nor its exception to the documented pass-through rule, claimed the auxiliary-cache caveat was unconditional when upstream closed it in `73057ed16` / `fdc6c32d7` (2026-07-17), and claimed `/refine model` can confirm a mid-session switch took effect, which it cannot.

## Validation

- `python -B -m tests.run_tests` → **197 OK** (was 155), six consecutive runs
- `python -m compileall` over all eight modules → exit 0
- `git diff --check` → clean
- override race test alone → 20 runs, 0 failures

New coverage includes the two-thread override race, deterministic retry coverage on all three paths, non-UTF-8 and unusable stores, per-field priority, namespaced ids, and real coverage for the private live-model accessor — previously asserted by a patch that did nothing.

## Deliberately not in this PR

Resolving the target once per pass and recording provider/model on the journal entry. Three independent reviewers asked for it; it is the telemetry feature and gets its own considered change rather than being smuggled into a fix batch.
