### PR TITLE
CI floor probe: prove the guard fires

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -14655,4 +14655,7 @@ class TraceContractTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    # [CI-floor probe] temporarily disable the suite entry point to prove the
+    # workflow floor fires when a dead entry point yields zero tests.
+    # unittest.main(verbosity=2)
+    pass


### PR DESCRIPTION
Temporary probe to verify the test-count floor goes red on a dead suite entry point. Will be closed and deleted after proof.