### PR TITLE
ci: run the unittest suite on Linux and Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # The point of the matrix is the OS, not the tests. The longest-lived bug in
+    # this project was a hardcoded ~/.hermes that made the plugin read nothing on
+    # Windows, silently. A green run on one OS proves nothing about the other.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # No install step: the plugin and its tests are standard library only.
+      # run_tests.py puts the repo root on sys.path itself, so it runs as-is.
+      - name: Run tests
+        run: python tests/run_tests.py
+        env:
+          PYTHONIOENCODING: utf-8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,9 @@ jobs:
         python-version: ["3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Adds a GitHub Actions workflow so test runs are visible in the Actions tab.

**What it runs:** `python tests/run_tests.py` on `ubuntu-latest` and `windows-latest`, on Python 3.11 and 3.12.

**Why the matrix is about the OS, not the tests:** the longest-lived bug in this project was a hardcoded `~/.hermes` that made the plugin silently read nothing on Windows. A green run on one OS proves nothing about the other.

**Why no `pip install` step:** the plugin and its tests are standard library only, and `run_tests.py` puts the repo root on `sys.path` itself.

Verified locally before pushing: 241 tests, exit code 0.